### PR TITLE
No need to allow failures on macOS X in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
     - os: osx
       osx_image: xcode12.2 # request macOS 10.15.7
       rust: stable
-  allow_failures:
-    - os: osx
 
 compiler:
   - clang


### PR DESCRIPTION
Mac OS X now passes so remove it from allow failures in travis