### PR TITLE
Enable CodeQL C++ analysis with build dependencies (#46)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: [ 'cpp', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
@@ -53,6 +53,13 @@ jobs:
         # queries: security-extended,security-and-quality
 
         
+    # Install C++ build dependencies needed by the autobuild
+    - name: Install Dependencies
+      if: matrix.language == 'cpp'
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq cmake libzmq3-dev cppzmq-dev libprotobuf-dev protobuf-compiler libspdlog-dev libfmt-dev libyaml-cpp-dev libgtest-dev
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild


### PR DESCRIPTION
Adds `cpp` to the CodeQL language matrix and installs the required C++ build dependencies (ZMQ, protobuf, spdlog, fmt, yaml-cpp, gtest, cmake) before autobuild.

Closes #46.