### PR TITLE
Add Python client tests and coverage measurement (#266)

### DIFF
--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -60,7 +60,7 @@ jobs:
     - uses: codecov/codecov-action@v2
       if: matrix.os == 'macos-latest'
       with:
-        files: rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info
+        files: rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info clients/python/coverage.xml
 
     - name: docs
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -61,6 +61,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       with:
         files: rust_workspace.info,server/cpp/build/server.info,clients/cpp/build/client.info,clients/python/coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: docs
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -60,7 +60,7 @@ jobs:
     - uses: codecov/codecov-action@v2
       if: matrix.os == 'macos-latest'
       with:
-        files: rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info clients/python/coverage.xml
+        files: rust_workspace.info,server/cpp/build/server.info,clients/cpp/build/client.info,clients/python/coverage.xml
 
     - name: docs
       if: matrix.os == 'macos-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ pids
 **/.anna_history
 rust_workspace.info
 coverage
+coverage.xml
+__pycache__/
+.coverage
 
 # ignore compiled byte code
 target

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ client-python:
 .PHONY: coverage
 coverage: test
 	@echo "Generating coverage report in ./coverage/index.html"
-	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info clients/python/coverage.xml || true
+	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info || true
 
 .PHONY: test
 test: server-cpp-tests client-cpp-tests client-python-tests workspace-rust-tests

--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,10 @@ client-python:
 .PHONY: coverage
 coverage: test
 	@echo "Generating coverage report in ./coverage/index.html"
-	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info || true
+	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info clients/python/coverage.xml || true
 
 .PHONY: test
-test: server-cpp-tests client-cpp-tests workspace-rust-tests
+test: server-cpp-tests client-cpp-tests client-python-tests workspace-rust-tests
 
 .PHONY: server-cpp-tests
 server-cpp-tests:
@@ -148,6 +148,15 @@ client-cpp-tests:
 	@echo "Running C++ client tests with coverage"
 	@cd clients/cpp/build && make --no-print-directory -s client-test-coverage
 	# C++ client tests use gcov-style (.gcda) not profraw — no cleanup needed
+
+.PHONY: client-python-dependencies
+client-python-dependencies:
+	@pip3 install --quiet --user protobuf pytest pytest-cov 2>/dev/null || pip3 install --quiet --break-system-packages protobuf pytest pytest-cov 2>/dev/null || true
+
+.PHONY: client-python-tests
+client-python-tests: client-python-dependencies
+	@echo "Running Python client tests with coverage"
+	@cd clients/python && python3 -m pytest tests/ --quiet --cov=anna --cov-report=xml:coverage.xml 2>&1
 
 .PHONY: workspace-rust-tests
 workspace-rust-tests:

--- a/clients/python/anna/lattices.py
+++ b/clients/python/anna/lattices.py
@@ -22,7 +22,7 @@ from kvs_pb2 import (
 
 class Lattice:
     def __init__(self):
-        raise NotImplementedError
+        pass
 
     def __str__(self):
         return str(self.reveal())
@@ -130,10 +130,10 @@ class SetLattice(Lattice):
         new_set = set()
 
         for v in other.val:
-            new_set.insert(v)
+            new_set.add(v)
 
         for v in self.val:
-            new_set.insert(v)
+            new_set.add(v)
 
         return SetLattice(new_set)
 
@@ -225,7 +225,7 @@ class OrderedSetLattice(Lattice):
         # Note that reconstruction is faster than in-place merge.
         new_lst = []
 
-        other = other.reveal().lst
+        other = other.val.lst
         us = self.val.lst
         i, j = 0, 0  # Earliest unmerged indices.
         while i < len(us) or j < len(other):
@@ -302,11 +302,11 @@ class MapLattice(Lattice):
         self.mp = mp
 
     def merge(self, other):
-        if type(other) != MapLattice:
+        if not isinstance(other, MapLattice):
             raise ValueError('Cannot merge MapLattice with type ' +
                              str(type(other)) + '.')
 
-        for key in other.mp.keys:
+        for key in other.mp.keys():
             if key in self.mp:
                 if not isinstance(self.mp[key], Lattice) or not isinstance(other.mp[key], Lattice):
                     raise ValueError('Cannot merge a MapLattice with values' +
@@ -414,8 +414,8 @@ class SingleKeyCausalLattice(Lattice):
         self.vector_clock.serialize(single_key_causal_value.vector_clock)
 
         # Add the value(s) stored by this lattice.
-        for v in self.value:
-            single_key_causal_value.values.add(v)
+        for v in self.value.reveal():
+            single_key_causal_value.values.append(v)
 
         return single_key_causal_value, SINGLE_CAUSAL
 
@@ -481,8 +481,8 @@ class MultiKeyCausalLattice(Lattice):
             self.dependencies[key].serialize(kv.vector_clock)
 
         # Add the value(s) stored by this lattice.
-        for v in self.value:
-            multi_key_causal_value.values.add(v)
+        for v in self.value.reveal():
+            multi_key_causal_value.values.append(v)
 
         return multi_key_causal_value, MULTI_CAUSAL
 
@@ -500,7 +500,7 @@ class PriorityLattice(Lattice):
         return self.value
 
     def assign(self, value):
-        if type(value) != str:
+        if type(value) == str:
             value = bytes(value, 'utf-8')
 
         if type(value) != tuple or type(value[0]) != float or type(value[1]) != bytes:

--- a/clients/python/tests/test_base_client.py
+++ b/clients/python/tests/test_base_client.py
@@ -1,0 +1,99 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'anna'))
+
+from base_client import BaseAnnaClient
+from lattices import LWWPairLattice, SetLattice, PriorityLattice
+
+
+class TestSerialize:
+    def test_serialize_lww(self):
+        l = LWWPairLattice(1, b"hello")
+        data, typ = BaseAnnaClient._serialize(l)
+        assert data is not None
+
+    def test_serialize_set(self):
+        l = SetLattice({b"a", b"b"})
+        data, typ = BaseAnnaClient._serialize(l)
+        assert data is not None
+
+    def test_serialize_priority(self):
+        l = PriorityLattice(1.0, b"val")
+        data, typ = BaseAnnaClient._serialize(l)
+        assert data is not None
+
+    def test_serialize_non_lattice(self):
+        try:
+            BaseAnnaClient._serialize("not a lattice")
+            assert False
+        except ValueError:
+            pass
+
+
+class TestDeserialize:
+    def test_deserialize_lww(self):
+        from kvs_pb2 import KeyTuple, LWW
+        tup = KeyTuple()
+        tup.lattice_type = LWW
+        from kvs_pb2 import LWWValue
+        val = LWWValue()
+        val.timestamp = 1
+        val.value = b"hello"
+        tup.payload = val.SerializeToString()
+
+        result = BaseAnnaClient._deserialize(tup)
+        assert isinstance(result, LWWPairLattice)
+        assert result.reveal() == b"hello"
+
+    def test_deserialize_set(self):
+        from kvs_pb2 import KeyTuple, SET
+        tup = KeyTuple()
+        tup.lattice_type = SET
+        from kvs_pb2 import SetValue
+        val = SetValue()
+        val.values.append(b"a")
+        val.values.append(b"b")
+        tup.payload = val.SerializeToString()
+
+        result = BaseAnnaClient._deserialize(tup)
+        assert isinstance(result, SetLattice)
+        assert result.reveal() == {b"a", b"b"}
+
+    def test_deserialize_priority(self):
+        from kvs_pb2 import KeyTuple, PRIORITY
+        tup = KeyTuple()
+        tup.lattice_type = PRIORITY
+        from kvs_pb2 import PriorityValue
+        val = PriorityValue()
+        val.priority = 2.0
+        val.value = b"data"
+        tup.payload = val.SerializeToString()
+
+        result = BaseAnnaClient._deserialize(tup)
+        assert isinstance(result, PriorityLattice)
+        assert result.reveal() == b"data"
+
+    def test_deserialize_invalid_type(self):
+        from kvs_pb2 import KeyTuple
+        tup = KeyTuple()
+        tup.lattice_type = 999
+
+        try:
+            BaseAnnaClient._deserialize(tup)
+            assert False
+        except ValueError:
+            pass
+
+    def test_deserialize_ordered_set(self):
+        from kvs_pb2 import KeyTuple, ORDERED_SET
+        tup = KeyTuple()
+        tup.lattice_type = ORDERED_SET
+        from kvs_pb2 import SetValue
+        val = SetValue()
+        val.values.append(b"a")
+        val.values.append(b"b")
+        tup.payload = val.SerializeToString()
+
+        result = BaseAnnaClient._deserialize(tup)
+        from lattices import OrderedSetLattice
+        assert isinstance(result, OrderedSetLattice)

--- a/clients/python/tests/test_base_client.py
+++ b/clients/python/tests/test_base_client.py
@@ -2,44 +2,42 @@ import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'anna'))
 
+import pytest
+
 from base_client import BaseAnnaClient
-from lattices import LWWPairLattice, SetLattice, PriorityLattice
-from kvs_pb2 import LWW, SET, PRIORITY
+from kvs_pb2 import LWW, ORDERED_SET, PRIORITY, SET
+from kvs_pb2 import KeyTuple, LWWValue, PriorityValue, SetValue
+from lattices import LWWPairLattice, OrderedSetLattice, PriorityLattice, SetLattice
 
 
 class TestSerialize:
     def test_serialize_lww(self):
-        l = LWWPairLattice(1, b"hello")
-        data, typ = BaseAnnaClient._serialize(l)
+        lattice = LWWPairLattice(1, b"hello")
+        data, typ = BaseAnnaClient._serialize(lattice)
         assert typ == LWW
         assert data is not None
 
     def test_serialize_set(self):
-        l = SetLattice({b"a", b"b"})
-        data, typ = BaseAnnaClient._serialize(l)
+        lattice = SetLattice({b"a", b"b"})
+        data, typ = BaseAnnaClient._serialize(lattice)
         assert typ == SET
         assert data is not None
 
     def test_serialize_priority(self):
-        l = PriorityLattice(1.0, b"val")
-        data, typ = BaseAnnaClient._serialize(l)
+        lattice = PriorityLattice(1.0, b"val")
+        data, typ = BaseAnnaClient._serialize(lattice)
         assert typ == PRIORITY
         assert data is not None
 
     def test_serialize_non_lattice(self):
-        try:
+        with pytest.raises(ValueError):
             BaseAnnaClient._serialize("not a lattice")
-            assert False
-        except ValueError:
-            pass
 
 
 class TestDeserialize:
     def test_deserialize_lww(self):
-        from kvs_pb2 import KeyTuple, LWW
         tup = KeyTuple()
         tup.lattice_type = LWW
-        from kvs_pb2 import LWWValue
         val = LWWValue()
         val.timestamp = 1
         val.value = b"hello"
@@ -50,10 +48,8 @@ class TestDeserialize:
         assert result.reveal() == b"hello"
 
     def test_deserialize_set(self):
-        from kvs_pb2 import KeyTuple, SET
         tup = KeyTuple()
         tup.lattice_type = SET
-        from kvs_pb2 import SetValue
         val = SetValue()
         val.values.append(b"a")
         val.values.append(b"b")
@@ -64,10 +60,8 @@ class TestDeserialize:
         assert result.reveal() == {b"a", b"b"}
 
     def test_deserialize_priority(self):
-        from kvs_pb2 import KeyTuple, PRIORITY
         tup = KeyTuple()
         tup.lattice_type = PRIORITY
-        from kvs_pb2 import PriorityValue
         val = PriorityValue()
         val.priority = 2.0
         val.value = b"data"
@@ -78,27 +72,20 @@ class TestDeserialize:
         assert result.reveal() == b"data"
 
     def test_deserialize_invalid_type(self):
-        from kvs_pb2 import KeyTuple
         tup = KeyTuple()
         tup.lattice_type = 999
 
-        try:
+        with pytest.raises(ValueError):
             BaseAnnaClient._deserialize(tup)
-            assert False
-        except ValueError:
-            pass
 
     def test_deserialize_ordered_set(self):
-        from kvs_pb2 import KeyTuple, ORDERED_SET
         tup = KeyTuple()
         tup.lattice_type = ORDERED_SET
-        from kvs_pb2 import SetValue
         val = SetValue()
         val.values.append(b"a")
         val.values.append(b"b")
         tup.payload = val.SerializeToString()
 
         result = BaseAnnaClient._deserialize(tup)
-        from lattices import OrderedSetLattice
         assert isinstance(result, OrderedSetLattice)
         assert result.reveal() == [b"a", b"b"]

--- a/clients/python/tests/test_base_client.py
+++ b/clients/python/tests/test_base_client.py
@@ -4,22 +4,26 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'anna'))
 
 from base_client import BaseAnnaClient
 from lattices import LWWPairLattice, SetLattice, PriorityLattice
+from kvs_pb2 import LWW, SET, PRIORITY
 
 
 class TestSerialize:
     def test_serialize_lww(self):
         l = LWWPairLattice(1, b"hello")
         data, typ = BaseAnnaClient._serialize(l)
+        assert typ == LWW
         assert data is not None
 
     def test_serialize_set(self):
         l = SetLattice({b"a", b"b"})
         data, typ = BaseAnnaClient._serialize(l)
+        assert typ == SET
         assert data is not None
 
     def test_serialize_priority(self):
         l = PriorityLattice(1.0, b"val")
         data, typ = BaseAnnaClient._serialize(l)
+        assert typ == PRIORITY
         assert data is not None
 
     def test_serialize_non_lattice(self):
@@ -97,3 +101,4 @@ class TestDeserialize:
         result = BaseAnnaClient._deserialize(tup)
         from lattices import OrderedSetLattice
         assert isinstance(result, OrderedSetLattice)
+        assert result.reveal() == [b"a", b"b"]

--- a/clients/python/tests/test_common.py
+++ b/clients/python/tests/test_common.py
@@ -1,0 +1,39 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'anna'))
+
+from common import Thread, UserThread, REQUEST_PULLING_BASE_PORT, KEY_ADDRESS_BASE_PORT
+
+
+class TestThread:
+    def test_constructor(self):
+        t = Thread("127.0.0.1", 0)
+        assert t.get_ip() == "127.0.0.1"
+        assert t.get_tid() == 0
+
+
+class TestUserThread:
+    def test_get_request_pull_connect_addr(self):
+        t = UserThread("127.0.0.1", 0)
+        expected = "tcp://127.0.0.1:" + str(REQUEST_PULLING_BASE_PORT)
+        assert t.get_request_pull_connect_addr() == expected
+
+    def test_get_request_pull_bind_addr(self):
+        t = UserThread("127.0.0.1", 0)
+        expected = "tcp://*:" + str(REQUEST_PULLING_BASE_PORT)
+        assert t.get_request_pull_bind_addr() == expected
+
+    def test_get_key_address_connect_addr(self):
+        t = UserThread("127.0.0.1", 0)
+        expected = "tcp://127.0.0.1:" + str(KEY_ADDRESS_BASE_PORT)
+        assert t.get_key_address_connect_addr() == expected
+
+    def test_get_key_address_bind_addr(self):
+        t = UserThread("127.0.0.1", 0)
+        expected = "tcp://*:" + str(KEY_ADDRESS_BASE_PORT)
+        assert t.get_key_address_bind_addr() == expected
+
+    def test_with_offset(self):
+        t = UserThread("10.0.0.1", 5)
+        expected_port = str(REQUEST_PULLING_BASE_PORT + 5)
+        assert t.get_request_pull_connect_addr() == "tcp://10.0.0.1:" + expected_port

--- a/clients/python/tests/test_lattices.py
+++ b/clients/python/tests/test_lattices.py
@@ -1,0 +1,547 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'anna'))
+
+from lattices import (
+    LWWPairLattice, SetLattice, ListBasedOrderedSet, OrderedSetLattice,
+    MaxIntLattice, MapLattice, VectorClock, SingleKeyCausalLattice,
+    MultiKeyCausalLattice, PriorityLattice, Lattice
+)
+
+
+class TestLWWPairLattice:
+    def test_constructor(self):
+        l = LWWPairLattice(1, b"hello")
+        assert l.ts == 1
+        assert l.val == b"hello"
+
+    def test_constructor_invalid_type(self):
+        try:
+            LWWPairLattice("not_int", b"val")
+            assert False
+        except ValueError:
+            pass
+
+    def test_reveal(self):
+        l = LWWPairLattice(1, b"hello")
+        assert l.reveal() == b"hello"
+
+    def test_assign_tuple(self):
+        l = LWWPairLattice(1, b"hello")
+        l.assign((2, b"world"))
+        assert l.ts == 2
+        assert l.val == b"world"
+
+    def test_assign_str_value(self):
+        l = LWWPairLattice(1, b"hello")
+        l.assign((3, b"test"))
+        assert l.ts == 3
+        assert l.val == b"test"
+
+    def test_assign_invalid_type(self):
+        l = LWWPairLattice(1, b"hello")
+        try:
+            l.assign("invalid")
+            assert False
+        except ValueError:
+            pass
+
+    def test_merge_newer_wins(self):
+        older = LWWPairLattice(1, b"old")
+        newer = LWWPairLattice(2, b"new")
+        result = older.merge(newer)
+        assert result.reveal() == b"new"
+
+    def test_merge_older_keeps(self):
+        newer = LWWPairLattice(2, b"new")
+        older = LWWPairLattice(1, b"old")
+        result = newer.merge(older)
+        assert result.reveal() == b"new"
+
+    def test_serialize(self):
+        l = LWWPairLattice(5, b"data")
+        pb, typ = l.serialize()
+        assert pb.timestamp == 5
+        assert pb.value == b"data"
+
+    def test_str(self):
+        l = LWWPairLattice(1, b"hello")
+        assert str(l) == str(b"hello")
+
+
+class TestSetLattice:
+    def test_constructor_empty(self):
+        s = SetLattice()
+        assert s.reveal() == set()
+
+    def test_constructor_with_values(self):
+        s = SetLattice({b"a", b"b"})
+        assert s.reveal() == {b"a", b"b"}
+
+    def test_constructor_invalid_type(self):
+        try:
+            SetLattice("not a set")
+            assert False
+        except ValueError:
+            pass
+
+    def test_assign(self):
+        s = SetLattice({b"a"})
+        s.assign({b"b", b"c"})
+        assert s.reveal() == {b"b", b"c"}
+
+    def test_assign_invalid_type(self):
+        s = SetLattice()
+        try:
+            s.assign("invalid")
+            assert False
+        except ValueError:
+            pass
+
+    def test_merge_same_type(self):
+        s1 = SetLattice({b"a", b"b"})
+        s2 = SetLattice({b"b", b"c"})
+        merged = s1.merge(s2)
+        assert merged.reveal() == {b"a", b"b", b"c"}
+
+    def test_merge_invalid_type(self):
+        s = SetLattice()
+        try:
+            s.merge("invalid")
+            assert False
+        except ValueError:
+            pass
+
+    def test_serialize(self):
+        s = SetLattice({b"hello"})
+        pb, typ = s.serialize()
+        assert b"hello" in pb.values
+
+    def test_serialize_invalid_type(self):
+        s = SetLattice({"string_not_bytes"})
+        try:
+            s.serialize()
+            assert False
+        except ValueError:
+            pass
+
+    def test_eq(self):
+        s1 = SetLattice({b"a", b"b"})
+        s2 = SetLattice({b"b", b"a"})
+        assert s1 == s2
+
+    def test_eq_none(self):
+        s = SetLattice()
+        assert (s == None) == False
+
+    def test_eq_different_type(self):
+        s = SetLattice()
+        assert (s == "other") == False
+
+
+class TestListBasedOrderedSet:
+    def test_constructor_empty(self):
+        s = ListBasedOrderedSet()
+        assert s.lst == []
+
+    def test_constructor_with_values(self):
+        s = ListBasedOrderedSet([b"a", b"b", b"c"])
+        assert s.lst == [b"a", b"b", b"c"]
+
+    def test_constructor_unsorted(self):
+        s = ListBasedOrderedSet([b"c", b"a", b"b"])
+        assert s.lst == [b"a", b"b", b"c"]
+
+    def test_constructor_with_duplicates(self):
+        s = ListBasedOrderedSet([b"a", b"b", b"a"])
+        assert s.lst == [b"a", b"b"]
+
+    def test_insert_empty(self):
+        s = ListBasedOrderedSet()
+        s.insert(b"a")
+        assert s.lst == [b"a"]
+
+    def test_insert_end(self):
+        s = ListBasedOrderedSet([b"a"])
+        s.insert(b"b")
+        assert s.lst == [b"a", b"b"]
+
+    def test_insert_beginning(self):
+        s = ListBasedOrderedSet([b"b", b"c"])
+        s.insert(b"a")
+        assert s.lst == [b"a", b"b", b"c"]
+
+    def test_insert_middle(self):
+        s = ListBasedOrderedSet([b"a", b"c"])
+        s.insert(b"b")
+        assert s.lst == [b"a", b"b", b"c"]
+
+    def test_insert_duplicate(self):
+        s = ListBasedOrderedSet([b"a", b"c"])
+        s.insert(b"a")
+        assert s.lst == [b"a", b"c"]
+
+    def test_index_of_found(self):
+        s = ListBasedOrderedSet([b"a", b"b", b"c"])
+        idx, found = s._index_of(b"b")
+        assert idx == 1
+        assert found == True
+
+    def test_index_of_not_found(self):
+        s = ListBasedOrderedSet([b"a", b"c"])
+        idx, found = s._index_of(b"b")
+        assert idx == 1
+        assert found == False
+
+    def test_index_of_empty(self):
+        s = ListBasedOrderedSet()
+        idx, found = s._index_of(b"a")
+        assert idx == 0
+        assert found == False
+
+
+class TestOrderedSetLattice:
+    def test_constructor_empty(self):
+        o = OrderedSetLattice()
+        assert o.reveal() == []
+
+    def test_constructor_with_values(self):
+        o = OrderedSetLattice(ListBasedOrderedSet([b"a", b"b"]))
+        assert o.reveal() == [b"a", b"b"]
+
+    def test_constructor_invalid_type(self):
+        try:
+            OrderedSetLattice("invalid")
+            assert False
+        except ValueError:
+            pass
+
+    def test_reveal(self):
+        o = OrderedSetLattice(ListBasedOrderedSet([b"a"]))
+        assert o.reveal() == [b"a"]
+
+    def test_assign(self):
+        o = OrderedSetLattice()
+        o.assign(ListBasedOrderedSet([b"x"]))
+        assert o.reveal() == [b"x"]
+
+    def test_merge_disjoint(self):
+        o1 = OrderedSetLattice(ListBasedOrderedSet([b"a", b"c"]))
+        o2 = OrderedSetLattice(ListBasedOrderedSet([b"b", b"d"]))
+        merged = o1.merge(o2)
+        assert merged.reveal() == [b"a", b"b", b"c", b"d"]
+
+    def test_merge_overlapping(self):
+        o1 = OrderedSetLattice(ListBasedOrderedSet([b"a", b"b", b"d"]))
+        o2 = OrderedSetLattice(ListBasedOrderedSet([b"b", b"c", b"e"]))
+        merged = o1.merge(o2)
+        assert merged.reveal() == [b"a", b"b", b"c", b"d", b"e"]
+
+    def test_merge_empty(self):
+        o1 = OrderedSetLattice(ListBasedOrderedSet([b"a"]))
+        o2 = OrderedSetLattice()
+        merged = o1.merge(o2)
+        assert merged.reveal() == [b"a"]
+
+    def test_merge_subset(self):
+        o1 = OrderedSetLattice(ListBasedOrderedSet([b"a", b"b", b"c"]))
+        o2 = OrderedSetLattice(ListBasedOrderedSet([b"b"]))
+        merged = o1.merge(o2)
+        assert merged.reveal() == [b"a", b"b", b"c"]
+
+    def test_merge_invalid_type(self):
+        o = OrderedSetLattice()
+        try:
+            o.merge("invalid")
+            assert False
+        except ValueError:
+            pass
+
+    def test_serialize(self):
+        o = OrderedSetLattice(ListBasedOrderedSet([b"a"]))
+        pb, typ = o.serialize()
+        assert b"a" in pb.values
+
+    def test_str(self):
+        o = OrderedSetLattice(ListBasedOrderedSet([b"a"]))
+        assert str(o) == "[b'a']"
+
+
+class TestMaxIntLattice:
+    def test_constructor(self):
+        m = MaxIntLattice(5)
+        assert m.value == 5
+
+    def test_constructor_invalid_type(self):
+        try:
+            MaxIntLattice("not_int")
+            assert False
+        except ValueError:
+            pass
+
+    def test_reveal(self):
+        m = MaxIntLattice(42)
+        assert m.reveal() == 42
+
+    def test_assign(self):
+        m = MaxIntLattice(1)
+        m.assign(5)
+        assert m.value == 5
+
+    def test_assign_invalid_type(self):
+        m = MaxIntLattice(1)
+        try:
+            m.assign("invalid")
+            assert False
+        except ValueError:
+            pass
+
+    def test_merge_higher_wins(self):
+        m = MaxIntLattice(1)
+        m.merge(MaxIntLattice(5))
+        assert m.value == 5
+
+    def test_merge_lower_no_change(self):
+        m = MaxIntLattice(5)
+        m.merge(MaxIntLattice(1))
+        assert m.value == 5
+
+    def test_merge_equal(self):
+        m = MaxIntLattice(3)
+        m.merge(MaxIntLattice(3))
+        assert m.value == 3
+
+    def test_merge_invalid_type(self):
+        m = MaxIntLattice(1)
+        try:
+            m.merge("invalid")
+            assert False
+        except ValueError:
+            pass
+
+
+class TestMapLattice:
+    def test_constructor(self):
+        m = MapLattice({})
+        assert m.reveal() == {}
+
+    def test_constructor_invalid_type(self):
+        try:
+            MapLattice("not dict")
+            assert False
+        except ValueError:
+            pass
+
+    def test_reveal(self):
+        m = MapLattice({"a": MaxIntLattice(1)})
+        assert m.reveal() == {"a": MaxIntLattice(1)}
+
+    def test_assign(self):
+        m = MapLattice({})
+        m.assign({"x": MaxIntLattice(2)})
+        assert m.reveal() == {"x": MaxIntLattice(2)}
+
+    def test_assign_invalid_type(self):
+        m = MapLattice({})
+        try:
+            m.assign("invalid")
+            assert False
+        except ValueError:
+            pass
+
+    def test_merge_new_key(self):
+        m1 = MapLattice({"a": MaxIntLattice(1)})
+        m2 = MapLattice({"b": MaxIntLattice(2)})
+        m1.merge(m2)
+        assert m1.reveal()["b"].reveal() == 2
+
+    def test_merge_existing_key(self):
+        m1 = MapLattice({"a": MaxIntLattice(1)})
+        m2 = MapLattice({"a": MaxIntLattice(5)})
+        m1.merge(m2)
+        assert m1.reveal()["a"].reveal() == 5
+
+    def test_copy(self):
+        m = MapLattice({"a": MaxIntLattice(1)})
+        c = m.copy()
+        assert c.reveal() == {"a": MaxIntLattice(1)}
+
+    def test_eq(self):
+        m1 = MapLattice({"a": MaxIntLattice(1)})
+        m2 = MapLattice({"a": MaxIntLattice(1)})
+        assert m1 == m2
+
+
+class TestVectorClock:
+    def test_constructor(self):
+        vc = VectorClock({"a": MaxIntLattice(1)})
+        assert vc.reveal()["a"].reveal() == 1
+
+    def test_constructor_invalid_type(self):
+        try:
+            VectorClock("not dict")
+            assert False
+        except ValueError:
+            pass
+
+    def test_deserialize(self):
+        mp = {"a": 1, "b": 2}
+        vc = VectorClock(mp, deserialize=True)
+        assert vc.reveal()["a"].reveal() == 1
+        assert vc.reveal()["b"].reveal() == 2
+
+    def test_deserialize_non_int(self):
+        try:
+            VectorClock({"a": "not_int"}, deserialize=True)
+            assert False
+        except ValueError:
+            pass
+
+    def test_update(self):
+        vc = VectorClock({"a": MaxIntLattice(1)})
+        vc.update("a", 5)
+        assert vc.reveal()["a"].reveal() == 5
+
+    def test_update_new_key_does_nothing(self):
+        vc = VectorClock({"a": MaxIntLattice(1)})
+        vc.update("b", 5)
+        assert "b" not in vc.reveal()
+
+    def test_serialize(self):
+        vc = VectorClock({"a": MaxIntLattice(3)})
+        pobj = {}
+        vc.serialize(pobj)
+        assert pobj["a"] == 3
+
+
+class TestSingleKeyCausalLattice:
+    def test_constructor(self):
+        vc = VectorClock({"a": MaxIntLattice(1)})
+        val = SetLattice({b"data"})
+        l = SingleKeyCausalLattice(vc, val)
+        assert l.vector_clock == vc
+        assert l.value == val
+
+    def test_constructor_invalid_vc(self):
+        try:
+            SingleKeyCausalLattice("not_vc", SetLattice())
+            assert False
+        except ValueError:
+            pass
+
+    def test_constructor_invalid_value(self):
+        try:
+            SingleKeyCausalLattice(VectorClock({}), "not_set")
+            assert False
+        except ValueError:
+            pass
+
+    def test_reveal(self):
+        vc = VectorClock({"a": MaxIntLattice(1)})
+        l = SingleKeyCausalLattice(vc, SetLattice({b"data"}))
+        assert l.reveal() == [b"data"]
+
+    def test_merge_dominated(self):
+        vc1 = VectorClock({"a": MaxIntLattice(2)})
+        vc2 = VectorClock({"a": MaxIntLattice(1)})
+        l1 = SingleKeyCausalLattice(vc1, SetLattice({b"new"}))
+        l2 = SingleKeyCausalLattice(vc2, SetLattice({b"old"}))
+        l1.merge(l2)
+        assert l1.value.reveal() == {b"new"}
+
+    def test_serialize(self):
+        vc = VectorClock({"a": MaxIntLattice(1)})
+        l = SingleKeyCausalLattice(vc, SetLattice({b"data"}))
+        pb, typ = l.serialize()
+        assert pb is not None
+
+
+class TestMultiKeyCausalLattice:
+    def test_constructor(self):
+        vc = VectorClock({"a": MaxIntLattice(1)})
+        deps = MapLattice({"other": VectorClock({"b": MaxIntLattice(0)})})
+        val = SetLattice({b"data"})
+        l = MultiKeyCausalLattice(vc, deps, val)
+        assert l.vector_clock == vc
+        assert l.dependencies == deps
+        assert l.value == val
+
+    def test_constructor_invalid_vc(self):
+        try:
+            MultiKeyCausalLattice("bad", MapLattice({}), SetLattice())
+            assert False
+        except ValueError:
+            pass
+
+    def test_constructor_invalid_deps(self):
+        try:
+            MultiKeyCausalLattice(VectorClock({}), "bad", SetLattice())
+            assert False
+        except ValueError:
+            pass
+
+    def test_constructor_invalid_value(self):
+        try:
+            MultiKeyCausalLattice(VectorClock({}), MapLattice({}), "bad")
+            assert False
+        except ValueError:
+            pass
+
+    def test_reveal(self):
+        vc = VectorClock({"a": MaxIntLattice(1)})
+        l = MultiKeyCausalLattice(vc, MapLattice({}), SetLattice({b"data"}))
+        assert l.reveal() == [b"data"]
+
+
+class TestPriorityLattice:
+    def test_constructor(self):
+        p = PriorityLattice(1.0, b"val")
+        assert p.priority == 1.0
+        assert p.value == b"val"
+
+    def test_constructor_invalid_type(self):
+        try:
+            PriorityLattice("not_float", b"val")
+            assert False
+        except ValueError:
+            pass
+
+    def test_reveal(self):
+        p = PriorityLattice(2.5, b"data")
+        assert p.reveal() == b"data"
+
+    def test_assign(self):
+        p = PriorityLattice(1.0, b"old")
+        p.assign((3.0, b"new"))
+        assert p.priority == 3.0
+        assert p.value == b"new"
+
+    def test_assign_invalid_type(self):
+        p = PriorityLattice(1.0, b"val")
+        try:
+            p.assign("invalid")
+            assert False
+        except ValueError:
+            pass
+
+    def test_merge_lower_priority_wins(self):
+        high = PriorityLattice(5.0, b"high")
+        low = PriorityLattice(1.0, b"low")
+        result = high.merge(low)
+        assert result.reveal() == b"low"
+
+    def test_merge_higher_priority_keeps(self):
+        low = PriorityLattice(1.0, b"low")
+        high = PriorityLattice(5.0, b"high")
+        result = low.merge(high)
+        assert result.reveal() == b"low"
+
+    def test_serialize(self):
+        p = PriorityLattice(2.0, b"val")
+        pb, typ = p.serialize()
+        assert pb.priority == 2.0
+        assert pb.value == b"val"
+
+    def test_str(self):
+        p = PriorityLattice(1.5, b"val")
+        assert str(p) == str(b"val")

--- a/clients/python/tests/test_lattices.py
+++ b/clients/python/tests/test_lattices.py
@@ -453,7 +453,8 @@ class TestSingleKeyCausalLattice:
         vc = VectorClock({"a": MaxIntLattice(1)})
         l = SingleKeyCausalLattice(vc, SetLattice({b"data"}))
         pb, typ = l.serialize()
-        assert pb is not None
+        assert pb.vector_clock["a"] == 1
+        assert list(pb.values) == [b"data"]
 
 
 class TestMultiKeyCausalLattice:


### PR DESCRIPTION
- Added pytest tests for lattices, common, base_client (106 tests covering all lattice types)
- Fixed several bugs discovered while writing tests (Lattice.__init__ raising, SetLattice.merge set.add vs set.insert, OrderedSetLattice.merge accessor, MapLattice.merge keys() call, SingleKeyCausalLattice/MultiKeyCausalLattice iteration, PriorityLattice.assign type check)
- Added client-python-tests Makefile target with pytest-cov coverage reporting
- Updated test and coverage targets to include Python
- Added clients/python/coverage.xml to codecov upload in CI