### PR TITLE
Separate C++ client into anna-client-lib and anna-cli

### DIFF
--- a/clients/cpp/src/CMakeLists.txt
+++ b/clients/cpp/src/CMakeLists.txt
@@ -21,7 +21,15 @@ SET(LIBRARY_DEPENDENCIES
     anna-zmq
 )
 
+# The annalib client library: KVS operations (get/put/...) and process
+# management (start/stop/status), wrapping KvsClientInterface with no
+# dependency on stdin/stdout/argv. See issue #75.
+ADD_LIBRARY(anna-client-lib STATIC client_lib.cpp)
+TARGET_LINK_LIBRARIES(anna-client-lib spdlog::spdlog fmt::fmt ${yamlcpp_LIBRARY} ${ZeroMQ_LIBRARY} ${LIBRARY_DEPENDENCIES})
+TARGET_INCLUDE_DIRECTORIES(anna-client-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# anna-cli is an example CLI built on top of anna-client-lib.
 ADD_EXECUTABLE(anna-cli cli.cpp)
-TARGET_LINK_LIBRARIES(anna-cli spdlog::spdlog fmt::fmt ${yamlcpp_LIBRARY} ${ZeroMQ_LIBRARY} ${LIBRARY_DEPENDENCIES})
+TARGET_LINK_LIBRARIES(anna-cli anna-client-lib spdlog::spdlog fmt::fmt ${yamlcpp_LIBRARY} ${ZeroMQ_LIBRARY} ${LIBRARY_DEPENDENCIES})
 
 SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/cli)

--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -15,250 +15,53 @@
 #include <fstream>
 #include <algorithm>
 #include <string>
-#include <stdio.h>
-#include <string.h>
 
-#include "kvs_client.hpp"
-#include "yaml-cpp/yaml.h"
+#include "client_lib.hpp"
 
-#include <assert.h>
+// This is an example CLI built on top of the annalib client library
+// (client_lib.hpp / kvs_client.hpp) -- it only handles argv/stdin parsing
+// and formatting output, all KVS/process-management logic lives in the
+// library. See issue #75.
 
-unsigned kRoutingThreadCount;
+namespace {
 
-ZmqUtil zmq_util;
-ZmqUtilInterface *kZmqUtil = &zmq_util;
-
-const char * const PROCESS_LIST[] = {"anna-monitor", "anna-route", "anna-kvs"};
-
-void print_set(set<string> set) {
+void print_set(const set<string>& values) {
   std::cout << "{ ";
-  for (const string &val : set) {
+  for (const string& val : values) {
     std::cout << val << " ";
   }
 
   std::cout << "}" << std::endl;
 }
 
-string get(KvsClientInterface *client, string key) {
-    client->get_async(key);
+void print_causal_value(const annalib::CausalValue& causal) {
+  for (const auto& pair : causal.vector_clock) {
+    std::cout << "{" << pair.first << " : " << std::to_string(pair.second)
+              << "}" << std::endl;
+  }
 
-    vector<kvs::KeyResponse> responses = client->receive_async();
-    while (responses.size() == 0) {
-      responses = client->receive_async();
+  for (const auto& dep_key_vc_pair : causal.dependencies) {
+    std::cout << dep_key_vc_pair.first << " : ";
+    for (const auto& vc_pair : dep_key_vc_pair.second) {
+      std::cout << "{" << vc_pair.first << " : "
+                << std::to_string(vc_pair.second) << "}" << std::endl;
     }
+  }
 
-    if (responses.size() > 1) {
-      std::cout << "Error: received more than one response" << std::endl;
-    }
-
-    assert(responses[0].tuples(0).lattice_type() == kvs::LatticeType::LWW);
-
-    LWWPairLattice<string> lww_lattice =
-        deserialize_lww(responses[0].tuples(0).payload());
-
-    return lww_lattice.reveal().value;
-}
-
-string get_causal(KvsClientInterface *client, string key) {
-    client->get_async(key);
-
-    vector<kvs::KeyResponse> responses = client->receive_async();
-    while (responses.size() == 0) {
-      responses = client->receive_async();
-    }
-
-    if (responses.size() > 1) {
-      std::cout << "Error: received more than one response" << std::endl;
-    }
-
-    assert(responses[0].tuples(0).lattice_type() == kvs::LatticeType::MULTI_CAUSAL);
-
-    MultiKeyCausalLattice<SetLattice<string>> mkcl =
-        MultiKeyCausalLattice<SetLattice<string>>(to_multi_key_causal_payload(
-            deserialize_multi_key_causal(responses[0].tuples(0).payload())));
-
-    for (const auto &pair : mkcl.reveal().vector_clock.reveal()) {
-      std::cout << "{" << pair.first << " : "
-                << std::to_string(pair.second.reveal()) << "}" << std::endl;
-    }
-
-    for (const auto &dep_key_vc_pair : mkcl.reveal().dependencies.reveal()) {
-      std::cout << dep_key_vc_pair.first << " : ";
-      for (const auto &vc_pair : dep_key_vc_pair.second.reveal()) {
-        std::cout << "{" << vc_pair.first << " : "
-                  << std::to_string(vc_pair.second.reveal()) << "}"
-                  << std::endl;
-      }
-    }
-
-    return *(mkcl.reveal().value.reveal().begin());
-}
-
-kvs::KeyResponse put(KvsClientInterface *client, string key, string value) {
-    LWWPairLattice<string> val(
-        TimestampValuePair<string>(generate_timestamp(0), value));
-
-    string rid = client->put_async(key, serialize(val), kvs::LatticeType::LWW);
-
-    vector<kvs::KeyResponse> responses = client->receive_async();
-    while (responses.size() == 0) {
-      responses = client->receive_async();
-    }
-
-    kvs::KeyResponse response = responses[0];
-
-    // TODO encode this error into the response
-    if (response.response_id() != rid) {
-      std::cout << "Invalid response: ID did not match request ID!"
-                << std::endl;
-    }
-
-    return response;
-}
-
-kvs::KeyResponse put_causal(KvsClientInterface *client, string key, string value) {
-    MultiKeyCausalPayload<SetLattice<string>> mkcp;
-    // construct a test client id - version pair
-    mkcp.vector_clock.insert("test", 1);
-
-    // construct one test dependencies
-    mkcp.dependencies.insert(
-        "dep1", VectorClock(map<string, MaxLattice<unsigned>>({{"test1", 1}})));
-
-    // populate the value
-    mkcp.value.insert(value);
-
-    MultiKeyCausalLattice<SetLattice<string>> mkcl(mkcp);
-
-    string rid = client->put_async(key, serialize(mkcl), kvs::LatticeType::MULTI_CAUSAL);
-
-    vector<kvs::KeyResponse> responses = client->receive_async();
-    while (responses.size() == 0) {
-      responses = client->receive_async();
-    }
-
-    kvs::KeyResponse response = responses[0];
-
-    // TODO encode this error into the response
-    if (response.response_id() != rid) {
-      std::cout << "Invalid response: ID did not match request ID!"
-                << std::endl;
-    }
-
-    return response;
-}
-
-kvs::KeyResponse put_set(KvsClientInterface *client, string key, set<string> set) {
-    string rid = client->put_async(key, serialize(SetLattice<string>(set)),
-                                   kvs::LatticeType::SET);
-
-    vector<kvs::KeyResponse> responses = client->receive_async();
-    while (responses.size() == 0) {
-      responses = client->receive_async();
-    }
-
-    kvs::KeyResponse response = responses[0];
-
-    // TODO encode this error into the response
-    if (response.response_id() != rid) {
-      std::cout << "Invalid response: ID did not match request ID!"
-                << std::endl;
-    }
-
-    return response;
-}
-
-set<string> get_set(KvsClientInterface *client, string key) {
-    client->get_async(key);
-    string serialized;
-
-    vector<kvs::KeyResponse> responses = client->receive_async();
-    while (responses.size() == 0) {
-      responses = client->receive_async();
-    }
-
-    SetLattice<string> latt = deserialize_set(responses[0].tuples(0).payload());
-    set<string> set_value = latt.reveal();
-
-    return set_value;
-}
-
-/*
-fn pids_from_name(name: &str) -> Vec<i32> {
-    let s = System::new_all();
-    s.processes_by_name(name)
-        .map(|process| process.pid().into())
-        .collect()
-}
-*/
-
-int start(string config_file_path) {
-    int process_count = 3; // TODO until implemented
-    for(const string &process_name : PROCESS_LIST) {
-    /*
-        let pids = pids_from_name(process_name);
-        if !pids.is_empty() {
-            bail!(
-                "Process '{}' is already running with pids = {:?}",
-                process_count,
-                pids
-            )
-        }
-
-        Command::new(process_name)
-            .args([
-                "--config",
-                config_file_path
-                    .to_str()
-                    .ok_or("Could not get config file path")?,
-            ])
-            .spawn()
-            .chain_err(|| format!("Failed to spawn process '{}'", process_name))?;
-
-        process_count += 1;
-    */
-    }
-
-    return process_count;
-}
-
-vector<string> status()  {
-    vector<string> status = {};
-
-    for(const string &process_name : PROCESS_LIST) {
-    /*
-        let pids = pids_from_name(process_name);
-        status.push((process_name.to_string(), pids));
-        */
-    }
-
-    return status;
-}
-
-int stop() {
-    int kill_count = 3; // TODO until we implement
-    for(const string &process_name : PROCESS_LIST) {
-    /*
-        for pid in pids_from_name(process_name) {
-            if kill(Pid::from_raw(pid), Some(nix::sys::signal::SIGTERM)).is_ok() {
-                kill_count += 1;
-            }
-        }
-        */
-    }
-
-    return kill_count;
+  std::cout << causal.value << std::endl;
 }
 
 string cli_usage() {
-    return "Valid commands are GET, GET_SET, PUT, PUT_SET, PUT_CAUSAL, GET_CAUSAL, START, STOP, STATUS, HELP and EXIT";
+  return "Valid commands are GET, GET_SET, PUT, PUT_SET, PUT_CAUSAL, "
+         "GET_CAUSAL, START, STOP, STATUS, HELP and EXIT";
 }
 
-void execute_cli_command(KvsClientInterface *client, string config_file, string input) {
+void execute_cli_command(KvsClientInterface* client, const string& config_file,
+                         const string& input) {
   vector<string> v;
   split(input, ' ', v);
 
-  if (v.size() == 0) { // EOF?
+  if (v.size() == 0) {  // EOF?
     std::exit(EXIT_SUCCESS);
   }
 
@@ -266,38 +69,40 @@ void execute_cli_command(KvsClientInterface *client, string config_file, string 
   std::transform(command.begin(), command.end(), command.begin(), ::toupper);
 
   if (command == "GET") {
-    std::cout << get(client, v[1]) << std::endl;
+    std::cout << annalib::get(client, v[1]) << std::endl;
   } else if (command == "GET_CAUSAL") {
-    std::cout << get_causal(client, v[1]) << std::endl;
+    print_causal_value(annalib::get_causal(client, v[1]));
   } else if (command == "PUT") {
-    kvs::KeyResponse response = put(client, v[1], v[2]);
+    kvs::KeyResponse response = annalib::put(client, v[1], v[2]);
     if (response.error() != kvs::AnnaError::NO_ERROR) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "PUT_CAUSAL") {
-    kvs::KeyResponse response = put_causal(client, v[1], v[2]);
+    kvs::KeyResponse response = annalib::put_causal(client, v[1], v[2]);
     if (response.error() != kvs::AnnaError::NO_ERROR) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "PUT_SET") {
-    set<string> set;
-    for (int i = 2; i < v.size(); i++) {
-      set.insert(v[i]);
+    set<string> values;
+    for (size_t i = 2; i < v.size(); i++) {
+      values.insert(v[i]);
     }
-    kvs::KeyResponse response = put_set(client, v[1], set);
+    kvs::KeyResponse response = annalib::put_set(client, v[1], values);
     if (response.error() != kvs::AnnaError::NO_ERROR) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "GET_SET") {
-    print_set(get_set(client, v[1]));
+    print_set(annalib::get_set(client, v[1]));
   } else if (command == "STATUS") {
-    for(const string &name : status()) {
-        std::cout << name << " process is running" << std::endl;
+    for (const string& name : annalib::status()) {
+      std::cout << name << " process is running" << std::endl;
     }
   } else if (command == "START") {
-    std::cout << start(config_file) << " anna processes were started" << std::endl;
+    std::cout << annalib::start(config_file) << " anna processes were started"
+              << std::endl;
   } else if (command == "STOP") {
-    std::cout << start(config_file) << " anna processes were stopped" << std::endl;
+    std::cout << annalib::stop() << " anna processes were stopped"
+              << std::endl;
   } else if (command == "HELP") {
     std::cout << cli_usage() << std::endl;
   } else if (command == "EXIT") {
@@ -309,7 +114,7 @@ void execute_cli_command(KvsClientInterface *client, string config_file, string 
 }
 
 // Read commands interactively from the terminal
-void cli_loop_interactive(KvsClientInterface *client, string config_file) {
+void cli_loop_interactive(KvsClientInterface* client, const string& config_file) {
   string input;
   while (true) {
     std::cout << "anna> ";
@@ -320,7 +125,8 @@ void cli_loop_interactive(KvsClientInterface *client, string config_file) {
 }
 
 // Read commands from `filename` until EOF
-void cli_loop_file(KvsClientInterface *client, string config_file, string filename) {
+void cli_loop_file(KvsClientInterface* client, const string& config_file,
+                   const string& filename) {
   string input;
   std::ifstream infile(filename);
 
@@ -329,12 +135,14 @@ void cli_loop_file(KvsClientInterface *client, string config_file, string filena
   }
 }
 
-string usage(string name) {
-    return name + " --config config-file command <CLI command file>\n" +
-    "Valid commands are help, start, stop, status, cli\n";
+string usage(const string& name) {
+  return name + " --config config-file command <CLI command file>\n" +
+         "Valid commands are help, start, stop, status, cli\n";
 }
 
-int main(int argc, char *argv[]) {
+}  // namespace
+
+int main(int argc, char* argv[]) {
   // There can be two or three options
   // #0 - binary name
   // #1 - "--config" directive
@@ -350,48 +158,26 @@ int main(int argc, char *argv[]) {
   string command = argv[3];
   std::transform(command.begin(), command.end(), command.begin(), ::toupper);
 
-  // read the YAML conf
-  YAML::Node conf = YAML::LoadFile(argv[2]);
-  kRoutingThreadCount = conf["threads"]["routing"].as<unsigned>();
-
-  YAML::Node user = conf["user"];
-  Address ip = user["ip"].as<Address>();
-
-  vector<Address> routing_ips;
-  if (YAML::Node elb = user["routing-elb"]) {
-    routing_ips.push_back(elb.as<string>());
-  } else {
-    YAML::Node routing = user["routing"];
-    for (const YAML::Node &node : routing) {
-      routing_ips.push_back(node.as<Address>());
-    }
-  }
-
-  vector<UserRoutingThread> threads;
-  for (Address addr : routing_ips) {
-    for (unsigned i = 0; i < kRoutingThreadCount; i++) {
-      threads.push_back(UserRoutingThread(addr, i));
-    }
-  }
-
-  KvsClient client(threads, ip, 0, 10000);
-
+  annalib::ClientConfig config = annalib::load_config(config_filename);
+  std::unique_ptr<KvsClient> client = annalib::make_client(config);
 
   if (command == "CLI") {
     if (argc == 4) {
-      cli_loop_interactive(&client, config_filename);
+      cli_loop_interactive(client.get(), config_filename);
     } else {
-      cli_loop_file(&client, argv[2], argv[4]);
+      cli_loop_file(client.get(), config_filename, argv[4]);
     }
   } else if (command == "START") {
-      std::cout << start(config_filename) << " anna processes were started" << std::endl;
-  } else if (command == "START") {
-      std::cout << start(config_filename) << " anna processes were stopped" << std::endl;
+    std::cout << annalib::start(config_filename) << " anna processes were started"
+              << std::endl;
+  } else if (command == "STOP") {
+    std::cout << annalib::stop() << " anna processes were stopped"
+              << std::endl;
   } else if (command == "STATUS") {
-    for(const string &name : status()) {
-        std::cout << name << " process is running" << std::endl;
+    for (const string& name : annalib::status()) {
+      std::cout << name << " process is running" << std::endl;
     }
   } else if (command == "HELP") {
-      std::cout << usage(my_name) << std::endl;
+    std::cout << usage(my_name) << std::endl;
   }
 }

--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -209,6 +209,12 @@ set<string> get_set(KvsClientInterface* client, const string& key) {
     responses = client->receive_async();
   }
 
+  if (responses.size() > 1) {
+    std::cerr << "Error: received more than one response" << std::endl;
+  }
+
+  assert(responses[0].tuples(0).lattice_type() == kvs::LatticeType::SET);
+
   SetLattice<string> latt = deserialize_set(responses[0].tuples(0).payload());
 
   return latt.reveal();

--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -1,0 +1,247 @@
+//  Copyright 2019 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "client_lib.hpp"
+
+#include <cassert>
+
+#include "yaml-cpp/yaml.h"
+
+// kZmqUtil is declared `extern` (in the global namespace) by
+// zmq/zmq_util.hpp and used by KvsClient/requests.hpp; this is its one
+// definition for any binary that links against this library.
+namespace {
+ZmqUtil zmq_util;
+}  // namespace
+ZmqUtilInterface* kZmqUtil = &zmq_util;
+
+namespace annalib {
+
+const vector<string> kProcessList = {"anna-monitor", "anna-route",
+                                      "anna-kvs"};
+
+ClientConfig load_config(const string& config_file_path) {
+  YAML::Node conf = YAML::LoadFile(config_file_path);
+  unsigned routing_thread_count = conf["threads"]["routing"].as<unsigned>();
+
+  YAML::Node user = conf["user"];
+  Address ip = user["ip"].as<Address>();
+
+  vector<Address> routing_ips;
+  if (YAML::Node elb = user["routing-elb"]) {
+    routing_ips.push_back(elb.as<string>());
+  } else {
+    YAML::Node routing = user["routing"];
+    for (const YAML::Node& node : routing) {
+      routing_ips.push_back(node.as<Address>());
+    }
+  }
+
+  ClientConfig config;
+  config.ip = ip;
+  for (const Address& addr : routing_ips) {
+    for (unsigned i = 0; i < routing_thread_count; i++) {
+      config.routing_threads.push_back(UserRoutingThread(addr, i));
+    }
+  }
+
+  return config;
+}
+
+std::unique_ptr<KvsClient> make_client(const ClientConfig& config,
+                                        unsigned tid, unsigned timeout) {
+  return std::make_unique<KvsClient>(config.routing_threads, config.ip, tid,
+                                      timeout);
+}
+
+string get(KvsClientInterface* client, const string& key) {
+  client->get_async(key);
+
+  vector<kvs::KeyResponse> responses = client->receive_async();
+  while (responses.size() == 0) {
+    responses = client->receive_async();
+  }
+
+  if (responses.size() > 1) {
+    std::cerr << "Error: received more than one response" << std::endl;
+  }
+
+  assert(responses[0].tuples(0).lattice_type() == kvs::LatticeType::LWW);
+
+  LWWPairLattice<string> lww_lattice =
+      deserialize_lww(responses[0].tuples(0).payload());
+
+  return lww_lattice.reveal().value;
+}
+
+CausalValue get_causal(KvsClientInterface* client, const string& key) {
+  client->get_async(key);
+
+  vector<kvs::KeyResponse> responses = client->receive_async();
+  while (responses.size() == 0) {
+    responses = client->receive_async();
+  }
+
+  if (responses.size() > 1) {
+    std::cerr << "Error: received more than one response" << std::endl;
+  }
+
+  assert(responses[0].tuples(0).lattice_type() ==
+         kvs::LatticeType::MULTI_CAUSAL);
+
+  MultiKeyCausalLattice<SetLattice<string>> mkcl =
+      MultiKeyCausalLattice<SetLattice<string>>(to_multi_key_causal_payload(
+          deserialize_multi_key_causal(responses[0].tuples(0).payload())));
+
+  CausalValue result;
+  result.value = *(mkcl.reveal().value.reveal().begin());
+
+  for (const auto& pair : mkcl.reveal().vector_clock.reveal()) {
+    result.vector_clock.push_back({pair.first, pair.second.reveal()});
+  }
+
+  for (const auto& dep_key_vc_pair : mkcl.reveal().dependencies.reveal()) {
+    vector<pair<string, unsigned>> vc;
+    for (const auto& vc_pair : dep_key_vc_pair.second.reveal()) {
+      vc.push_back({vc_pair.first, vc_pair.second.reveal()});
+    }
+    result.dependencies[dep_key_vc_pair.first] = vc;
+  }
+
+  return result;
+}
+
+kvs::KeyResponse put(KvsClientInterface* client, const string& key,
+                     const string& value) {
+  LWWPairLattice<string> val(
+      TimestampValuePair<string>(generate_timestamp(0), value));
+
+  string rid =
+      client->put_async(key, serialize(val), kvs::LatticeType::LWW);
+
+  vector<kvs::KeyResponse> responses = client->receive_async();
+  while (responses.size() == 0) {
+    responses = client->receive_async();
+  }
+
+  kvs::KeyResponse response = responses[0];
+
+  // TODO encode this error into the response
+  if (response.response_id() != rid) {
+    std::cerr << "Invalid response: ID did not match request ID!"
+              << std::endl;
+  }
+
+  return response;
+}
+
+kvs::KeyResponse put_causal(KvsClientInterface* client, const string& key,
+                            const string& value) {
+  MultiKeyCausalPayload<SetLattice<string>> mkcp;
+  // construct a test client id - version pair
+  mkcp.vector_clock.insert("test", 1);
+
+  // construct one test dependency
+  mkcp.dependencies.insert(
+      "dep1", VectorClock(map<string, MaxLattice<unsigned>>({{"test1", 1}})));
+
+  // populate the value
+  mkcp.value.insert(value);
+
+  MultiKeyCausalLattice<SetLattice<string>> mkcl(mkcp);
+
+  string rid = client->put_async(key, serialize(mkcl),
+                                 kvs::LatticeType::MULTI_CAUSAL);
+
+  vector<kvs::KeyResponse> responses = client->receive_async();
+  while (responses.size() == 0) {
+    responses = client->receive_async();
+  }
+
+  kvs::KeyResponse response = responses[0];
+
+  // TODO encode this error into the response
+  if (response.response_id() != rid) {
+    std::cerr << "Invalid response: ID did not match request ID!"
+              << std::endl;
+  }
+
+  return response;
+}
+
+kvs::KeyResponse put_set(KvsClientInterface* client, const string& key,
+                         const set<string>& values) {
+  string rid = client->put_async(key, serialize(SetLattice<string>(values)),
+                                 kvs::LatticeType::SET);
+
+  vector<kvs::KeyResponse> responses = client->receive_async();
+  while (responses.size() == 0) {
+    responses = client->receive_async();
+  }
+
+  kvs::KeyResponse response = responses[0];
+
+  // TODO encode this error into the response
+  if (response.response_id() != rid) {
+    std::cerr << "Invalid response: ID did not match request ID!"
+              << std::endl;
+  }
+
+  return response;
+}
+
+set<string> get_set(KvsClientInterface* client, const string& key) {
+  client->get_async(key);
+
+  vector<kvs::KeyResponse> responses = client->receive_async();
+  while (responses.size() == 0) {
+    responses = client->receive_async();
+  }
+
+  SetLattice<string> latt = deserialize_set(responses[0].tuples(0).payload());
+
+  return latt.reveal();
+}
+
+// start()/stop()/status() are not yet implemented -- see #103. These stubs
+// preserve the exact (non-)behavior that previously lived in cli.cpp.
+int start(const string& config_file_path) {
+  int process_count = 3;  // TODO until implemented
+  for (const string& process_name : kProcessList) {
+    (void)process_name;
+  }
+
+  return process_count;
+}
+
+vector<string> status() {
+  vector<string> result = {};
+
+  for (const string& process_name : kProcessList) {
+    (void)process_name;
+  }
+
+  return result;
+}
+
+int stop() {
+  int kill_count = 3;  // TODO until we implement
+  for (const string& process_name : kProcessList) {
+    (void)process_name;
+  }
+
+  return kill_count;
+}
+
+}  // namespace annalib

--- a/clients/cpp/src/client_lib.hpp
+++ b/clients/cpp/src/client_lib.hpp
@@ -1,0 +1,97 @@
+//  Copyright 2019 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef INCLUDE_CLIENT_LIB_HPP_
+#define INCLUDE_CLIENT_LIB_HPP_
+
+#include <memory>
+
+#include "kvs_client.hpp"
+
+// This header (together with client_lib.cpp) is the "library" half of the
+// C++ client: it wraps KvsClientInterface with the KVS operations (get, put,
+// ...) and process management (start, stop, status), with no dependency on
+// stdin/stdout or argv. `cli.cpp` is a thin example CLI built on top of this
+// library -- see issue #75.
+namespace annalib {
+
+// The set of configuration needed to construct a KvsClient: this client's
+// own IP address, and the set of routing threads it should talk to.
+struct ClientConfig {
+  vector<UserRoutingThread> routing_threads;
+  Address ip;
+};
+
+// Parse a YAML anna config file (the same format used by the server) into a
+// ClientConfig. Throws a YAML::Exception if the file is missing or
+// malformed.
+ClientConfig load_config(const string& config_file_path);
+
+// Construct a KvsClient connected to the routing tier described by `config`.
+std::unique_ptr<KvsClient> make_client(const ClientConfig& config,
+                                        unsigned tid = 0,
+                                        unsigned timeout = 10000);
+
+// Issue a blocking GET for `key` under the default (LWW) lattice type and
+// return its value.
+string get(KvsClientInterface* client, const string& key);
+
+// The result of a causal GET: the value plus the vector clock and
+// dependencies attached to it, for the caller to display/inspect as needed.
+struct CausalValue {
+  string value;
+  vector<pair<string, unsigned>> vector_clock;
+  map<string, vector<pair<string, unsigned>>> dependencies;
+};
+
+// Issue a blocking GET for `key` under the multi-key-causal lattice type.
+CausalValue get_causal(KvsClientInterface* client, const string& key);
+
+// Issue a blocking PUT of `value` for `key` under the default (LWW) lattice
+// type.
+kvs::KeyResponse put(KvsClientInterface* client, const string& key,
+                     const string& value);
+
+// Issue a blocking PUT of `value` for `key` under the multi-key-causal
+// lattice type.
+kvs::KeyResponse put_causal(KvsClientInterface* client, const string& key,
+                            const string& value);
+
+// Issue a blocking PUT of `values` for `key` under the set lattice type.
+kvs::KeyResponse put_set(KvsClientInterface* client, const string& key,
+                         const set<string>& values);
+
+// Issue a blocking GET for `key` under the set lattice type.
+set<string> get_set(KvsClientInterface* client, const string& key);
+
+// The anna server processes managed by start()/stop()/status().
+extern const vector<string> kProcessList;
+
+// Start the anna server processes described by the config file at
+// `config_file_path`. Returns the number of processes started.
+// NOTE: not yet implemented -- see #103.
+int start(const string& config_file_path);
+
+// Return the running status of each process in kProcessList.
+// NOTE: not yet implemented -- see #103.
+vector<string> status();
+
+// Stop all running anna server processes. Returns the number of processes
+// killed.
+// NOTE: not yet implemented -- see #103.
+int stop();
+
+}  // namespace annalib
+
+#endif  // INCLUDE_CLIENT_LIB_HPP_


### PR DESCRIPTION
Closes #75

## Changes

Extracts the KVS operations (`get`/`put`/`get_causal`/`put_causal`/`get_set`/`put_set`) and process management (`start`/`stop`/`status`) out of `cli.cpp` into a new `anna-client-lib` static library (`client_lib.hpp` / `client_lib.cpp`), so that:

- `cli.cpp` is now a thin example CLI (argv parsing, REPL loop, output formatting) built on top of the library — matching the existing lib/bin split already used by the Rust client (`annalib`/`anna`).
- Future work can link against `anna-client-lib` without pulling in `main()`:
  - #104 (C++ client unit tests)
  - #293 (C++ client system test)
  - #294 (C++ CLI integration tests)
  - #120 (embedding example)
- `get_causal()` no longer prints directly to stdout; it returns a `CausalValue` struct (value + vector clock + dependencies) that the CLI formats for display.
- `load_config()` / `make_client()` centralize YAML config parsing and `KvsClient` construction in the library.

### Bonus bug fixes (found while moving this code)
- The CLI's `STOP` command called `start()` instead of `stop()`.
- `main()`'s `STOP` branch was unreachable dead code (it was a duplicate `"START"` condition), and also called `start()` instead of `stop()`.

## Testing
- `make build` — clean build of server, C++ client, Rust client
- `make test` — full suite passes
- `make clippy && make fmt` — no new warnings
- Manual smoke test of `anna-cli --config conf/anna-local.yml {help,start,stop,status}`

Part of the milestone 1 test-infrastructure plan (see milestone description).