### PR TITLE
Add unit tests for Python client.py and zmq_util.py (#106)

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,0 +1,184 @@
+from unittest.mock import MagicMock, patch, PropertyMock
+import pytest
+
+from anna.kvs_pb2 import LWW, SET, NO_ERROR, KeyResponse, KeyTuple, LWWValue, SetValue
+from anna.lattices import LWWPairLattice, SetLattice
+
+
+def make_client():
+    """Create an AnnaTcpClient with mocked ZMQ context and sockets."""
+    with patch("anna.client.zmq") as mock_zmq, \
+         patch("anna.base_client.BaseAnnaClient.__init__", lambda self: None):
+        mock_ctx = MagicMock()
+        mock_zmq.Context.return_value = mock_ctx
+        mock_zmq.PULL = 7
+        mock_zmq.PUSH = 8
+
+        from anna.client import AnnaTcpClient
+        client = AnnaTcpClient("127.0.0.1", "127.0.0.1", local=True, offset=0)
+
+    return client
+
+
+class TestAnnaTcpClientConstructor:
+    def test_creates_client(self):
+        client = make_client()
+        assert client.elb_addr == "127.0.0.1"
+        assert client.elb_ports == [6450]
+
+    def test_non_local_ports(self):
+        with patch("anna.client.zmq") as mock_zmq, \
+             patch("anna.base_client.BaseAnnaClient.__init__", lambda self: None):
+            mock_zmq.Context.return_value = MagicMock()
+            mock_zmq.PULL = 7
+            mock_zmq.PUSH = 8
+            from anna.client import AnnaTcpClient
+            client = AnnaTcpClient("elb.example.com", "10.0.0.1", local=False)
+        assert client.elb_ports == list(range(6450, 6454))
+
+    def test_ip_inference(self):
+        with patch("anna.client.zmq") as mock_zmq, \
+             patch("anna.client.socket") as mock_socket, \
+             patch("anna.base_client.BaseAnnaClient.__init__", lambda self: None):
+            mock_zmq.Context.return_value = MagicMock()
+            mock_zmq.PULL = 7
+            mock_zmq.PUSH = 8
+            mock_socket.gethostname.return_value = "myhost"
+            mock_socket.gethostbyname.return_value = "192.168.1.1"
+            from anna.client import AnnaTcpClient
+            client = AnnaTcpClient("127.0.0.1", None, local=True)
+        assert client.ut.get_ip() == "192.168.1.1"
+
+
+class TestGetRequestId:
+    def test_increments(self):
+        client = make_client()
+        id1 = client._get_request_id()
+        id2 = client._get_request_id()
+        assert id1 != id2
+        assert "127.0.0.1" in id1
+
+    def test_wraps_at_10000(self):
+        client = make_client()
+        client.rid = 9999
+        id1 = client._get_request_id()
+        assert id1.endswith(":9999")
+        id2 = client._get_request_id()
+        assert id2.endswith(":0")
+
+
+class TestPrepareDataRequest:
+    def test_creates_request_with_key(self):
+        client = make_client()
+        req, tuples = client._prepare_data_request(["mykey"])
+        assert len(tuples) == 1
+        assert tuples[0].key == "mykey"
+        assert req.request_id != ""
+
+    def test_multiple_keys(self):
+        client = make_client()
+        req, tuples = client._prepare_data_request(["k1", "k2", "k3"])
+        assert len(tuples) == 3
+        assert tuples[0].key == "k1"
+        assert tuples[2].key == "k3"
+
+
+class TestGetWorkerAddress:
+    def test_returns_none_when_no_addresses(self):
+        client = make_client()
+        with patch.object(client, '_query_routing', return_value=[]):
+            result = client._get_worker_address("missing_key")
+            assert result is None
+
+    def test_caches_addresses(self):
+        client = make_client()
+        client.address_cache["cached_key"] = ["tcp://127.0.0.1:6200"]
+        result = client._get_worker_address("cached_key")
+        assert result == "tcp://127.0.0.1:6200"
+
+
+class TestInvalidateCache:
+    def test_removes_key(self):
+        client = make_client()
+        client.address_cache["mykey"] = ["addr1"]
+        client._invalidate_cache("mykey")
+        assert "mykey" not in client.address_cache
+
+
+class TestGet:
+    def test_get_returns_deserialized_value(self):
+        client = make_client()
+        client.address_cache["mykey"] = ["tcp://127.0.0.1:6200"]
+
+        lww_val = LWWValue()
+        lww_val.timestamp = 1
+        lww_val.value = b"hello"
+
+        response = KeyResponse()
+        response.response_id = "placeholder"
+        tup = response.tuples.add()
+        tup.key = "mykey"
+        tup.lattice_type = LWW
+        tup.payload = lww_val.SerializeToString()
+        tup.error = NO_ERROR
+
+        mock_send_sock = MagicMock()
+        client.pusher_cache = MagicMock()
+        client.pusher_cache.get.return_value = mock_send_sock
+
+        with patch("anna.client.send_request") as mock_send, \
+             patch("anna.client.recv_response") as mock_recv:
+            # Make recv_response return our prepared response, matching any request ID
+            def recv_side_effect(req_ids, sock, cls):
+                response.response_id = req_ids[0]
+                return [response]
+            mock_recv.side_effect = recv_side_effect
+
+            result = client.get("mykey")
+
+        assert "mykey" in result
+        assert isinstance(result["mykey"], LWWPairLattice)
+        assert result["mykey"].reveal() == b"hello"
+
+
+class TestPut:
+    def test_put_returns_success(self):
+        client = make_client()
+        client.address_cache["mykey"] = ["tcp://127.0.0.1:6200"]
+
+        response = KeyResponse()
+        response.response_id = "placeholder"
+        tup = response.tuples.add()
+        tup.key = "mykey"
+        tup.error = NO_ERROR
+
+        mock_send_sock = MagicMock()
+        client.pusher_cache = MagicMock()
+        client.pusher_cache.get.return_value = mock_send_sock
+
+        with patch("anna.client.send_request"), \
+             patch("anna.client.recv_response") as mock_recv:
+            def recv_side_effect(req_ids, sock, cls):
+                response.response_id = req_ids[0]
+                return [response]
+            mock_recv.side_effect = recv_side_effect
+
+            val = LWWPairLattice(1, b"world")
+            result = client.put("mykey", val)
+
+        assert result["mykey"] is True
+
+    def test_put_returns_false_when_no_worker(self):
+        client = make_client()
+        with patch.object(client, '_get_worker_address', return_value=None):
+            val = LWWPairLattice(1, b"world")
+            result = client.put("mykey", val)
+        assert result is False
+
+
+class TestResponseAddress:
+    def test_returns_connect_address(self):
+        client = make_client()
+        addr = client.response_address
+        assert "127.0.0.1" in addr
+        assert "tcp://" in addr

--- a/clients/python/tests/test_zmq_util.py
+++ b/clients/python/tests/test_zmq_util.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock, call
+
+from anna.zmq_util import send_request, recv_response, SocketCache
+
+
+class TestSendRequest:
+    def test_serializes_and_sends(self):
+        req = MagicMock()
+        req.SerializeToString.return_value = b"serialized_data"
+        sock = MagicMock()
+
+        send_request(req, sock)
+
+        req.SerializeToString.assert_called_once()
+        sock.send.assert_called_once_with(b"serialized_data")
+
+
+class TestRecvResponse:
+    def test_receives_matching_response(self):
+        resp_class = MagicMock()
+        resp_obj = MagicMock()
+        resp_obj.response_id = "req-1"
+        resp_class.return_value = resp_obj
+        resp_obj.ParseFromString = MagicMock()
+
+        sock = MagicMock()
+        sock.recv.return_value = b"response_bytes"
+
+        responses = recv_response(["req-1"], sock, resp_class)
+
+        assert len(responses) == 1
+        assert responses[0] == resp_obj
+
+    def test_skips_non_matching_then_matches(self):
+        resp_class = MagicMock()
+
+        wrong_resp = MagicMock()
+        wrong_resp.response_id = "wrong-id"
+        wrong_resp.Clear = MagicMock()
+        wrong_resp.ParseFromString = MagicMock()
+
+        right_resp = MagicMock()
+        right_resp.response_id = "req-1"
+        right_resp.ParseFromString = MagicMock()
+
+        call_count = [0]
+        def make_resp():
+            obj = MagicMock()
+            if call_count[0] == 0:
+                obj.response_id = "wrong-id"
+                obj.Clear = MagicMock()
+                def update_id(data):
+                    obj.response_id = "req-1"
+                obj.ParseFromString = MagicMock(side_effect=update_id)
+            else:
+                obj.response_id = "req-1"
+            call_count[0] += 1
+            return obj
+
+        resp_class.side_effect = make_resp
+
+        sock = MagicMock()
+        sock.recv.return_value = b"data"
+
+        responses = recv_response(["req-1"], sock, resp_class)
+        assert len(responses) == 1
+
+    def test_collects_multiple_responses(self):
+        resp_class = MagicMock()
+
+        resp1 = MagicMock()
+        resp1.response_id = "req-1"
+        resp2 = MagicMock()
+        resp2.response_id = "req-2"
+
+        resp_class.side_effect = [resp1, resp2]
+
+        sock = MagicMock()
+        sock.recv.return_value = b"data"
+
+        responses = recv_response(["req-1", "req-2"], sock, resp_class)
+        assert len(responses) == 2
+
+
+class TestSocketCache:
+    def test_creates_socket_on_first_access(self):
+        ctx = MagicMock()
+        sock = MagicMock()
+        ctx.socket.return_value = sock
+
+        cache = SocketCache(ctx, 8)
+        result = cache.get("tcp://127.0.0.1:6200")
+
+        assert result == sock
+        ctx.socket.assert_called_once_with(8)
+        sock.connect.assert_called_once_with("tcp://127.0.0.1:6200")
+
+    def test_returns_cached_socket_on_second_access(self):
+        ctx = MagicMock()
+        sock = MagicMock()
+        ctx.socket.return_value = sock
+
+        cache = SocketCache(ctx, 8)
+        first = cache.get("tcp://127.0.0.1:6200")
+        second = cache.get("tcp://127.0.0.1:6200")
+
+        assert first is second
+        ctx.socket.assert_called_once()
+
+    def test_different_addrs_get_different_sockets(self):
+        ctx = MagicMock()
+        sock1 = MagicMock()
+        sock2 = MagicMock()
+        ctx.socket.side_effect = [sock1, sock2]
+
+        cache = SocketCache(ctx, 8)
+        first = cache.get("tcp://127.0.0.1:6200")
+        second = cache.get("tcp://127.0.0.1:6201")
+
+        assert first is not second
+        assert ctx.socket.call_count == 2


### PR DESCRIPTION
## Summary
- 7 tests for `zmq_util.py`: `send_request`, `recv_response` (matching, non-matching, multiple responses), `SocketCache` (create, cache hit, different addresses)
- 14 tests for `client.py`: `AnnaTcpClient` constructor (local, non-local, IP inference), request ID generation/wrapping, `_prepare_data_request`, `_get_worker_address`, cache invalidation, `get`/`put` with mocked ZMQ, `response_address` property

Total Python tests: 139 (was 118)

Closes #106

## Test plan
- [x] All 139 tests pass (`make client-python-tests`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)