### PR TITLE
Fix docs workflow: install lychee via cargo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y -qq protobuf-compiler lychee
-        cargo install mdbook
+        sudo apt-get install -y -qq protobuf-compiler
+        cargo install mdbook lychee
 
     - name: Build docs
       run: make docs


### PR DESCRIPTION
lychee is not an apt package — install via cargo install instead.