### PR TITLE
Move codecov upload from macOS to ubuntu (#313)

### DIFF
--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -55,7 +55,7 @@ jobs:
       run: cargo test
 
     - uses: codecov/codecov-action@v2
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'ubuntu-latest'
       with:
         files: rust_workspace.info,server/cpp/build/server.info,clients/cpp/build/client.info,clients/python/coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
Move the codecov upload step from macOS to ubuntu-latest. Both platforms already run `make test` which includes coverage generation. This tests whether the overall CI wall-clock time improves.

**Baseline (PR #317):** macOS 6m2s, ubuntu 6m11s, ubuntu-arm 5m42s, windows 6m21s

Closes #313

## Decision criteria
Compare the max(macOS, ubuntu) times from this PR against the baseline. If the new max is lower, keep it; if higher, revert.