### PR TITLE
Add rustyline tab-completion for CLI commands (#19)

### DIFF
--- a/clients/rust/src/lib/completer.rs
+++ b/clients/rust/src/lib/completer.rs
@@ -1,0 +1,101 @@
+//! Tab-completion for anna CLI commands.
+
+use rustyline::completion::{Completer, Pair};
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::Validator;
+use rustyline::{Context, Helper};
+
+/// Commands available in the anna interactive CLI.
+pub const ANNA_COMMANDS: &[&str] = &[
+    "GET", "PUT", "GET_SET", "PUT_SET", "GET_CAUSAL", "PUT_CAUSAL", "START", "STOP", "STATUS",
+    "HELP", "EXIT",
+];
+
+/// Provides tab-completion for anna CLI commands.
+pub struct AnnaCompleter;
+
+impl Completer for AnnaCompleter {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        let prefix = &line[..pos].to_ascii_uppercase();
+        if prefix.contains(' ') {
+            return Ok((pos, vec![]));
+        }
+        let matches: Vec<Pair> = ANNA_COMMANDS
+            .iter()
+            .filter(|cmd| cmd.starts_with(prefix.as_str()))
+            .map(|cmd| Pair {
+                display: cmd.to_string(),
+                replacement: cmd.to_string(),
+            })
+            .collect();
+        Ok((0, matches))
+    }
+}
+
+impl Hinter for AnnaCompleter {
+    type Hint = String;
+}
+impl Highlighter for AnnaCompleter {}
+impl Validator for AnnaCompleter {}
+impl Helper for AnnaCompleter {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn complete(input: &str) -> Vec<String> {
+        let completer = AnnaCompleter;
+        let (_, pairs) = completer
+            .complete(input, input.len(), &Context::new(&rustyline::history::DefaultHistory::new()))
+            .unwrap();
+        pairs.into_iter().map(|p| p.display).collect()
+    }
+
+    #[test]
+    fn completes_get() {
+        let results = complete("GE");
+        assert!(results.contains(&"GET".to_string()));
+        assert!(results.contains(&"GET_SET".to_string()));
+        assert!(results.contains(&"GET_CAUSAL".to_string()));
+    }
+
+    #[test]
+    fn completes_put() {
+        let results = complete("PU");
+        assert!(results.contains(&"PUT".to_string()));
+        assert!(results.contains(&"PUT_SET".to_string()));
+    }
+
+    #[test]
+    fn completes_case_insensitive() {
+        let results = complete("ge");
+        assert!(results.contains(&"GET".to_string()));
+    }
+
+    #[test]
+    fn no_completion_after_space() {
+        let results = complete("GET ");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn empty_prefix_returns_all() {
+        let results = complete("");
+        assert_eq!(results.len(), ANNA_COMMANDS.len());
+    }
+
+    #[test]
+    fn exact_match() {
+        let results = complete("EXIT");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], "EXIT");
+    }
+}

--- a/clients/rust/src/lib/lib.rs
+++ b/clients/rust/src/lib/lib.rs
@@ -12,6 +12,8 @@ use std::path::Path;
 use std::process::Command;
 use sysinfo::System;
 
+/// Tab-completion for the anna CLI.
+pub mod completer;
 /// `config` of anna - read from config file or created via API calls.
 pub mod config;
 /// put all error types and methods into an `errors` module

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -7,10 +7,10 @@
 use std::env;
 use std::process::exit;
 
-use annalib::{config::Config, info, kvs_client::KVSClient, start, status, stop};
+use annalib::{completer::AnnaCompleter, config::Config, info, kvs_client::KVSClient, start, status, stop};
 use clap::{Arg, ArgMatches, Command};
 use log::{debug, error, info, warn};
-use rustyline::DefaultEditor;
+use rustyline::Editor;
 use simplog::SimpleLogger;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -198,7 +198,8 @@ fn cli_usage() -> String {
 }
 
 fn cli_loop_interactive(mut client: KVSClient, config_file_path: PathBuf) -> Result<&'static str> {
-    let mut rl = DefaultEditor::new()?;
+    let mut rl = Editor::new()?;
+    rl.set_helper(Some(AnnaCompleter));
     if rl.load_history(ANNA_HISTORY_FILENAME).is_err() {
         println!(
             "No previous history. Saving new history in {}",


### PR DESCRIPTION
## Summary
Implement `AnnaCompleter` providing tab-completion for all CLI commands:
GET, PUT, GET_SET, PUT_SET, GET_CAUSAL, PUT_CAUSAL, START, STOP, STATUS, HELP, EXIT.

- Only completes the first token (command name, not arguments)
- Case-insensitive prefix matching
- Replaces `DefaultEditor` with `Editor<AnnaCompleter>`

Closes #19

## Test plan
- [x] `make test` — all suites pass
- [x] Manual test: typing `GE<tab>` completes to `GET`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)