### PR TITLE
Add graceful server shutdown and capture system test coverage (#329)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,13 +146,24 @@ coverage: test
 	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info || true
 
 .PHONY: test
-test: server-cpp-tests client-cpp-tests client-python-tests workspace-rust-tests client-go-tests
+test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage
+
+.PHONY: server-system-coverage
+server-system-coverage:
+	@echo "Capturing server coverage from client system tests"
+	@cd server/cpp/build && lcov --directory . --capture --output-file server-system.info --ignore-errors inconsistent,format,unused 2>/dev/null || true
+	@cd server/cpp/build && lcov --remove server-system.info '/Applications/*' '/usr*' '*/build/*' '*/gtest/*' '*/tests/*' -o server-system.info --ignore-errors inconsistent,format,unused 2>/dev/null || true
 
 .PHONY: server-cpp-tests
 server-cpp-tests:
 	@echo "Running C++ server tests with coverage"
 	@cd server/cpp/build && make --no-print-directory -s server-test-coverage
 	@find server/cpp -name "*.profraw" | xargs rm -f
+
+.PHONY: merge-server-coverage
+merge-server-coverage:
+	@echo "Merging server unit test and system test coverage"
+	@cd server/cpp/build && lcov --add-tracefile server.info --add-tracefile server-system.info --output-file server.info --ignore-errors inconsistent,format,unused 2>/dev/null || true
 
 .PHONY: client-cpp-tests
 client-cpp-tests:

--- a/clients/cpp/tests/system/test_system_runner.py
+++ b/clients/cpp/tests/system/test_system_runner.py
@@ -167,13 +167,21 @@ policy:
             sys.exit(result.returncode)
 
     finally:
-        # Kill the server process group
         print("Cleaning up...")
         for proc in procs:
             try:
                 os.killpg(os.getpgid(proc.pid), subprocess.signal.SIGTERM)
             except Exception as e:
-                print(f"Error killing process {proc.pid}: {e}")
+                print(f"Error sending SIGTERM to {proc.pid}: {e}")
+
+        for proc in procs:
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                try:
+                    os.killpg(os.getpgid(proc.pid), subprocess.signal.SIGKILL)
+                except Exception:
+                    pass
         
         if os.path.exists(test_config):
             os.remove(test_config)

--- a/clients/cpp/tests/system/test_system_runner.py
+++ b/clients/cpp/tests/system/test_system_runner.py
@@ -1,4 +1,5 @@
 import subprocess
+import signal
 import time
 import os
 import sys
@@ -170,7 +171,7 @@ policy:
         print("Cleaning up...")
         for proc in procs:
             try:
-                os.killpg(os.getpgid(proc.pid), subprocess.signal.SIGTERM)
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
             except Exception as e:
                 print(f"Error sending SIGTERM to {proc.pid}: {e}")
 
@@ -179,7 +180,7 @@ policy:
                 proc.wait(timeout=5)
             except Exception:
                 try:
-                    os.killpg(os.getpgid(proc.pid), subprocess.signal.SIGKILL)
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                 except Exception:
                     pass
         

--- a/clients/go/tests/system_test.go
+++ b/clients/go/tests/system_test.go
@@ -61,6 +61,7 @@ func startServers(t *testing.T) {
 
 func stopServers() {
 	annalib.Stop()
+	time.Sleep(2 * time.Second)
 }
 
 func TestSystemKVSClient(t *testing.T) {

--- a/clients/python/tests/test_system.py
+++ b/clients/python/tests/test_system.py
@@ -136,6 +136,15 @@ def live_server(tmp_path_factory):
         except Exception:
             pass
 
+    for proc in procs:
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except Exception:
+                pass
+
 
 @pytest.fixture
 def client(live_server):

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 #include "kvs/kvs_handlers.hpp"
+#include "signal_handler.hpp"
 #include "yaml-cpp/yaml.h"
 
 // define server report threshold (in second)
@@ -300,7 +301,7 @@ void run(unsigned thread_id, string ebs_root, Address public_ip, Address private
   unsigned epoch = 0;
 
   // enter event loop
-  while (true) {
+  while (!shutdown_requested.load()) {
     kZmqUtil->poll(&pollitems, std::chrono::milliseconds{0});
 
     // receives a node join
@@ -779,6 +780,8 @@ int main(int argc, char *argv[]) {
                    kEbsNodeCapacity);
 
   kThreadNum = kTierMetadata[kSelfTier].thread_number_;
+
+  install_shutdown_handler();
 
   // start the initial threads based on kThreadNum
   vector<std::thread> worker_threads;

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -793,9 +793,9 @@ int main(int argc, char *argv[]) {
 
   run(0, ebs_root, public_ip, private_ip, seed_ip, routing_ips, monitoring_ips, mgmt_ip);
 
-  // join on all threads to make sure they finish before exiting
-  for (unsigned tid = 1; tid < kThreadNum; tid++) {
-    worker_threads[tid].join();
+  // join on all worker threads to make sure they finish before exiting
+  for (auto& t : worker_threads) {
+    t.join();
   }
 
   return 0;

--- a/server/cpp/src/monitor/monitoring.cpp
+++ b/server/cpp/src/monitor/monitoring.cpp
@@ -15,6 +15,7 @@
 #include "monitor/monitoring_handlers.hpp"
 #include "monitor/monitoring_utils.hpp"
 #include "monitor/policies.hpp"
+#include "signal_handler.hpp"
 #include "yaml-cpp/yaml.h"
 
 unsigned kMemoryThreadCount;
@@ -44,6 +45,8 @@ HashRingUtilInterface *kHashRingUtil = &hash_ring_util;
 int main(int argc, char *argv[]) {
   auto log = spdlog::basic_logger_mt("monitoring_log", "log.txt", true);
   log->flush_on(spdlog::level::info);
+
+  install_shutdown_handler();
 
   if (argc != 3) {
     std::cerr << "Usage: " << argv[0] << "--config <config file path>" << std::endl;
@@ -176,7 +179,7 @@ int main(int argc, char *argv[]) {
 
   unsigned rid = 0;
 
-  while (true) {
+  while (!shutdown_requested.load()) {
     kZmqUtil->poll(&pollitems, std::chrono::milliseconds{0});
 
     if (pollitems[0].revents & ZMQ_POLLIN) {

--- a/server/cpp/src/route/routing.cpp
+++ b/server/cpp/src/route/routing.cpp
@@ -190,4 +190,8 @@ int main(int argc, char *argv[]) {
   }
 
   run(0, ip, monitoring_ips);
+
+  for (auto& t : routing_worker_threads) {
+    t.join();
+  }
 }

--- a/server/cpp/src/route/routing.cpp
+++ b/server/cpp/src/route/routing.cpp
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 #include "route/routing_handlers.hpp"
+#include "signal_handler.hpp"
 #include "yaml-cpp/yaml.h"
 
 hmap<Tier, TierMetadata, TierEnumHash> kTierMetadata;
@@ -101,8 +102,8 @@ void run(unsigned thread_id, Address ip, vector<Address> monitoring_ips) {
       {static_cast<void *>(replication_change_puller), 0, ZMQ_POLLIN, 0},
       {static_cast<void *>(key_address_puller), 0, ZMQ_POLLIN, 0}};
 
-  while (true) {
-    kZmqUtil->poll(&pollitems, std::chrono::milliseconds{-1});
+  while (!shutdown_requested.load()) {
+    kZmqUtil->poll(&pollitems, std::chrono::milliseconds{100});
 
     // only relevant for the seed node
     if (pollitems[0].revents & ZMQ_POLLIN) {
@@ -178,6 +179,8 @@ int main(int argc, char *argv[]) {
   kTierMetadata[Tier::DISK] =
       TierMetadata(Tier::DISK, kEbsThreadCount, kDefaultGlobalEbsReplication,
                    kEbsNodeCapacity);
+
+  install_shutdown_handler();
 
   vector<std::thread> routing_worker_threads;
 

--- a/server/cpp/src/signal_handler.hpp
+++ b/server/cpp/src/signal_handler.hpp
@@ -1,0 +1,18 @@
+#ifndef SIGNAL_HANDLER_HPP
+#define SIGNAL_HANDLER_HPP
+
+#include <csignal>
+#include <atomic>
+
+inline std::atomic<bool> shutdown_requested{false};
+
+inline void install_shutdown_handler() {
+  struct sigaction sa;
+  sa.sa_handler = [](int) { shutdown_requested.store(true); };
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sigaction(SIGTERM, &sa, nullptr);
+  sigaction(SIGINT, &sa, nullptr);
+}
+
+#endif // SIGNAL_HANDLER_HPP

--- a/tests/shared/cli/run_smoke_test.py
+++ b/tests/shared/cli/run_smoke_test.py
@@ -146,6 +146,15 @@ def stop_servers(procs):
         except Exception:
             pass
 
+    for proc in procs:
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except Exception:
+                pass
+
 
 def run_smoke_test(cli_cmd):
     server_dir = find_server_dir()


### PR DESCRIPTION
## Summary
- Add SIGTERM handler to all 3 server binaries (anna-kvs, anna-route, anna-monitor) for graceful shutdown
- Server main loops now check `shutdown_requested` flag instead of `while(true)`
- gcov coverage data is now flushed when servers exit cleanly during system tests
- Test runners wait up to 5s for graceful exit, then SIGKILL as fallback
- Makefile pipeline: client tests → capture server `.gcda` → server unit tests → merge coverage
- Server codecov now includes coverage from both unit tests AND client system tests

## Test plan
- [ ] `make test` passes — server shuts down cleanly during system tests
- [ ] `server.info` contains coverage from both unit and system test runs
- [ ] CI passes on all platforms
- [ ] Server coverage in codecov increases (system test paths now measured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)