### PR TITLE
Add system tests for all lattice types to improve server coverage (#336)

### DIFF
--- a/clients/cpp/tests/system/test_system.cpp
+++ b/clients/cpp/tests/system/test_system.cpp
@@ -51,6 +51,124 @@ TEST_F(SystemTest, PutSetGetSet) {
   EXPECT_EQ(result, values);
 }
 
+TEST_F(SystemTest, OrderedSetPutGet) {
+  std::string config_path = "test_config.yml";
+  annalib::ClientConfig config = annalib::load_config(config_path);
+  config.ip = "127.0.0.1";
+
+  auto client = annalib::make_client(config, 0, 5000);
+  ASSERT_NE(client, nullptr);
+
+  string key = "sys_oset";
+  set<string> values = {"alpha", "beta", "gamma"};
+
+  // 1. Put ordered set
+  kvs::KeyResponse resp = annalib::put_ordered_set(client.get(), key, values);
+  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+
+  // 2. Get ordered set
+  vector<string> result = annalib::get_ordered_set(client.get(), key);
+  EXPECT_EQ(result.size(), 3);
+}
+
+TEST_F(SystemTest, SingleCausalPutGet) {
+  std::string config_path = "test_config.yml";
+  annalib::ClientConfig config = annalib::load_config(config_path);
+  config.ip = "127.0.0.1";
+
+  auto client = annalib::make_client(config, 0, 5000);
+  ASSERT_NE(client, nullptr);
+
+  string key = "sys_sc";
+  string val = "sc_hello";
+
+  // 1. Put single causal
+  kvs::KeyResponse resp =
+      annalib::put_single_causal(client.get(), key, val);
+  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+
+  // 2. Get single causal
+  annalib::SingleCausalValue result =
+      annalib::get_single_causal(client.get(), key);
+  EXPECT_FALSE(result.values.empty());
+  bool found = false;
+  for (const auto& v : result.values) {
+    if (v == val) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "Expected values to contain 'sc_hello'";
+  EXPECT_FALSE(result.vector_clock.empty());
+}
+
+TEST_F(SystemTest, MultiCausalPutGet) {
+  std::string config_path = "test_config.yml";
+  annalib::ClientConfig config = annalib::load_config(config_path);
+  config.ip = "127.0.0.1";
+
+  auto client = annalib::make_client(config, 0, 5000);
+  ASSERT_NE(client, nullptr);
+
+  string key = "sys_mc";
+  string val = "mc_hello";
+
+  // 1. Put causal
+  kvs::KeyResponse resp = annalib::put_causal(client.get(), key, val);
+  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+
+  // 2. Get causal
+  annalib::CausalValue result = annalib::get_causal(client.get(), key);
+  EXPECT_EQ(result.value, val);
+}
+
+TEST_F(SystemTest, PriorityPutGet) {
+  std::string config_path = "test_config.yml";
+  annalib::ClientConfig config = annalib::load_config(config_path);
+  config.ip = "127.0.0.1";
+
+  auto client = annalib::make_client(config, 0, 5000);
+  ASSERT_NE(client, nullptr);
+
+  string key = "sys_pri";
+  double priority = 1.5;
+  string val = "important";
+
+  // 1. Put priority
+  kvs::KeyResponse resp =
+      annalib::put_priority(client.get(), key, priority, val);
+  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+
+  // 2. Get priority
+  annalib::PriorityResult result = annalib::get_priority(client.get(), key);
+  EXPECT_NEAR(result.priority, 1.5, 1e-9);
+  EXPECT_EQ(result.value, val);
+}
+
+TEST_F(SystemTest, DeleteKey) {
+  std::string config_path = "test_config.yml";
+  annalib::ClientConfig config = annalib::load_config(config_path);
+  config.ip = "127.0.0.1";
+
+  auto client = annalib::make_client(config, 0, 5000);
+  ASSERT_NE(client, nullptr);
+
+  string key = "sys_del";
+  string val = "to_delete";
+
+  // 1. Put
+  kvs::KeyResponse resp = annalib::put(client.get(), key, val);
+  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+
+  // 2. Get - verify value exists
+  string result = annalib::get(client.get(), key);
+  EXPECT_EQ(result, val);
+
+  // 3. Delete
+  kvs::KeyResponse del_resp = annalib::del(client.get(), key);
+  ASSERT_EQ(del_resp.error(), kvs::AnnaError::NO_ERROR);
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/clients/go/tests/system_test.go
+++ b/clients/go/tests/system_test.go
@@ -153,6 +153,84 @@ func TestSystemKVSClient(t *testing.T) {
 	if len(setVal) != 4 {
 		t.Errorf("Expected 4 elements after union, got %d: %v", len(setVal), setVal)
 	}
+
+	// ORDERED_SET: PUT and GET
+	if err := client.PutOrderedSet("go_sys_oset", []string{"alpha", "beta", "gamma"}); err != nil {
+		t.Fatalf("PUT_ORDERED_SET failed: %v", err)
+	}
+	osetVal, err := client.GetOrderedSet("go_sys_oset")
+	if err != nil {
+		t.Fatalf("GET_ORDERED_SET failed: %v", err)
+	}
+	if !contains(osetVal, "alpha") || !contains(osetVal, "beta") || !contains(osetVal, "gamma") {
+		t.Errorf("GET_ORDERED_SET missing expected values, got %v", osetVal)
+	}
+	if len(osetVal) != 3 {
+		t.Errorf("GET_ORDERED_SET expected 3 elements, got %d", len(osetVal))
+	}
+
+	// SINGLE_CAUSAL: PUT and GET
+	if err := client.PutSingleCausal("go_sys_sc", "sc_hello"); err != nil {
+		t.Fatalf("PUT_SINGLE_CAUSAL failed: %v", err)
+	}
+	scVal, err := client.GetSingleCausal("go_sys_sc")
+	if err != nil {
+		t.Fatalf("GET_SINGLE_CAUSAL failed: %v", err)
+	}
+	if !contains(scVal.Values, "sc_hello") {
+		t.Errorf("GET_SINGLE_CAUSAL Values missing 'sc_hello', got %v", scVal.Values)
+	}
+	if _, ok := scVal.VectorClock["test"]; !ok {
+		t.Errorf("GET_SINGLE_CAUSAL VectorClock missing 'test' key, got %v", scVal.VectorClock)
+	}
+
+	// MULTI_CAUSAL: PUT and GET
+	if err := client.PutCausal("go_sys_mc", "mc_hello"); err != nil {
+		t.Fatalf("PUT_CAUSAL failed: %v", err)
+	}
+	mcVal, err := client.GetCausal("go_sys_mc")
+	if err != nil {
+		t.Fatalf("GET_CAUSAL failed: %v", err)
+	}
+	if mcVal.Value != "mc_hello" {
+		t.Errorf("GET_CAUSAL Value = %q, want %q", mcVal.Value, "mc_hello")
+	}
+	if _, ok := mcVal.VectorClock["test"]; !ok {
+		t.Errorf("GET_CAUSAL VectorClock missing 'test' key, got %v", mcVal.VectorClock)
+	}
+	if _, ok := mcVal.Dependencies["dep1"]; !ok {
+		t.Errorf("GET_CAUSAL Dependencies missing 'dep1' key, got %v", mcVal.Dependencies)
+	}
+
+	// PRIORITY: PUT and GET
+	if err := client.PutPriority("go_sys_pri", 1.5, "important"); err != nil {
+		t.Fatalf("PUT_PRIORITY failed: %v", err)
+	}
+	priPriority, priValue, err := client.GetPriority("go_sys_pri")
+	if err != nil {
+		t.Fatalf("GET_PRIORITY failed: %v", err)
+	}
+	if priPriority != 1.5 {
+		t.Errorf("GET_PRIORITY priority = %f, want 1.5", priPriority)
+	}
+	if priValue != "important" {
+		t.Errorf("GET_PRIORITY value = %q, want %q", priValue, "important")
+	}
+
+	// DELETE: PUT, verify, then DELETE
+	if err := client.Put("go_sys_del", "to_delete"); err != nil {
+		t.Fatalf("PUT for delete test failed: %v", err)
+	}
+	delVal, err := client.Get("go_sys_del")
+	if err != nil {
+		t.Fatalf("GET before delete failed: %v", err)
+	}
+	if delVal != "to_delete" {
+		t.Errorf("GET before delete = %q, want %q", delVal, "to_delete")
+	}
+	if err := client.Delete("go_sys_del"); err != nil {
+		t.Fatalf("DELETE failed: %v", err)
+	}
 }
 
 func contains(slice []string, item string) bool {

--- a/clients/python/anna/client.py
+++ b/clients/python/anna/client.py
@@ -294,7 +294,8 @@ class AnnaTcpClient(BaseAnnaClient):
         return result.get(key)
 
     def put_ordered_set(self, key, values):
-        ordered_set = ListBasedOrderedSet(values)
+        encoded = [v.encode("utf-8") if isinstance(v, str) else v for v in values]
+        ordered_set = ListBasedOrderedSet(encoded)
         lattice = OrderedSetLattice(ordered_set)
         return self.put(key, lattice)
 

--- a/clients/python/tests/test_system.py
+++ b/clients/python/tests/test_system.py
@@ -186,3 +186,53 @@ class TestSystemPutGet:
     def test_get_nonexistent_key(self, client):
         got = client.get("sys_nonexistent_key_xyz")
         assert got["sys_nonexistent_key_xyz"] is None
+
+    def test_put_and_get_ordered_set(self, client):
+        from anna.lattices import ListBasedOrderedSet, OrderedSetLattice
+        result = client.put_ordered_set("sys_oset", ["alpha", "beta", "gamma"])
+        assert result["sys_oset"] is True
+
+        got = client.get_ordered_set("sys_oset")
+        assert got is not None
+        revealed = got.reveal()
+        assert isinstance(revealed, ListBasedOrderedSet)
+        assert "alpha" in revealed
+        assert "beta" in revealed
+        assert "gamma" in revealed
+
+    def test_put_and_get_single_causal(self, client):
+        from anna.lattices import SingleKeyCausalLattice
+        result = client.put_single_causal("sys_sc", "sc_hello")
+        assert result["sys_sc"] is True
+
+        got = client.get_single_causal("sys_sc")
+        assert got is not None
+        assert isinstance(got, SingleKeyCausalLattice)
+
+    def test_put_and_get_causal(self, client):
+        from anna.lattices import MultiKeyCausalLattice
+        result = client.put_causal("sys_mc", "mc_hello")
+        assert result["sys_mc"] is True
+
+        got = client.get_causal("sys_mc")
+        assert got is not None
+        assert isinstance(got, MultiKeyCausalLattice)
+
+    def test_put_and_get_priority(self, client):
+        from anna.lattices import PriorityLattice
+        result = client.put_priority("sys_pri", 1.5, "important")
+        assert result["sys_pri"] is True
+
+        got = client.get_priority("sys_pri")
+        assert got is not None
+        assert isinstance(got, PriorityLattice)
+
+    def test_delete(self, client):
+        from anna.lattices import LWWPairLattice
+        client.put("sys_del", LWWPairLattice(time.time_ns(), b"to_delete"))
+
+        got = client.get("sys_del")
+        assert got["sys_del"] is not None
+        assert got["sys_del"].reveal() == b"to_delete"
+
+        client.delete("sys_del")

--- a/clients/python/tests/test_system.py
+++ b/clients/python/tests/test_system.py
@@ -195,10 +195,10 @@ class TestSystemPutGet:
         got = client.get_ordered_set("sys_oset")
         assert got is not None
         revealed = got.reveal()
-        assert isinstance(revealed, ListBasedOrderedSet)
-        assert "alpha" in revealed
-        assert "beta" in revealed
-        assert "gamma" in revealed
+        assert len(revealed) == 3
+        assert b"alpha" in revealed
+        assert b"beta" in revealed
+        assert b"gamma" in revealed
 
     def test_put_and_get_single_causal(self, client):
         from anna.lattices import SingleKeyCausalLattice

--- a/clients/rust/tests/system.rs
+++ b/clients/rust/tests/system.rs
@@ -70,5 +70,93 @@ async fn system_test_kvs_client() {
         );
         assert!(set_val.contains(&"x".to_string()));
         assert!(set_val.contains(&"w".to_string()));
+
+        // ORDERED_SET
+        client
+            .put_ordered_set("sys_test_oset", &["alpha", "beta", "gamma"])
+            .await
+            .expect("PUT_ORDERED_SET failed");
+        let oset_val = client
+            .get_ordered_set("sys_test_oset")
+            .await
+            .expect("GET_ORDERED_SET failed");
+        assert!(oset_val.contains(&"alpha".to_string()));
+        assert!(oset_val.contains(&"beta".to_string()));
+        assert!(oset_val.contains(&"gamma".to_string()));
+        assert_eq!(oset_val.len(), 3, "ORDERED_SET should have 3 elements");
     }
+
+    // SINGLE_CAUSAL
+    #[cfg(feature = "causal")]
+    {
+        client
+            .put_single_causal("sys_test_sc", "sc_hello")
+            .await
+            .expect("PUT_SINGLE_CAUSAL failed");
+        let (vc, values) = client
+            .get_single_causal("sys_test_sc")
+            .await
+            .expect("GET_SINGLE_CAUSAL failed");
+        assert!(
+            values.contains(&"sc_hello".to_string()),
+            "SINGLE_CAUSAL values should contain 'sc_hello'"
+        );
+        assert!(
+            vc.contains_key("test"),
+            "SINGLE_CAUSAL vector clock should have 'test' key"
+        );
+    }
+
+    // MULTI_CAUSAL
+    #[cfg(feature = "causal")]
+    {
+        client
+            .put_causal("sys_test_mc", "mc_hello")
+            .await
+            .expect("PUT_CAUSAL failed");
+        let (vc, deps, value) = client
+            .get_causal("sys_test_mc")
+            .await
+            .expect("GET_CAUSAL failed");
+        assert_eq!(value, "mc_hello", "MULTI_CAUSAL value should be 'mc_hello'");
+        assert!(
+            vc.contains_key("test"),
+            "MULTI_CAUSAL vector clock should have 'test' key"
+        );
+        assert!(
+            deps.iter().any(|(k, _)| k == "dep1"),
+            "MULTI_CAUSAL dependencies should have 'dep1'"
+        );
+    }
+
+    // PRIORITY
+    client
+        .put_priority("sys_test_pri", 1.5, "important")
+        .await
+        .expect("PUT_PRIORITY failed");
+    let (priority, pri_value) = client
+        .get_priority("sys_test_pri")
+        .await
+        .expect("GET_PRIORITY failed");
+    assert!(
+        (priority - 1.5).abs() < f64::EPSILON,
+        "PRIORITY should be 1.5, got {}",
+        priority
+    );
+    assert_eq!(pri_value, "important", "PRIORITY value should be 'important'");
+
+    // DELETE
+    client
+        .put("sys_test_del", "to_delete")
+        .await
+        .expect("PUT failed");
+    let del_val = client
+        .get("sys_test_del")
+        .await
+        .expect("GET failed");
+    assert_eq!(del_val, "to_delete", "Value before delete should be 'to_delete'");
+    client
+        .delete("sys_test_del")
+        .await
+        .expect("DELETE failed");
 }

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -4,182 +4,188 @@ A comprehensive list of features implemented in the Anna KVS, derived from
 the research papers, documentation, and server source code. This list serves
 as the basis for black-box system testing.
 
+The "System Tested" column indicates whether the feature is tested against a
+**live server** (system tests or CLI smoke tests), not just unit tested with
+mocks.
+
 ## Client Operations
 
-| Feature                    | Description                                                  | Tested |
-|----------------------------|--------------------------------------------------------------|--------|
-| GET                        | Retrieve a value by key                                      | Yes    |
-| PUT                        | Store a value by key (lattice merge)                         | Yes    |
-| DELETE                     | Remove a key (PUT with empty value and dominating timestamp) | Yes    |
-| GET_SET                    | Retrieve a set-valued key                                    | Yes    |
-| PUT_SET                    | Add values to a set (union semantics)                        | Yes    |
-| GET_CAUSAL                 | Retrieve with causal metadata (vector clock, dependencies)   | Yes    |
-| PUT_CAUSAL                 | Store with causal metadata                                   | Yes    |
-| GET_ORDERED_SET            | Retrieve an ordered set-valued key                           | Yes    |
-| PUT_ORDERED_SET            | Add values to an ordered set                                 | Yes    |
-| GET_SINGLE_CAUSAL          | Retrieve with single-key causal metadata                     | Yes    |
-| PUT_SINGLE_CAUSAL          | Store with single-key causal metadata                        | Yes    |
-| GET_PRIORITY               | Retrieve a priority-valued key                               | Yes    |
-| PUT_PRIORITY               | Store a priority-value pair (lowest priority wins)           | Yes    |
-| Address cache invalidation | Server signals client to refresh address cache               | No     |
-| Multi-key GET              | Retrieve multiple keys in one request                        | No     |
+| Feature                    | Description                                                  | System Tested |
+|----------------------------|--------------------------------------------------------------|---------------|
+| GET                        | Retrieve a value by key                                      | Yes           |
+| PUT                        | Store a value by key (lattice merge)                         | Yes           |
+| DELETE                     | Remove a key (PUT with empty value and dominating timestamp) | Yes           |
+| GET_SET                    | Retrieve a set-valued key                                    | Yes           |
+| PUT_SET                    | Add values to a set (union semantics)                        | Yes           |
+| GET_CAUSAL                 | Retrieve with causal metadata (vector clock, dependencies)   | Yes           |
+| PUT_CAUSAL                 | Store with causal metadata                                   | Yes           |
+| GET_ORDERED_SET            | Retrieve an ordered set-valued key                           | Yes           |
+| PUT_ORDERED_SET            | Add values to an ordered set                                 | Yes           |
+| GET_SINGLE_CAUSAL          | Retrieve with single-key causal metadata                     | Yes           |
+| PUT_SINGLE_CAUSAL          | Store with single-key causal metadata                        | Yes           |
+| GET_PRIORITY               | Retrieve a priority-valued key                               | Yes           |
+| PUT_PRIORITY               | Store a priority-value pair (lowest priority wins)           | Yes           |
+| Address cache invalidation | Server signals client to refresh address cache               | No            |
+| Multi-key GET              | Retrieve multiple keys in one request                        | No            |
 
 ## Lattice Types
 
-| Lattice                | Description                                         | Tested |
-|------------------------|-----------------------------------------------------|--------|
-| LWW (Last-Writer-Wins) | Timestamp-based conflict resolution                 | Yes    |
-| SET                    | Unordered set with union merge                      | Yes    |
-| ORDERED_SET            | Ordered set with union merge                        | Yes    |
-| SINGLE_CAUSAL          | Single-key causal with vector clock                 | Yes    |
-| MULTI_CAUSAL           | Multi-key causal with vector clock and dependencies | Yes    |
-| PRIORITY               | Priority-value pair, lowest priority wins           | Yes    |
+| Lattice                | Description                                         | System Tested |
+|------------------------|-----------------------------------------------------|---------------|
+| LWW (Last-Writer-Wins) | Timestamp-based conflict resolution                 | Yes           |
+| SET                    | Unordered set with union merge                      | Yes           |
+| ORDERED_SET            | Ordered set with union merge                        | Yes           |
+| SINGLE_CAUSAL          | Single-key causal with vector clock                 | Yes           |
+| MULTI_CAUSAL           | Multi-key causal with vector clock and dependencies | Yes           |
+| PRIORITY               | Priority-value pair, lowest priority wins           | Yes           |
 
 ## Storage Tiers
 
-| Feature                       | Description                                | Tested                 |
-|-------------------------------|--------------------------------------------|------------------------|
-| Memory tier                   | In-memory storage using hash tables        | Yes (via system tests) |
-| Disk (EBS) tier               | File-based storage on mounted volumes      | No                     |
-| Tier selection via env var    | `SERVER_TYPE=memory` or `SERVER_TYPE=ebs`  | No                     |
-| Identical kernel across tiers | Same storage kernel, different serde layer | No                     |
+| Feature                       | Description                                | System Tested |
+|-------------------------------|--------------------------------------------|---------------|
+| Memory tier                   | In-memory storage using hash tables        | Yes           |
+| Disk (EBS) tier               | File-based storage on mounted volumes      | No            |
+| Tier selection via env var    | `SERVER_TYPE=memory` or `SERVER_TYPE=ebs`  | No            |
+| Identical kernel across tiers | Same storage kernel, different serde layer | No            |
 
 ## Replication
 
-| Feature                         | Description                                                  | Tested |
-|---------------------------------|--------------------------------------------------------------|--------|
-| Per-key replication factors     | Independent replication per key per tier                      | No     |
-| Default replication from config | `replication.memory`, `replication.ebs`, `replication.local`  | No     |
-| Replication factor request      | Server fetches unknown factors from metadata                  | No     |
-| Replication factor change       | Monitor can dynamically adjust replication                    | No     |
-| Metadata stored as KVS data     | Replication info under `METADATA\|replication\|<key>`         | No     |
-| Gossip after replication change | Data redistributed to new responsible threads                 | No     |
+| Feature                         | Description                                                  | System Tested |
+|---------------------------------|--------------------------------------------------------------|---------------|
+| Per-key replication factors     | Independent replication per key per tier                      | No            |
+| Default replication from config | `replication.memory`, `replication.ebs`, `replication.local`  | No            |
+| Replication factor request      | Server fetches unknown factors from metadata                  | No            |
+| Replication factor change       | Monitor can dynamically adjust replication                    | No            |
+| Metadata stored as KVS data     | Replication info under `METADATA\|replication\|<key>`         | No            |
+| Gossip after replication change | Data redistributed to new responsible threads                 | No            |
 
 ## Gossip / Multicast
 
-| Feature                     | Description                                      | Tested |
-|-----------------------------|--------------------------------------------------|--------|
-| Periodic gossip (10s epoch) | Changesets multicast to all responsible replicas  | No     |
-| Merge-at-sender             | Batched updates merged before sending             | No     |
-| Gossip to caches            | Changed keys also sent to function executor nodes | No     |
-| Join gossip                 | Redistribute data to newly joined nodes           | No     |
-| Cross-tier gossip           | Updates propagated between memory and disk tiers  | No     |
+| Feature                     | Description                                      | System Tested |
+|-----------------------------|--------------------------------------------------|---------------|
+| Periodic gossip (10s epoch) | Changesets multicast to all responsible replicas  | No            |
+| Merge-at-sender             | Batched updates merged before sending             | No            |
+| Gossip to caches            | Changed keys also sent to function executor nodes | No            |
+| Join gossip                 | Redistribute data to newly joined nodes           | No            |
+| Cross-tier gossip           | Updates propagated between memory and disk tiers  | No            |
 
 ## Cluster Management
 
-| Feature          | Description                                          | Tested |
-|------------------|------------------------------------------------------|--------|
-| Node join        | New node joins cluster, receives data via gossip     | No     |
-| Node depart      | Node leaves, data redistributed                      | No     |
-| Self-depart      | Node gracefully removes itself, gossips all data out | No     |
-| Rejoin detection | Join counter distinguishes fresh joins from rejoins  | No     |
-| Seed node        | First routing node serves cluster membership         | No     |
+| Feature          | Description                                          | System Tested |
+|------------------|------------------------------------------------------|---------------|
+| Node join        | New node joins cluster, receives data via gossip     | No            |
+| Node depart      | Node leaves, data redistributed                      | No            |
+| Self-depart      | Node gracefully removes itself, gossips all data out | No            |
+| Rejoin detection | Join counter distinguishes fresh joins from rejoins  | No            |
+| Seed node        | First routing node serves cluster membership         | No            |
 
 ## Routing Tier
 
-| Feature                   | Description                                              | Tested         |
-|---------------------------|----------------------------------------------------------|----------------|
-| Key address lookup        | Client queries routing for server addresses              | Yes (implicit) |
-| Hash ring caching         | Routing caches storage tier hash rings                   | Yes (implicit) |
-| Memory-tier preference    | Returns memory addresses when available                  | No             |
-| Replication-aware routing | Uses replication vectors to find all responsible threads | No             |
-| Pending request queue     | Queues requests while replication factor is unknown      | No             |
-| Multi-threaded routing    | Configurable number of routing threads                   | No             |
+| Feature                   | Description                                              | System Tested |
+|---------------------------|----------------------------------------------------------|---------------|
+| Key address lookup        | Client queries routing for server addresses              | Yes           |
+| Hash ring caching         | Routing caches storage tier hash rings                   | Yes           |
+| Memory-tier preference    | Returns memory addresses when available                  | No            |
+| Replication-aware routing | Uses replication vectors to find all responsible threads | No            |
+| Pending request queue     | Queues requests while replication factor is unknown      | No            |
+| Multi-threaded routing    | Configurable number of routing threads                   | No            |
 
 ## Monitoring and Policy Engine
 
-| Feature                     | Description                                                   | Tested |
-|-----------------------------|---------------------------------------------------------------|--------|
-| Statistics collection       | Per-key access frequency, per-node storage, CPU occupancy     | No     |
-| Elasticity policy           | Add/remove nodes based on storage/compute capacity            | No     |
-| Hot-key replication         | Selectively replicate hot keys across more threads/nodes      | No     |
-| Cross-tier data movement    | Promote hot data to memory, demote cold to disk               | No     |
-| SLO enforcement             | Latency-based scaling (target: 3ms)                           | No     |
-| Underutilization scale-down | Remove nodes when occupancy is low                            | No     |
-| Grace period                | Prevent over-correction during data redistribution            | No     |
-| Policy toggles              | `policy.elasticity`, `policy.selective-rep`, `policy.tiering` | No     |
+| Feature                     | Description                                                   | System Tested |
+|-----------------------------|---------------------------------------------------------------|---------------|
+| Statistics collection       | Per-key access frequency, per-node storage, CPU occupancy     | No            |
+| Elasticity policy           | Add/remove nodes based on storage/compute capacity            | No            |
+| Hot-key replication         | Selectively replicate hot keys across more threads/nodes      | No            |
+| Cross-tier data movement    | Promote hot data to memory, demote cold to disk               | No            |
+| SLO enforcement             | Latency-based scaling (target: 3ms)                           | No            |
+| Underutilization scale-down | Remove nodes when occupancy is low                            | No            |
+| Grace period                | Prevent over-correction during data redistribution            | No            |
+| Policy toggles              | `policy.elasticity`, `policy.selective-rep`, `policy.tiering` | No            |
 
 ## Consistent Hashing
 
-| Feature                         | Description                                  | Tested |
-|---------------------------------|----------------------------------------------|--------|
-| Two-level hash ring             | Global (nodes) + Local (threads within node) | No     |
-| Virtual nodes (3000 per thread) | Even distribution across physical threads    | No     |
-| CRC32 hashing                   | Hash function for key-to-ring mapping        | No     |
-| Thread responsibility lookup    | Determines which threads handle a key        | No     |
+| Feature                         | Description                                  | System Tested |
+|---------------------------------|----------------------------------------------|---------------|
+| Two-level hash ring             | Global (nodes) + Local (threads within node) | No            |
+| Virtual nodes (3000 per thread) | Even distribution across physical threads    | No            |
+| CRC32 hashing                   | Hash function for key-to-ring mapping        | No            |
+| Thread responsibility lookup    | Determines which threads handle a key        | No            |
 
 ## Fault Tolerance
 
-| Feature                                 | Description                                     | Tested |
-|-----------------------------------------|-------------------------------------------------|--------|
-| k-fault tolerance                       | k+1 replicas ensure k failures tolerable        | No     |
-| Failure detection via timeout           | Nodes detect peer failures and update hash ring  | No     |
-| Automatic repartitioning                | Data redistributed after node failure            | No     |
-| Stateless routing/monitoring            | Recovers by querying peers/storage               | No     |
-| Key migration interleaved with requests | No downtime during reconfiguration               | No     |
+| Feature                                 | Description                                     | System Tested |
+|-----------------------------------------|-------------------------------------------------|---------------|
+| k-fault tolerance                       | k+1 replicas ensure k failures tolerable        | No            |
+| Failure detection via timeout           | Nodes detect peer failures and update hash ring  | No            |
+| Automatic repartitioning                | Data redistributed after node failure            | No            |
+| Stateless routing/monitoring            | Recovers by querying peers/storage               | No            |
+| Key migration interleaved with requests | No downtime during reconfiguration               | No            |
 
 ## Periodic Self-Reporting (every 15s)
 
-| Feature                              | Description                                  | Tested |
-|--------------------------------------|----------------------------------------------|--------|
-| Storage consumption reporting        | Per-thread storage size in KB                | No     |
-| CPU occupancy reporting              | Ratio of working time to wall-clock time     | No     |
-| Access count reporting               | Total accesses per epoch                     | No     |
-| Per-key access frequency             | Tracked over 60-second window                | No     |
-| Per-key size for primary replicas    | Size of data for keys this thread owns       | No     |
-| Per-event-type occupancy logging     | Performance profiling of event handlers      | No     |
+| Feature                              | Description                                  | System Tested |
+|--------------------------------------|----------------------------------------------|---------------|
+| Storage consumption reporting        | Per-thread storage size in KB                | No            |
+| CPU occupancy reporting              | Ratio of working time to wall-clock time     | No            |
+| Access count reporting               | Total accesses per epoch                     | No            |
+| Per-key access frequency             | Tracked over 60-second window                | No            |
+| Per-key size for primary replicas    | Size of data for keys this thread owns       | No            |
+| Per-event-type occupancy logging     | Performance profiling of event handlers      | No            |
 
 ## Configuration
 
-| Feature                      | Description                                                   | Tested  |
-|------------------------------|---------------------------------------------------------------|---------|
-| YAML config file             | All settings in a single YAML file                            | Yes     |
-| Thread counts                | `threads.memory`, `threads.ebs`, `threads.routing`            | Partial |
-| Node capacities              | `capacities.memory-cap`, `capacities.ebs-cap`                 | No      |
-| Server identity              | `server.public_ip`, `server.private_ip`                       | No      |
-| Cluster topology             | `server.seed_ip`, `server.mgmt_ip`, monitoring/routing IPs    | Partial |
-| Management node integration  | Kubernetes support for node provisioning                      | No      |
-| Standalone mode              | `mgmt_ip: "NULL"` for local/non-k8s deployment               | Yes     |
+| Feature                      | Description                                                   | System Tested |
+|------------------------------|---------------------------------------------------------------|---------------|
+| YAML config file             | All settings in a single YAML file                            | Yes           |
+| Thread counts                | `threads.memory`, `threads.ebs`, `threads.routing`            | Partial       |
+| Node capacities              | `capacities.memory-cap`, `capacities.ebs-cap`                 | No            |
+| Server identity              | `server.public_ip`, `server.private_ip`                       | No            |
+| Cluster topology             | `server.seed_ip`, `server.mgmt_ip`, monitoring/routing IPs    | Partial       |
+| Management node integration  | Kubernetes support for node provisioning                      | No            |
+| Standalone mode              | `mgmt_ip: "NULL"` for local/non-k8s deployment               | Yes           |
 
 ## Communication
 
-| Feature          | Description                                  | Tested         |
-|------------------|----------------------------------------------|----------------|
-| ZeroMQ PUSH/PULL | Async messaging between all components       | Yes            |
-| Protocol Buffers | Structured message serialization             | Yes            |
-| Socket cache     | Lazy-created, cached ZMQ push sockets        | Yes (implicit) |
-| Graceful shutdown | SIGTERM handler for clean exit               | Yes            |
+| Feature           | Description                                  | System Tested |
+|-------------------|----------------------------------------------|---------------|
+| ZeroMQ PUSH/PULL  | Async messaging between all components       | Yes           |
+| Protocol Buffers  | Structured message serialization             | Yes           |
+| Socket cache      | Lazy-created, cached ZMQ push sockets        | Yes           |
+| Graceful shutdown | SIGTERM handler for clean exit                | Yes           |
 
 ## Error Handling
 
-| Error Code   | Description                                      | Tested |
-|--------------|--------------------------------------------------|--------|
-| NO_ERROR     | Operation succeeded                              | Yes    |
-| KEY_DNE      | Key does not exist                                | No     |
-| WRONG_THREAD | This thread is not responsible for the key        | No     |
-| TIMEOUT      | Operation timed out                               | No     |
-| LATTICE      | Lattice type mismatch                             | No     |
-| NO_SERVERS   | No servers available (routing tier)               | No     |
+| Error Code   | Description                                      | System Tested |
+|--------------|--------------------------------------------------|---------------|
+| NO_ERROR     | Operation succeeded                              | Yes           |
+| KEY_DNE      | Key does not exist                                | No            |
+| WRONG_THREAD | This thread is not responsible for the key        | No            |
+| TIMEOUT      | Operation timed out                               | No            |
+| LATTICE      | Lattice type mismatch                             | No            |
+| NO_SERVERS   | No servers available (routing tier)               | No            |
 
 ## Summary
 
-| Category                 | Total Features | Tested | Coverage |
-|--------------------------|----------------|--------|----------|
-| Client Operations        | 15             | 13     | 87%      |
-| Lattice Types            | 6              | 6      | 100%     |
-| Storage Tiers            | 4              | 1      | 25%      |
-| Replication              | 6              | 0      | 0%       |
-| Gossip / Multicast       | 5              | 0      | 0%       |
-| Cluster Management       | 5              | 0      | 0%       |
-| Routing Tier             | 6              | 2      | 33%      |
-| Monitoring / Policy      | 8              | 0      | 0%       |
-| Consistent Hashing       | 4              | 0      | 0%       |
-| Fault Tolerance          | 5              | 0      | 0%       |
-| Periodic Self-Reporting  | 6              | 0      | 0%       |
-| Configuration            | 7              | 4      | 57%      |
-| Communication            | 4              | 4      | 100%     |
-| Error Handling           | 6              | 1      | 17%      |
-| **Total**                | **87**         | **31** | **36%**  |
+| Category                 | Total Features | System Tested | Coverage |
+|--------------------------|----------------|---------------|----------|
+| Client Operations        | 15             | 13            | 87%      |
+| Lattice Types            | 6              | 6             | 100%     |
+| Storage Tiers            | 4              | 1             | 25%      |
+| Replication              | 6              | 0             | 0%       |
+| Gossip / Multicast       | 5              | 0             | 0%       |
+| Cluster Management       | 5              | 0             | 0%       |
+| Routing Tier             | 6              | 2             | 33%      |
+| Monitoring / Policy      | 8              | 0             | 0%       |
+| Consistent Hashing       | 4              | 0             | 0%       |
+| Fault Tolerance          | 5              | 0             | 0%       |
+| Periodic Self-Reporting  | 6              | 0             | 0%       |
+| Configuration            | 7              | 4             | 57%      |
+| Communication            | 4              | 4             | 100%     |
+| Error Handling           | 6              | 1             | 17%      |
+| **Total**                | **87**         | **31**        | **36%**  |
 
-The next step (#336) is to prioritize untested features and add system tests
-to improve both feature and code coverage of the server.
+Features not system-tested are either internal implementation details (consistent
+hashing, self-reporting), require multi-node setups (replication, gossip, cluster
+management, fault tolerance), or require specific workload patterns (monitoring
+policies).


### PR DESCRIPTION
## Summary

All 4 clients' system tests now exercise all 6 lattice types + DELETE against a live server:

| Test | LWW | SET | ORDERED_SET | SINGLE_CAUSAL | MULTI_CAUSAL | PRIORITY | DELETE |
|------|-----|-----|-------------|---------------|--------------|----------|--------|
| C++ | Yes | Yes | **New** | **New** | **New** | **New** | **New** |
| Rust | Yes | Yes | **New** | **New** | **New** | **New** | **New** |
| Python | Yes | Yes | **New** | **New** | **New** | **New** | **New** |
| Go | Yes | Yes | **New** | **New** | **New** | **New** | **New** |

These tests hit the server's serializers, request handler branches, and lattice merge paths for all types — the primary goal is increasing **server** code coverage beyond the current 52%.

Closes #336

## Test plan
- [ ] CI passes on all platforms
- [ ] Server coverage increases in codecov (new lattice type code paths exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)