### PR TITLE
Fix docs link checker errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Anna has four client implementations, each with a library and CLI:
 | Go | `annalib` | `anna-go` | Go |
 
 All clients support the same operations (GET, PUT, GET_SET, PUT_SET, GET_CAUSAL, PUT_CAUSAL)
-and are tested against [shared golden files](tests/shared/cli/).
+and are tested against shared golden files (`tests/shared/cli/`).
 
 ## Building
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -19,4 +19,3 @@ library and CLI. All clients support the same operations (GET, PUT, GET_SET,
 PUT_SET, GET_CAUSAL, PUT_CAUSAL) and are tested against the same shared
 golden files.
 
-- [Rust client](clients/rust/README.md)


### PR DESCRIPTION
## Summary
Fix lychee link checker errors in the docs deploy workflow:

1. `tests/shared/cli/` — directory link in README changed to inline code (not a navigable page)
2. `clients/rust/README.md` — removed from SUMMARY.md (standalone file, not a book chapter; mdbook can't resolve it in the generated HTML)

Verified locally: `make docs` passes with 0 lychee errors.

## Also
Please enable "Do not allow bypassing the above settings" on master branch protection (Settings → Branches → master) to prevent direct pushes by admins.

## Test plan
- [x] `make docs` passes with 0 lychee errors locally
- [ ] CI passes
- [ ] Docs workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)