### PR TITLE
Add fault tolerance test and client timeout retry (#364)

### DIFF
--- a/clients/rust/src/lib/config.rs
+++ b/clients/rust/src/lib/config.rs
@@ -304,4 +304,72 @@ mod test {
         assert_eq!(config.get_user_ip(), "127.0.0.1");
         assert!(!config.get_routing_ips().is_empty());
     }
+
+    #[test]
+    fn default_timings() {
+        let config = Config::default();
+        assert_eq!(config.get_gossip_epoch(), 10);
+        assert_eq!(config.get_monitoring_timeout(), 30);
+        assert_eq!(config.get_base_offset(), 0);
+    }
+
+    #[test]
+    fn timings_from_config_file() {
+        let config = Config::read(&PathBuf::from("src/lib/test_config.yml"))
+            .expect("Could not read test_config.yml");
+        assert_eq!(config.get_gossip_epoch(), 10);
+        assert_eq!(config.get_monitoring_timeout(), 30);
+    }
+
+    #[test]
+    fn timings_partial_override() {
+        let yaml = "\
+monitoring:
+  mgmt_ip: 127.0.0.1
+  ip: 127.0.0.1
+routing:
+  monitoring:
+      - 127.0.0.1
+  ip: 127.0.0.1
+user:
+  monitoring:
+      - 127.0.0.1
+  routing:
+      - 127.0.0.1
+  ip: 127.0.0.1
+server:
+  monitoring:
+      - 127.0.0.1
+  routing:
+      - 127.0.0.1
+  seed_ip: 127.0.0.1
+  public_ip: 127.0.0.1
+  private_ip: 127.0.0.1
+  mgmt_ip: \"NULL\"
+policy:
+  elasticity: false
+  selective-rep: false
+  tiering: false
+ebs: ./
+capacities:
+  memory-cap: 1
+  ebs-cap: 0
+threads:
+  memory: 1
+  ebs: 1
+  routing: 1
+  benchmark: 1
+timings:
+  gossip_epoch: 2
+replication:
+  memory: 1
+  ebs: 0
+  minimum: 1
+  local: 1
+";
+        let config: Config =
+            serde_yaml::from_str(yaml).expect("Failed to parse partial timings config");
+        assert_eq!(config.get_gossip_epoch(), 2);
+        assert_eq!(config.get_monitoring_timeout(), 30);
+    }
 }

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -1054,6 +1054,72 @@ mod tests {
         assert!(!client.key_address_cache.contains_key("evict_me"));
     }
 
+    #[tokio::test]
+    async fn evict_address_removes_single_address() {
+        let config = Config::read(
+            &std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("default-config.yml"),
+        )
+        .expect("failed to read default config");
+        let mut client = KVSClient::new(&config, Some(88)).await;
+        let mut addrs = HashSet::new();
+        addrs.insert("tcp://10.0.0.1:6200".to_string());
+        addrs.insert("tcp://10.0.0.2:6200".to_string());
+        client.key_address_cache.insert("multi_addr".into(), addrs);
+
+        client.evict_address("multi_addr", "tcp://10.0.0.1:6200");
+        let remaining = &client.key_address_cache["multi_addr"];
+        assert_eq!(remaining.len(), 1);
+        assert!(remaining.contains("tcp://10.0.0.2:6200"));
+    }
+
+    #[tokio::test]
+    async fn evict_address_removes_key_when_last_address() {
+        let config = Config::read(
+            &std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("default-config.yml"),
+        )
+        .expect("failed to read default config");
+        let mut client = KVSClient::new(&config, Some(87)).await;
+        client.key_address_cache.insert(
+            "single_addr".into(),
+            ["tcp://10.0.0.1:6200".to_string()].into(),
+        );
+
+        client.evict_address("single_addr", "tcp://10.0.0.1:6200");
+        assert!(!client.key_address_cache.contains_key("single_addr"));
+    }
+
+    #[tokio::test]
+    async fn evict_address_also_removes_socket() {
+        let config = Config::read(
+            &std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("default-config.yml"),
+        )
+        .expect("failed to read default config");
+        let mut client = KVSClient::new(&config, Some(86)).await;
+        client.key_address_cache.insert(
+            "sock_test".into(),
+            ["tcp://10.0.0.1:6200".to_string()].into(),
+        );
+        let sock = PushSocket::new();
+        client
+            .socket_cache
+            .insert("tcp://10.0.0.1:6200".to_string(), sock);
+
+        client.evict_address("sock_test", "tcp://10.0.0.1:6200");
+        assert!(!client.socket_cache.contains_key("tcp://10.0.0.1:6200"));
+    }
+
+    #[tokio::test]
+    async fn set_timeout_changes_duration() {
+        let config = Config::read(
+            &std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("default-config.yml"),
+        )
+        .expect("failed to read default config");
+        let mut client = KVSClient::new(&config, Some(85)).await;
+        assert_eq!(client.timeout, Duration::from_secs(10));
+        client.set_timeout(Duration::from_secs(3));
+        assert_eq!(client.timeout, Duration::from_secs(3));
+    }
+
     #[test]
     fn empty_set_value_roundtrip() {
         let original = SetValue { values: vec![] };

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -254,7 +254,7 @@ impl KVSClient {
         lattice_type: Option<i32>,
         payload: Option<Vec<u8>>,
     ) -> Option<KeyResponse> {
-        const MAX_RETRIES: usize = 3;
+        const MAX_RETRIES: usize = 5;
 
         for attempt in 0..=MAX_RETRIES {
             let worker = self.get_worker_address(key).await?;

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -237,6 +237,15 @@ impl KVSClient {
         }
     }
 
+    fn evict_address_from_cache(&mut self, key: &str, addr: &str) {
+        if let Some(addrs) = self.key_address_cache.get_mut(key) {
+            addrs.remove(addr);
+            if addrs.is_empty() {
+                self.key_address_cache.remove(key);
+            }
+        }
+    }
+
     async fn send_data_request(
         &mut self,
         key: &str,
@@ -282,11 +291,8 @@ impl KVSClient {
                         if !response.tuples.is_empty() {
                             let t = &response.tuples[0];
                             if t.error == AnnaError::WrongThread as i32 && attempt < MAX_RETRIES {
-                                debug!(
-                                    "WRONG_THREAD for key {}, invalidating cache and retrying",
-                                    key
-                                );
-                                self.key_address_cache.remove(key);
+                                debug!("WRONG_THREAD for key {} at {}, retrying", key, worker);
+                                self.evict_address_from_cache(key, &worker);
                                 continue;
                             }
                             if t.invalidate {
@@ -301,8 +307,14 @@ impl KVSClient {
                     }
                 },
                 None => {
-                    warn!("Request timed out for key {}", key);
-                    self.key_address_cache.remove(key);
+                    warn!(
+                        "Request timed out for key {} at {}, attempt {}",
+                        key, worker, attempt
+                    );
+                    self.evict_address_from_cache(key, &worker);
+                    if attempt < MAX_RETRIES {
+                        continue;
+                    }
                     return None;
                 }
             }
@@ -875,6 +887,11 @@ impl KVSClient {
     /// Clear the key-address cache.
     pub fn clear_cache(&mut self) {
         self.key_address_cache.clear()
+    }
+
+    /// Set the request timeout duration.
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
     }
 }
 

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -282,12 +282,18 @@ impl KVSClient {
             request.tuples.push(tuple);
 
             let encoded = request.encode_to_vec();
-            if self.send_request(&encoded, &worker).await.is_err() {
-                return None;
-            }
 
-            match self.recv_response(false).await {
-                Some(data) => match KeyResponse::decode(data.as_slice()) {
+            let result = tokio::time::timeout(self.timeout, async {
+                self.send_request(&encoded, &worker).await?;
+                match self.recv_response(false).await {
+                    Some(data) => Ok(data),
+                    None => Err(Error::Kvs("recv timed out".into())),
+                }
+            })
+            .await;
+
+            match result {
+                Ok(Ok(data)) => match KeyResponse::decode(data.as_slice()) {
                     Ok(response) => {
                         if !response.tuples.is_empty() {
                             let t = &response.tuples[0];
@@ -307,7 +313,7 @@ impl KVSClient {
                         return None;
                     }
                 },
-                None => {
+                _ => {
                     warn!(
                         "Request timed out for key {} at {}, attempt {}",
                         key, worker, attempt

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -237,13 +237,14 @@ impl KVSClient {
         }
     }
 
-    fn evict_address_from_cache(&mut self, key: &str, addr: &str) {
+    fn evict_address(&mut self, key: &str, addr: &str) {
         if let Some(addrs) = self.key_address_cache.get_mut(key) {
             addrs.remove(addr);
             if addrs.is_empty() {
                 self.key_address_cache.remove(key);
             }
         }
+        self.socket_cache.remove(addr);
     }
 
     async fn send_data_request(
@@ -292,7 +293,7 @@ impl KVSClient {
                             let t = &response.tuples[0];
                             if t.error == AnnaError::WrongThread as i32 && attempt < MAX_RETRIES {
                                 debug!("WRONG_THREAD for key {} at {}, retrying", key, worker);
-                                self.evict_address_from_cache(key, &worker);
+                                self.evict_address(key, &worker);
                                 continue;
                             }
                             if t.invalidate {
@@ -311,7 +312,7 @@ impl KVSClient {
                         "Request timed out for key {} at {}, attempt {}",
                         key, worker, attempt
                     );
-                    self.evict_address_from_cache(key, &worker);
+                    self.evict_address(key, &worker);
                     if attempt < MAX_RETRIES {
                         continue;
                     }

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -425,7 +425,7 @@ async fn multi_node_fault_tolerance() {
     let config =
         Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
     let mut client = KVSClient::new(&config, Some(53)).await;
-    client.set_timeout(Duration::from_secs(3));
+    client.set_timeout(Duration::from_secs(5));
 
     // PUT data and wait for gossip to replicate to both nodes
     client
@@ -439,13 +439,11 @@ async fn multi_node_fault_tolerance() {
     std::thread::sleep(Duration::from_secs(TEST_GOSSIP_EPOCH as u64 + 2));
 
     // Kill Node 1's KVS — data should survive on Node 2.
-    // The client handles the dead node by evicting its address from cache
-    // on timeout and retrying via the remaining node.
+    // Don't clear cache: the client has both addresses cached. When Node 1
+    // times out, evict_address_from_cache removes only that address, and the
+    // retry uses Node 2's cached address directly (without re-querying
+    // routing, which would re-add the dead address).
     cluster.kill_process("anna-kvs@127.0.0.1");
-
-    // Clear client cache so it re-queries routing (which should no longer
-    // include the dead node)
-    client.clear_cache();
 
     let v1 = client
         .get("ft_key_1")

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -425,7 +425,7 @@ async fn multi_node_fault_tolerance() {
     let config =
         Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
     let mut client = KVSClient::new(&config, Some(53)).await;
-    client.set_timeout(Duration::from_secs(5));
+    client.set_timeout(Duration::from_secs(2));
 
     // PUT data and wait for gossip to replicate to both nodes
     client

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -425,7 +425,6 @@ async fn multi_node_fault_tolerance() {
     let config =
         Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
     let mut client = KVSClient::new(&config, Some(53)).await;
-    client.set_timeout(Duration::from_secs(2));
 
     // PUT data and wait for gossip to replicate to both nodes
     client
@@ -438,20 +437,23 @@ async fn multi_node_fault_tolerance() {
         .expect("PUT ft_key_2 failed");
     std::thread::sleep(Duration::from_secs(TEST_GOSSIP_EPOCH as u64 + 2));
 
-    // Kill Node 1's KVS — data should survive on Node 2.
-    // Don't clear cache: the client has both addresses cached. When Node 1
-    // times out, evict_address_from_cache removes only that address, and the
-    // retry uses Node 2's cached address directly (without re-querying
-    // routing, which would re-add the dead address).
+    // Kill Node 1's KVS process
     cluster.kill_process("anna-kvs@127.0.0.1");
 
-    let v1 = client
+    // Anna has no automatic crash detection — routing still returns both
+    // addresses. Verify fault tolerance by reading each key individually
+    // with a fresh client and short timeout. The client's retry logic
+    // evicts the dead address on timeout and retries via the live node.
+    let mut reader = KVSClient::new(&config, Some(54)).await;
+    reader.set_timeout(Duration::from_secs(2));
+
+    let v1 = reader
         .get("ft_key_1")
         .await
         .expect("GET ft_key_1 failed after node failure");
     assert_eq!(v1, "survive_1");
 
-    let v2 = client
+    let v2 = reader
         .get("ft_key_2")
         .await
         .expect("GET ft_key_2 failed after node failure");

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -125,8 +125,13 @@ fn wait_for_port(ip: &str, port: u16, timeout_secs: u64) -> bool {
     false
 }
 
+struct ServerProcess {
+    child: Child,
+    label: String,
+}
+
 struct MultiNodeCluster {
-    children: Vec<Child>,
+    processes: Vec<ServerProcess>,
     config_dir: PathBuf,
     base_offset: u32,
 }
@@ -140,7 +145,7 @@ impl MultiNodeCluster {
         ));
         fs::create_dir_all(&config_dir).expect("Failed to create config dir");
         MultiNodeCluster {
-            children: Vec::new(),
+            processes: Vec::new(),
             config_dir,
             base_offset,
         }
@@ -163,7 +168,10 @@ impl MultiNodeCluster {
 
         for name in ["anna-monitor", "anna-route", "anna-kvs"] {
             if let Some(child) = spawn_server(name, &config, &server_path()) {
-                self.children.push(child);
+                self.processes.push(ServerProcess {
+                    child,
+                    label: format!("{}@{}", name, node_ip),
+                });
             } else {
                 self.shutdown();
                 panic!("Server binary {} not found", name);
@@ -191,7 +199,10 @@ impl MultiNodeCluster {
         );
 
         if let Some(child) = spawn_server("anna-kvs", &config, &server_path()) {
-            self.children.push(child);
+            self.processes.push(ServerProcess {
+                child,
+                label: format!("anna-kvs@{}", node_ip),
+            });
         } else {
             self.shutdown();
             panic!("Server binary anna-kvs not found");
@@ -199,16 +210,26 @@ impl MultiNodeCluster {
         std::thread::sleep(Duration::from_secs(3));
     }
 
+    fn kill_process(&mut self, label_substring: &str) {
+        for proc in &mut self.processes {
+            if proc.label.contains(label_substring) {
+                proc.child.kill().ok();
+                proc.child.wait().ok();
+            }
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+
     fn client_config_path(&self, node_ip: &str) -> PathBuf {
         self.config_dir.join(format!("node-{}.yml", node_ip))
     }
 
     fn shutdown(&mut self) {
-        for child in &mut self.children {
-            child.kill().ok();
-            child.wait().ok();
+        for proc in &mut self.processes {
+            proc.child.kill().ok();
+            proc.child.wait().ok();
         }
-        self.children.clear();
+        self.processes.clear();
     }
 }
 
@@ -380,4 +401,61 @@ async fn multi_node_address_cache_invalidation() {
         .await
         .expect("GET post_join_key failed");
     assert_eq!(v, "fresh");
+}
+
+/// Fault tolerance: with replication=2, kill one KVS node and verify data
+/// survives on the remaining node after the monitoring system detects the
+/// failure and updates the routing tier's hash ring.
+/// Uses base_offset=6000 to avoid conflicts with other tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn multi_node_fault_tolerance() {
+    use annalib::config::Config;
+    use annalib::kvs_client::KVSClient;
+
+    if skip_unless_multi_ip() {
+        return;
+    }
+
+    let mut cluster = MultiNodeCluster::new(6000);
+
+    cluster.start_full_node(NODE1_IP, 2);
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
+
+    let config =
+        Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
+    let mut client = KVSClient::new(&config, Some(53)).await;
+    client.set_timeout(Duration::from_secs(3));
+
+    // PUT data and wait for gossip to replicate to both nodes
+    client
+        .put("ft_key_1", "survive_1")
+        .await
+        .expect("PUT ft_key_1 failed");
+    client
+        .put("ft_key_2", "survive_2")
+        .await
+        .expect("PUT ft_key_2 failed");
+    std::thread::sleep(Duration::from_secs(TEST_GOSSIP_EPOCH as u64 + 2));
+
+    // Kill Node 1's KVS — data should survive on Node 2.
+    // The client handles the dead node by evicting its address from cache
+    // on timeout and retrying via the remaining node.
+    cluster.kill_process("anna-kvs@127.0.0.1");
+
+    // Clear client cache so it re-queries routing (which should no longer
+    // include the dead node)
+    client.clear_cache();
+
+    let v1 = client
+        .get("ft_key_1")
+        .await
+        .expect("GET ft_key_1 failed after node failure");
+    assert_eq!(v1, "survive_1");
+
+    let v2 = client
+        .get("ft_key_2")
+        .await
+        .expect("GET ft_key_2 failed after node failure");
+    assert_eq!(v2, "survive_2");
 }

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -113,7 +113,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 
 | Feature                                 | Description                                     | System Tested |
 |-----------------------------------------|-------------------------------------------------|---------------|
-| k-fault tolerance                       | k+1 replicas ensure k failures tolerable        | No            |
+| k-fault tolerance                       | k+1 replicas ensure k failures tolerable        | [#364](https://github.com/andrewdavidmackenzie/anna/issues/364) |
 | Failure detection via timeout           | Nodes detect peer failures and update hash ring  | No            |
 | Automatic repartitioning                | Data redistributed after node failure            | No            |
 | Stateless routing/monitoring            | Recovers by querying peers/storage               | No            |
@@ -172,7 +172,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Single-Node Features         | 9     | 9             | 100%     | —      |
 | Error Handling               | 6     | 1             | 17%      | #355   |
 | Multi-Tiered Storage         | 4     | 0             | 0%       | #356   |
-| Multi-Node Features          | 27    | 9             | 33%      | #352   |
+| Multi-Node Features          | 27    | 10            | 37%      | #352   |
 | Monitoring & Policy Engine   | 8     | 0             | 0%       | #357   |
 | Server Internals             | 6     | 0             | 0%       | #358   |
-| **Total**                    | **81**| **40**        | **49%**  |        |
+| **Total**                    | **81**| **41**        | **51%**  |        |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -170,9 +170,9 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Client Operations            | 15    | 15            | 100%     | —      |
 | Lattice Types                | 6     | 6             | 100%     | —      |
 | Single-Node Features         | 9     | 9             | 100%     | —      |
-| Error Handling               | 5     | 1             | 20%      | #355   |
+| Error Handling               | 6     | 1             | 17%      | #355   |
 | Multi-Tiered Storage         | 4     | 0             | 0%       | #356   |
 | Multi-Node Features          | 31    | 11            | 35%      | #352   |
 | Monitoring & Policy Engine   | 8     | 0             | 0%       | #357   |
 | Server Internals             | 5     | 0             | 0%       | #358   |
-| **Total**                    | **83**| **42**        | **51%**  |        |
+| **Total**                    | **84**| **42**        | **50%**  |        |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -170,9 +170,9 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Client Operations            | 15    | 15            | 100%     | —      |
 | Lattice Types                | 6     | 6             | 100%     | —      |
 | Single-Node Features         | 9     | 9             | 100%     | —      |
-| Error Handling               | 6     | 1             | 17%      | #355   |
+| Error Handling               | 5     | 1             | 20%      | #355   |
 | Multi-Tiered Storage         | 4     | 0             | 0%       | #356   |
-| Multi-Node Features          | 27    | 10            | 37%      | #352   |
+| Multi-Node Features          | 31    | 11            | 35%      | #352   |
 | Monitoring & Policy Engine   | 8     | 0             | 0%       | #357   |
-| Server Internals             | 6     | 0             | 0%       | #358   |
-| **Total**                    | **81**| **41**        | **51%**  |        |
+| Server Internals             | 5     | 0             | 0%       | #358   |
+| **Total**                    | **83**| **42**        | **51%**  |        |


### PR DESCRIPTION
## Summary

- Add timeout retry to `KVSClient::send_data_request` — when a request times out (dead node), evict that specific address from cache and retry via remaining nodes. Matches the existing WRONG_THREAD retry pattern.
- Add `evict_address_from_cache()` for surgical eviction (removes one address, not the whole key's cache)
- Add `set_timeout()` for configurable client timeout
- Add `multi_node_fault_tolerance` system test: starts 2-node cluster with replication=2, PUTs data, waits for gossip, kills Node 1's KVS, verifies data survives via Node 2 through client retry

### Key finding
The Anna monitoring system does NOT implement automatic crash detection — `remove_node` is only called by policy-driven scaling. The client-side timeout retry handles fault tolerance instead: evict dead address, re-resolve from routing, retry via surviving node.

## Test plan

- [x] `make clippy` — 0 warnings
- [x] `make fmt` — clean
- [x] `make test` — all 73 tests pass (4 multi-node)
- [x] Fault tolerance test passes: kill Node 1, GET succeeds via Node 2
- [x] All multi-node tests run in parallel (15s total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)