### PR TITLE
Add virtual nodes distribution test (#373)

### DIFF
--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -891,6 +891,12 @@ impl KVSClient {
         Ok(results)
     }
 
+    /// Query routing for a key and return all responsible server addresses.
+    pub async fn get_key_addresses(&mut self, key: &str) -> Vec<Address> {
+        self.key_address_cache.remove(key);
+        self.query_routing(key).await
+    }
+
     /// Clear the key-address cache.
     pub fn clear_cache(&mut self) {
         self.key_address_cache.clear()
@@ -1124,6 +1130,26 @@ mod tests {
         assert_eq!(client.timeout, Duration::from_secs(10));
         client.set_timeout(Duration::from_secs(3));
         assert_eq!(client.timeout, Duration::from_secs(3));
+    }
+
+    #[tokio::test]
+    async fn get_key_addresses_clears_cache_first() {
+        let config = Config::read(
+            &std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("default-config.yml"),
+        )
+        .expect("failed to read default config");
+        let mut client = KVSClient::new(&config, Some(84)).await;
+        client.key_address_cache.insert(
+            "stale_key".into(),
+            ["tcp://10.0.0.1:6200".to_string()].into(),
+        );
+        let addrs = client.get_key_addresses("stale_key").await;
+        assert!(
+            addrs.is_empty(),
+            "Expected empty (no routing server), got {:?}",
+            addrs
+        );
+        assert!(!client.key_address_cache.contains_key("stale_key"));
     }
 
     #[test]

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -521,3 +521,67 @@ async fn no_servers_error() {
         err_msg
     );
 }
+
+/// Virtual nodes: verify consistent hashing distributes keys across 2 nodes.
+/// Uses base_offset=10000 to avoid conflicts with other tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn virtual_nodes_key_distribution() {
+    use annalib::config::Config;
+    use annalib::kvs_client::KVSClient;
+    use std::collections::HashMap;
+
+    if skip_unless_multi_ip() {
+        return;
+    }
+
+    let mut cluster = MultiNodeCluster::new(10000);
+    cluster.start_full_node(NODE1_IP, 1);
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
+
+    let config =
+        Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
+    let mut client = KVSClient::new(&config, Some(56)).await;
+
+    let mut node_counts: HashMap<String, usize> = HashMap::new();
+    let num_keys = 100;
+
+    for i in 0..num_keys {
+        let key = format!("dist_key_{}", i);
+        let addrs = client.get_key_addresses(&key).await;
+        assert!(!addrs.is_empty(), "No addresses returned for {}", key);
+        for addr in &addrs {
+            let node = if addr.contains(NODE1_IP) {
+                NODE1_IP
+            } else if addr.contains(NODE2_IP) {
+                NODE2_IP
+            } else {
+                "unknown"
+            };
+            *node_counts.entry(node.to_string()).or_default() += 1;
+        }
+    }
+
+    let node1_count = *node_counts.get(NODE1_IP).unwrap_or(&0);
+    let node2_count = *node_counts.get(NODE2_IP).unwrap_or(&0);
+    let total = node1_count + node2_count;
+
+    assert!(
+        total >= num_keys,
+        "Expected at least {} key assignments, got {}",
+        num_keys,
+        total
+    );
+    let node1_pct = (node1_count as f64 / total as f64) * 100.0;
+    let node2_pct = (node2_count as f64 / total as f64) * 100.0;
+    assert!(
+        node1_pct > 15.0 && node1_pct < 85.0,
+        "Node 1 has {}% of keys (expected 15-85%) — distribution too skewed",
+        node1_pct
+    );
+    assert!(
+        node2_pct > 15.0 && node2_pct < 85.0,
+        "Node 2 has {}% of keys (expected 15-85%) — distribution too skewed",
+        node2_pct
+    );
+}

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -126,7 +126,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Feature                         | Description                                  | System Tested |
 |---------------------------------|----------------------------------------------|---------------|
 | Two-level hash ring             | Global (nodes) + Local (threads within node) | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
-| Virtual nodes (3000 per thread) | Even distribution across physical threads    | No            |
+| Virtual nodes (3000 per thread) | Even distribution across physical threads    | [#373](https://github.com/andrewdavidmackenzie/anna/issues/373) |
 | CRC32 hashing                   | Hash function for key-to-ring mapping        | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
 | Thread responsibility lookup    | Determines which threads handle a key        | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
 
@@ -174,7 +174,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Single-Node Features         | 9     | 9             | 100%     | —      |
 | Error Handling               | 5     | 5             | 100%     | #355   |
 | Multi-Tiered Storage         | 4     | 0             | 0%       | #356   |
-| Multi-Node Features          | 31    | 11            | 35%      | #352   |
+| Multi-Node Features          | 31    | 12            | 39%      | #352   |
 | Monitoring & Policy Engine   | 8     | 0             | 0%       | #357   |
 | Server Internals             | 5     | 0             | 0%       | #358   |
-| **Total**                    | **83**| **45**        | **54%**  |        |
+| **Total**                    | **83**| **46**        | **55%**  |        |


### PR DESCRIPTION
Closes #373

## Summary
- Add `KVSClient::get_key_addresses()` public method to query routing for a key's responsible addresses
- Add `virtual_nodes_key_distribution` multi-node test: 100 keys across 2 nodes, verifies 15-85% per node
- Unit test for `get_key_addresses` cache-clearing behavior
- Feature coverage: 46/83 (55%)

## Test plan
- [x] `make clippy` — 0 warnings
- [x] `make fmt` — clean
- [x] `make test` — all 83 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)