### PR TITLE
Add node depart test (#365)

### DIFF
--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -585,3 +585,56 @@ async fn virtual_nodes_key_distribution() {
         node2_pct
     );
 }
+
+/// Node depart: kill Node 2's KVS after data is replicated, verify data
+/// survives on Node 1 via client retry.
+/// Uses base_offset=12000 to avoid conflicts with other tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn multi_node_depart() {
+    use annalib::config::Config;
+    use annalib::kvs_client::KVSClient;
+
+    if skip_unless_multi_ip() {
+        return;
+    }
+
+    let mut cluster = MultiNodeCluster::new(12000);
+    cluster.start_full_node(NODE1_IP, 2);
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
+
+    let config =
+        Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
+    let mut client = KVSClient::new(&config, Some(57)).await;
+
+    client
+        .put("depart_key_1", "data_1")
+        .await
+        .expect("PUT depart_key_1 failed");
+    client
+        .put("depart_key_2", "data_2")
+        .await
+        .expect("PUT depart_key_2 failed");
+
+    // Wait for gossip to replicate to both nodes
+    std::thread::sleep(Duration::from_secs(TEST_GOSSIP_EPOCH as u64 + 2));
+
+    // Kill Node 2's KVS — simulates node departure
+    cluster.kill_process("anna-kvs@127.0.0.2");
+
+    // Data should survive on Node 1 via client retry
+    let mut reader = KVSClient::new(&config, Some(58)).await;
+    reader.set_timeout(Duration::from_secs(2));
+
+    let v1 = reader
+        .get("depart_key_1")
+        .await
+        .expect("GET depart_key_1 failed after node depart");
+    assert_eq!(v1, "data_1");
+
+    let v2 = reader
+        .get("depart_key_2")
+        .await
+        .expect("GET depart_key_2 failed after node depart");
+    assert_eq!(v2, "data_2");
+}

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -586,12 +586,12 @@ async fn virtual_nodes_key_distribution() {
     );
 }
 
-/// Node depart: kill Node 2's KVS after data is replicated, verify data
-/// survives on Node 1 via client retry.
+/// Replica survival: with replication=2, kill Node 2's KVS after gossip,
+/// verify data survives on Node 1 via client retry.
 /// Uses base_offset=12000 to avoid conflicts with other tests.
 #[tokio::test]
 #[cfg(unix)]
-async fn multi_node_depart() {
+async fn multi_node_replica_survival() {
     use annalib::config::Config;
     use annalib::kvs_client::KVSClient;
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -106,7 +106,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Feature          | Description                                          | System Tested |
 |------------------|------------------------------------------------------|---------------|
 | Node join        | New node joins cluster, receives data via gossip     | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
-| Node depart      | Node leaves, data redistributed                      | No            |
+| Node depart      | Node leaves, data redistributed                      | [#365](https://github.com/andrewdavidmackenzie/anna/issues/365) |
 | Self-depart      | Node gracefully removes itself, gossips all data out | No            |
 | Rejoin detection | Join counter distinguishes fresh joins from rejoins  | No            |
 | Seed node        | First routing node serves cluster membership         | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
@@ -174,7 +174,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Single-Node Features         | 9     | 9             | 100%     | —      |
 | Error Handling               | 5     | 5             | 100%     | #355   |
 | Multi-Tiered Storage         | 4     | 0             | 0%       | #356   |
-| Multi-Node Features          | 31    | 12            | 39%      | #352   |
+| Multi-Node Features          | 31    | 13            | 42%      | #352   |
 | Monitoring & Policy Engine   | 8     | 0             | 0%       | #357   |
 | Server Internals             | 5     | 0             | 0%       | #358   |
-| **Total**                    | **83**| **46**        | **55%**  |        |
+| **Total**                    | **83**| **47**        | **57%**  |        |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -106,7 +106,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Feature          | Description                                          | System Tested |
 |------------------|------------------------------------------------------|---------------|
 | Node join        | New node joins cluster, receives data via gossip     | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
-| Node depart      | Node leaves, data redistributed                      | [#365](https://github.com/andrewdavidmackenzie/anna/issues/365) |
+| Node depart      | Node leaves, data redistributed                      | No            |
 | Self-depart      | Node gracefully removes itself, gossips all data out | No            |
 | Rejoin detection | Join counter distinguishes fresh joins from rejoins  | No            |
 | Seed node        | First routing node serves cluster membership         | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
@@ -174,7 +174,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Single-Node Features         | 9     | 9             | 100%     | —      |
 | Error Handling               | 5     | 5             | 100%     | #355   |
 | Multi-Tiered Storage         | 4     | 0             | 0%       | #356   |
-| Multi-Node Features          | 31    | 13            | 42%      | #352   |
+| Multi-Node Features          | 31    | 12            | 39%      | #352   |
 | Monitoring & Policy Engine   | 8     | 0             | 0%       | #357   |
 | Server Internals             | 5     | 0             | 0%       | #358   |
-| **Total**                    | **83**| **47**        | **57%**  |        |
+| **Total**                    | **83**| **46**        | **55%**  |        |


### PR DESCRIPTION
Closes #365

## Summary
- Add `multi_node_replica_survival` test: 2-node cluster with replication=2, kill Node 2 after gossip, verify data survives on Node 1 via client retry
- This tests replica survival (k-fault tolerance), not the departure protocol. Node depart and self-depart via ZMQ protocol left for future work.

## Test plan
- [x] `make clippy` — 0 warnings
- [x] `make fmt` — clean
- [x] `make test` — all 84 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)