### PR TITLE
Add cluster resilience tests: rejoin and routing recovery (#372)

### DIFF
--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -586,12 +586,12 @@ async fn virtual_nodes_key_distribution() {
     );
 }
 
-/// Node depart: kill Node 2's KVS after data is replicated, verify data
-/// survives on Node 1 via client retry.
+/// Replica survival: with replication=2, kill Node 2's KVS after gossip,
+/// verify data survives on Node 1 via client retry.
 /// Uses base_offset=12000 to avoid conflicts with other tests.
 #[tokio::test]
 #[cfg(unix)]
-async fn multi_node_depart() {
+async fn multi_node_replica_survival() {
     use annalib::config::Config;
     use annalib::kvs_client::KVSClient;
 
@@ -640,7 +640,9 @@ async fn multi_node_depart() {
 }
 
 /// Rejoin detection: kill and restart a KVS node, verify it rejoins the
-/// cluster and can serve requests.
+/// cluster by proving data can be served from the restarted node.
+/// With replication=2, PUT after rejoin goes to both nodes. Kill Node 1
+/// and verify the restarted Node 2 serves the data.
 /// Uses base_offset=14000 to avoid conflicts with other tests.
 #[tokio::test]
 #[cfg(unix)]
@@ -653,36 +655,38 @@ async fn multi_node_rejoin() {
     }
 
     let mut cluster = MultiNodeCluster::new(14000);
-    cluster.start_full_node(NODE1_IP, 1);
-    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
+    cluster.start_full_node(NODE1_IP, 2);
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
 
     let config =
         Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
-    let mut client = KVSClient::new(&config, Some(59)).await;
-
-    // PUT data while both nodes are up
-    client
-        .put("rejoin_key", "before_restart")
-        .await
-        .expect("PUT rejoin_key failed");
 
     // Kill Node 2
     cluster.kill_process("anna-kvs@127.0.0.2");
 
     // Restart Node 2 — it should rejoin via the seed node
-    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
 
-    // PUT new data — routing should include the rejoined node
-    let mut client2 = KVSClient::new(&config, Some(60)).await;
-    client2
-        .put("post_rejoin_key", "after_restart")
+    // PUT data after rejoin — with replication=2, data goes to both nodes
+    let mut client = KVSClient::new(&config, Some(59)).await;
+    client
+        .put("rejoin_proof", "on_both_nodes")
         .await
-        .expect("PUT post_rejoin_key failed");
-    let v = client2
-        .get("post_rejoin_key")
+        .expect("PUT rejoin_proof failed");
+
+    // Wait for gossip to replicate
+    std::thread::sleep(Duration::from_secs(TEST_GOSSIP_EPOCH as u64 + 2));
+
+    // Kill Node 1 — forces reads through Node 2, proving it rejoined
+    cluster.kill_process("anna-kvs@127.0.0.1");
+
+    let mut reader = KVSClient::new(&config, Some(60)).await;
+    reader.set_timeout(Duration::from_secs(2));
+    let v = reader
+        .get("rejoin_proof")
         .await
-        .expect("GET post_rejoin_key failed");
-    assert_eq!(v, "after_restart");
+        .expect("GET rejoin_proof failed — Node 2 did not rejoin");
+    assert_eq!(v, "on_both_nodes");
 }
 
 /// Stateless routing recovery: kill routing and KVS, restart both, verify

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -638,3 +638,109 @@ async fn multi_node_depart() {
         .expect("GET depart_key_2 failed after node depart");
     assert_eq!(v2, "data_2");
 }
+
+/// Rejoin detection: kill and restart a KVS node, verify it rejoins the
+/// cluster and can serve requests.
+/// Uses base_offset=14000 to avoid conflicts with other tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn multi_node_rejoin() {
+    use annalib::config::Config;
+    use annalib::kvs_client::KVSClient;
+
+    if skip_unless_multi_ip() {
+        return;
+    }
+
+    let mut cluster = MultiNodeCluster::new(14000);
+    cluster.start_full_node(NODE1_IP, 1);
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
+
+    let config =
+        Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
+    let mut client = KVSClient::new(&config, Some(59)).await;
+
+    // PUT data while both nodes are up
+    client
+        .put("rejoin_key", "before_restart")
+        .await
+        .expect("PUT rejoin_key failed");
+
+    // Kill Node 2
+    cluster.kill_process("anna-kvs@127.0.0.2");
+
+    // Restart Node 2 — it should rejoin via the seed node
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
+
+    // PUT new data — routing should include the rejoined node
+    let mut client2 = KVSClient::new(&config, Some(60)).await;
+    client2
+        .put("post_rejoin_key", "after_restart")
+        .await
+        .expect("PUT post_rejoin_key failed");
+    let v = client2
+        .get("post_rejoin_key")
+        .await
+        .expect("GET post_rejoin_key failed");
+    assert_eq!(v, "after_restart");
+}
+
+/// Stateless routing recovery: kill routing and KVS, restart both, verify
+/// the cluster rebuilds and serves requests. Routing is stateless — it
+/// rebuilds its hash ring from join announcements when KVS nodes start.
+/// Uses base_offset=16000 to avoid conflicts with other tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn stateless_routing_recovery() {
+    use annalib::config::Config;
+    use annalib::kvs_client::KVSClient;
+
+    if skip_unless_multi_ip() {
+        return;
+    }
+
+    let mut cluster = MultiNodeCluster::new(16000);
+    cluster.start_full_node(NODE1_IP, 1);
+
+    let config =
+        Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
+    let mut client = KVSClient::new(&config, Some(61)).await;
+
+    client
+        .put("routing_recovery_key", "persistent")
+        .await
+        .expect("PUT failed");
+
+    // Kill both routing and KVS
+    cluster.kill_process("anna-route@127.0.0.1");
+    cluster.kill_process("anna-kvs@127.0.0.1");
+
+    // Restart routing, then KVS (KVS announces to routing on startup)
+    let node_config = cluster.config_dir.join(format!("node-{}.yml", NODE1_IP));
+    for name in ["anna-route", "anna-kvs"] {
+        if let Some(child) = spawn_server(name, &node_config, &server_path()) {
+            cluster.processes.push(ServerProcess {
+                child,
+                label: format!("{}@{}", name, NODE1_IP),
+            });
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    assert!(
+        wait_for_port(NODE1_IP, cluster.routing_port(), 30),
+        "Routing did not restart"
+    );
+    std::thread::sleep(Duration::from_secs(2));
+
+    // KVS data is in-memory and lost on restart, so PUT again
+    let mut client2 = KVSClient::new(&config, Some(62)).await;
+    client2
+        .put("post_recovery_key", "recovered")
+        .await
+        .expect("PUT after recovery failed");
+    let v = client2
+        .get("post_recovery_key")
+        .await
+        .expect("GET after recovery failed");
+    assert_eq!(v, "recovered");
+}

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -108,7 +108,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Node join        | New node joins cluster, receives data via gossip     | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
 | Node depart      | Node leaves, data redistributed                      | [#365](https://github.com/andrewdavidmackenzie/anna/issues/365) |
 | Self-depart      | Node gracefully removes itself, gossips all data out | No            |
-| Rejoin detection | Join counter distinguishes fresh joins from rejoins  | No            |
+| Rejoin detection | Join counter distinguishes fresh joins from rejoins  | [#372](https://github.com/andrewdavidmackenzie/anna/issues/372) |
 | Seed node        | First routing node serves cluster membership         | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
 
 ### Fault Tolerance
@@ -118,7 +118,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | k-fault tolerance                       | k+1 replicas ensure k failures tolerable        | [#364](https://github.com/andrewdavidmackenzie/anna/issues/364) |
 | Failure detection via timeout           | Nodes detect peer failures and update hash ring  | No            |
 | Automatic repartitioning                | Data redistributed after node failure            | No            |
-| Stateless routing/monitoring            | Recovers by querying peers/storage               | No            |
+| Stateless routing/monitoring            | Recovers by querying peers/storage               | [#372](https://github.com/andrewdavidmackenzie/anna/issues/372) |
 | Key migration interleaved with requests | No downtime during reconfiguration               | No            |
 
 ### Consistent Hashing
@@ -174,7 +174,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Single-Node Features         | 9     | 9             | 100%     | —      |
 | Error Handling               | 5     | 5             | 100%     | #355   |
 | Multi-Tiered Storage         | 4     | 0             | 0%       | #356   |
-| Multi-Node Features          | 31    | 13            | 42%      | #352   |
+| Multi-Node Features          | 31    | 15            | 48%      | #352   |
 | Monitoring & Policy Engine   | 8     | 0             | 0%       | #357   |
 | Server Internals             | 5     | 0             | 0%       | #358   |
-| **Total**                    | **83**| **47**        | **57%**  |        |
+| **Total**                    | **83**| **49**        | **59%**  |        |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -106,7 +106,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Feature          | Description                                          | System Tested |
 |------------------|------------------------------------------------------|---------------|
 | Node join        | New node joins cluster, receives data via gossip     | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
-| Node depart      | Node leaves, data redistributed                      | [#365](https://github.com/andrewdavidmackenzie/anna/issues/365) |
+| Node depart      | Node leaves, data redistributed                      | No            |
 | Self-depart      | Node gracefully removes itself, gossips all data out | No            |
 | Rejoin detection | Join counter distinguishes fresh joins from rejoins  | [#372](https://github.com/andrewdavidmackenzie/anna/issues/372) |
 | Seed node        | First routing node serves cluster membership         | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
@@ -118,7 +118,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | k-fault tolerance                       | k+1 replicas ensure k failures tolerable        | [#364](https://github.com/andrewdavidmackenzie/anna/issues/364) |
 | Failure detection via timeout           | Nodes detect peer failures and update hash ring  | No            |
 | Automatic repartitioning                | Data redistributed after node failure            | No            |
-| Stateless routing/monitoring            | Recovers by querying peers/storage               | [#372](https://github.com/andrewdavidmackenzie/anna/issues/372) |
+| Stateless routing recovery              | Routing rebuilds hash ring from KVS join messages | [#372](https://github.com/andrewdavidmackenzie/anna/issues/372) |
 | Key migration interleaved with requests | No downtime during reconfiguration               | No            |
 
 ### Consistent Hashing
@@ -174,7 +174,7 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Single-Node Features         | 9     | 9             | 100%     | —      |
 | Error Handling               | 5     | 5             | 100%     | #355   |
 | Multi-Tiered Storage         | 4     | 0             | 0%       | #356   |
-| Multi-Node Features          | 31    | 15            | 48%      | #352   |
+| Multi-Node Features          | 31    | 14            | 45%      | #352   |
 | Monitoring & Policy Engine   | 8     | 0             | 0%       | #357   |
 | Server Internals             | 5     | 0             | 0%       | #358   |
-| **Total**                    | **83**| **49**        | **59%**  |        |
+| **Total**                    | **83**| **48**        | **58%**  |        |


### PR DESCRIPTION
Closes #372

## Summary
- **Rejoin detection**: Kill and restart KVS Node 2, PUT with replication=2, kill Node 1, verify data served from restarted Node 2 — proves it rejoined
- **Stateless routing recovery**: Kill routing and KVS, restart both, verify cluster rebuilds from KVS join announcements
- Feature coverage: 48/83 (58%)

Note: Automatic repartitioning and key migration deferred. "Stateless routing recovery" narrowed from "routing/monitoring" since only routing is tested.

## Test plan
- [x] `make clippy` — 0 warnings
- [x] `make fmt` — clean
- [x] `make test` — all 86 tests pass (9 multi-node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)