### PR TITLE
Add replication factor change and gossip after change tests (#394)

### DIFF
--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -17,6 +17,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 const TEST_GOSSIP_EPOCH: u32 = 2;
+const ZMQ_SETTLE_MS: u64 = 500;
 const NODE1_IP: &str = "127.0.0.1";
 const NODE2_IP: &str = "127.0.0.2";
 
@@ -375,6 +376,58 @@ impl MultiNodeCluster {
             proc.child.wait().ok();
         }
         self.processes.clear();
+    }
+
+    async fn send_replication_change(&self, routing_ip: &str, key: &str, memory_rep: u32) {
+        use annalib::proto::metadata::{
+            replication_factor::ReplicationValue, ReplicationFactor, ReplicationFactorUpdate, Tier,
+        };
+        use prost::Message;
+        use zeromq::{PushSocket, Socket, SocketSend};
+
+        let rep = ReplicationFactor {
+            key: key.to_string(),
+            global: vec![
+                ReplicationValue {
+                    tier: Tier::Memory as i32,
+                    value: memory_rep,
+                },
+                ReplicationValue {
+                    tier: Tier::Disk as i32,
+                    value: 0,
+                },
+            ],
+            local: vec![ReplicationValue {
+                tier: Tier::Memory as i32,
+                value: 1,
+            }],
+        };
+        let update = ReplicationFactorUpdate { updates: vec![rep] };
+        let encoded = update.encode_to_vec();
+
+        let routing_port = 6550 + self.base_offset;
+        let routing_addr = format!("tcp://{}:{}", routing_ip, routing_port);
+        let mut rsock = PushSocket::new();
+        rsock
+            .connect(&routing_addr)
+            .await
+            .expect("Failed to connect to routing replication change port");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        rsock
+            .send(encoded.clone().into())
+            .await
+            .expect("Failed to send to routing");
+
+        for kvs_ip in [NODE1_IP, NODE2_IP] {
+            let kvs_port = 6300 + self.base_offset;
+            let kvs_addr = format!("tcp://{}:{}", kvs_ip, kvs_port);
+            let mut ksock = PushSocket::new();
+            if ksock.connect(&kvs_addr).await.is_ok() {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                ksock.send(encoded.clone().into()).await.ok();
+            }
+        }
+        std::thread::sleep(Duration::from_millis(ZMQ_SETTLE_MS));
     }
 }
 
@@ -1369,4 +1422,94 @@ async fn crash_detection_via_epoch() {
         "Node 2 should have been removed from routing, got {:?}",
         addrs
     );
+}
+
+/// Replication factor change: send ReplicationFactorUpdate directly to
+/// routing, verify it updates the number of responsible addresses.
+/// Uses base_offset=36000 to avoid conflicts with other tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn replication_factor_change() {
+    use annalib::config::Config;
+    use annalib::kvs_client::KVSClient;
+
+    if skip_unless_multi_ip() {
+        return;
+    }
+
+    let mut cluster = MultiNodeCluster::new(36000);
+    cluster.start_full_node(NODE1_IP, 1);
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
+
+    let config =
+        Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
+    let mut client = KVSClient::new(&config, Some(75)).await;
+
+    client
+        .put("rep_change_key", "initial")
+        .await
+        .expect("PUT failed");
+
+    let addrs_before = client.get_key_addresses("rep_change_key").await;
+    assert_eq!(addrs_before.len(), 1, "Expected 1 address before change");
+
+    cluster
+        .send_replication_change(NODE1_IP, "rep_change_key", 2)
+        .await;
+
+    let addrs_after = client.get_key_addresses("rep_change_key").await;
+    assert!(
+        addrs_after.len() >= 2,
+        "Expected 2 addresses after replication change, got {}",
+        addrs_after.len()
+    );
+
+    // Wait for gossip then verify data accessible
+    std::thread::sleep(Duration::from_secs(TEST_GOSSIP_EPOCH as u64 + 2));
+    client.clear_cache();
+    let val = client
+        .get("rep_change_key")
+        .await
+        .expect("GET after replication change failed");
+    assert_eq!(val, "initial");
+}
+
+/// Gossip after replication change: change replication from 1 to 2,
+/// verify data is redistributed to the second node via gossip.
+/// Uses base_offset=38000 to avoid conflicts with other tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn gossip_after_replication_change() {
+    use annalib::config::Config;
+    use annalib::kvs_client::KVSClient;
+
+    if skip_unless_multi_ip() {
+        return;
+    }
+
+    let mut cluster = MultiNodeCluster::new(38000);
+    cluster.start_full_node(NODE1_IP, 1);
+    cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
+
+    let config =
+        Config::read(&cluster.client_config_path(NODE1_IP)).expect("Failed to read config");
+    let mut client = KVSClient::new(&config, Some(76)).await;
+
+    client
+        .put("gossip_rep_key", "redistributed")
+        .await
+        .expect("PUT failed");
+
+    cluster
+        .send_replication_change(NODE1_IP, "gossip_rep_key", 2)
+        .await;
+
+    std::thread::sleep(Duration::from_secs(TEST_GOSSIP_EPOCH as u64 + 2));
+
+    let mut reader = KVSClient::new(&config, Some(77)).await;
+    let val = reader
+        .get("gossip_rep_key")
+        .await
+        .expect("GET after replication change + gossip failed");
+    assert_eq!(val, "redistributed");
 }

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -87,9 +87,9 @@ terms (e.g., `STORAGE_MEDIUM=ram|file`).
 | Per-key replication factors     | Independent replication per key per tier                      | [#385](https://github.com/andrewdavidmackenzie/anna/issues/385) |
 | Default replication from config | `replication.memory`, `replication.ebs`, `replication.local`  | [#352](https://github.com/andrewdavidmackenzie/anna/issues/352) |
 | Replication factor request      | Server fetches unknown factors from metadata                  | [#368](https://github.com/andrewdavidmackenzie/anna/issues/368) |
-| Replication factor change       | Monitor can dynamically adjust replication                    | No            |
+| Replication factor change       | Monitor can dynamically adjust replication                    | [#394](https://github.com/andrewdavidmackenzie/anna/issues/394) |
 | Metadata stored as KVS data     | Replication info under `METADATA\|replication\|<key>`         | [#368](https://github.com/andrewdavidmackenzie/anna/issues/368) |
-| Gossip after replication change | Data redistributed to new responsible threads                 | No            |
+| Gossip after replication change | Data redistributed to new responsible threads                 | [#394](https://github.com/andrewdavidmackenzie/anna/issues/394) |
 
 ### Gossip / Multicast
 


### PR DESCRIPTION
Closes #394

Recreated from closed #396 (had merge conflicts with #397).

## Summary
- Add `send_replication_change()` — sends `ReplicationFactorUpdate` protobuf to routing + KVS
- **replication_factor_change** test: change replication 1→2, verify routing returns 2 addresses
- **gossip_after_replication_change** test: verify data redistributed after replication update

## Test plan
- [x] `make clippy` — 0 warnings
- [x] `make fmt` — clean
- [x] Both tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)