### PR TITLE
KVS publishes monitoring IPs to metadata key

### DIFF
--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -676,3 +676,53 @@ async fn hot_key_selective_replication() {
         "Hot key should have higher access count than cold keys"
     );
 }
+
+/// Verify that the KVS server publishes monitoring IPs as a metadata key
+/// that clients can read to discover monitor addresses.
+///
+/// Uses base_offset=8900 to avoid conflicts with other monitor tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn monitoring_ips_metadata() {
+    use annalib::kvs_client::KVSClient;
+    use annalib::proto::shared::StringSet;
+    use prost::Message;
+
+    if !server_bin_dir().join("anna-kvs").exists() {
+        eprintln!("SKIP: server binaries not built");
+        return;
+    }
+
+    let mut cluster = MonitorTestCluster::new(8900);
+    cluster.start();
+
+    let config = cluster.client_config();
+    let mut client = KVSClient::new(&config, Some(96)).await;
+
+    // The KVS writes monitoring IPs every server_report_period (3s in test config).
+    // Poll until the metadata key appears.
+    let meta_key = "ANNA_METADATA|monitoring_ips";
+    let mut found = false;
+    for _ in 0..10 {
+        std::thread::sleep(Duration::from_secs(2));
+        if let Ok(bytes) = client.get_bytes(meta_key).await {
+            let string_set =
+                StringSet::decode(bytes.as_slice()).expect("Failed to decode StringSet");
+            assert!(
+                !string_set.keys.is_empty(),
+                "monitoring_ips StringSet should not be empty"
+            );
+            assert!(
+                string_set.keys.contains(&NODE_IP.to_string()),
+                "monitoring_ips should contain {}",
+                NODE_IP
+            );
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "ANNA_METADATA|monitoring_ips was not written within timeout"
+    );
+}

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -651,6 +651,29 @@ void run(unsigned thread_id, string ebs_root, Address public_ip, Address private
                               &pushers[wt.key_request_connect_address()]);
       }
 
+      // Publish monitoring IPs as a metadata key so clients can discover them
+      if (!monitoring_ips.empty()) {
+        shared::StringSet monitoring_set;
+        for (const auto &ip : monitoring_ips) {
+          monitoring_set.add_keys(ip);
+        }
+        string serialized_monitoring;
+        monitoring_set.SerializeToString(&serialized_monitoring);
+
+        req.Clear();
+        req.set_type(kvs::RequestType::PUT);
+        prepare_put_tuple(
+            req, kMetadataIdentifier + kMetadataDelimiter + "monitoring_ips",
+            kvs::LatticeType::LWW, serialize(ts, serialized_monitoring));
+
+        {
+          string serialized;
+          req.SerializeToString(&serialized);
+          kZmqUtil->send_string(serialized,
+                                &pushers[wt.key_request_connect_address()]);
+        }
+      }
+
       report_start = std::chrono::system_clock::now();
 
       // Get the most recent list of cache IPs from the management node.


### PR DESCRIPTION
## Summary

- KVS server writes `ANNA_METADATA|monitoring_ips` (a `StringSet` of monitoring IPs) every `server_report_period`
- Enables `LatencyReporter::new()` to discover monitoring addresses at runtime without explicit IPs
- Adds system test verifying the metadata key is written and readable

Closes #415

## Implementation

The write is added to the existing stats reporting block in `server.cpp`, following the same pattern as `ANNA_METADATA|stats|...`, `ANNA_METADATA|access|...`, and `ANNA_METADATA|size|...` — serialize a `StringSet` protobuf, wrap in LWW, and self-PUT via ZMQ.

## Test plan

- [x] C++ server builds cleanly
- [x] `make clippy` — no errors
- [x] `make fmt` — clean
- [ ] CI: `make test` (system test verifies metadata key is written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)