### PR TITLE
Add cluster topology discovery via metadata key

### DIFF
--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -1535,4 +1535,48 @@ mod tests {
         );
         assert_eq!(key, "ANNA_METADATA|size|10.0.0.1|10.0.0.1|1|MEMORY");
     }
+
+    #[test]
+    fn cluster_topology_protobuf_roundtrip() {
+        use crate::proto::metadata::ClusterTopology;
+
+        let topo = ClusterTopology {
+            routing_thread_count: 2,
+            memory_thread_count: 4,
+            ebs_thread_count: 1,
+        };
+        let encoded = topo.encode_to_vec();
+        let decoded =
+            ClusterTopology::decode(encoded.as_slice()).expect("failed to decode topology");
+        assert_eq!(decoded.routing_thread_count, 2);
+        assert_eq!(decoded.memory_thread_count, 4);
+        assert_eq!(decoded.ebs_thread_count, 1);
+    }
+
+    #[test]
+    fn monitoring_ips_string_set_roundtrip() {
+        use crate::proto::shared::StringSet;
+
+        let set = StringSet {
+            keys: vec!["10.0.0.1".into(), "10.0.0.2".into()],
+        };
+        let encoded = set.encode_to_vec();
+        let decoded =
+            StringSet::decode(encoded.as_slice()).expect("failed to decode StringSet");
+        assert_eq!(decoded.keys.len(), 2);
+        assert!(decoded.keys.contains(&"10.0.0.1".to_string()));
+        assert!(decoded.keys.contains(&"10.0.0.2".to_string()));
+    }
+
+    #[test]
+    fn monitoring_ips_metadata_key_format() {
+        let key = "ANNA_METADATA|monitoring_ips";
+        assert!(key.starts_with("ANNA_METADATA|"));
+    }
+
+    #[test]
+    fn cluster_topology_metadata_key_format() {
+        let key = "ANNA_METADATA|cluster_topology";
+        assert!(key.starts_with("ANNA_METADATA|"));
+    }
 }

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -471,7 +471,14 @@ impl KVSClient {
             .get_bytes("ANNA_METADATA|cluster_topology")
             .await
             .ok()?;
-        crate::proto::metadata::ClusterTopology::decode(bytes.as_slice()).ok()
+        Self::decode_cluster_topology(&bytes)
+    }
+
+    /// Decode a `ClusterTopology` protobuf from raw LWW value bytes.
+    pub fn decode_cluster_topology(
+        bytes: &[u8],
+    ) -> Option<crate::proto::metadata::ClusterTopology> {
+        crate::proto::metadata::ClusterTopology::decode(bytes).ok()
     }
 
     /// Retrieve monitoring IPs from the metadata key.
@@ -479,11 +486,16 @@ impl KVSClient {
     /// Returns an empty vec if the metadata key hasn't been written yet.
     pub async fn get_monitoring_ips(&mut self) -> Vec<String> {
         match self.get_bytes("ANNA_METADATA|monitoring_ips").await {
-            Ok(bytes) => crate::proto::shared::StringSet::decode(bytes.as_slice())
-                .map(|s| s.keys)
-                .unwrap_or_default(),
+            Ok(bytes) => Self::decode_monitoring_ips(&bytes),
             Err(_) => vec![],
         }
+    }
+
+    /// Decode monitoring IPs from a serialized `StringSet`.
+    pub fn decode_monitoring_ips(bytes: &[u8]) -> Vec<String> {
+        crate::proto::shared::StringSet::decode(bytes)
+            .map(|s| s.keys)
+            .unwrap_or_default()
     }
 
     /// Store a key-value pair (Last-Writer-Wins lattice).
@@ -1537,7 +1549,7 @@ mod tests {
     }
 
     #[test]
-    fn cluster_topology_protobuf_roundtrip() {
+    fn decode_cluster_topology_roundtrip() {
         use crate::proto::metadata::ClusterTopology;
 
         let topo = ClusterTopology {
@@ -1547,36 +1559,44 @@ mod tests {
         };
         let encoded = topo.encode_to_vec();
         let decoded =
-            ClusterTopology::decode(encoded.as_slice()).expect("failed to decode topology");
+            KVSClient::decode_cluster_topology(&encoded).expect("failed to decode topology");
         assert_eq!(decoded.routing_thread_count, 2);
         assert_eq!(decoded.memory_thread_count, 4);
         assert_eq!(decoded.ebs_thread_count, 1);
     }
 
     #[test]
-    fn monitoring_ips_string_set_roundtrip() {
+    fn decode_cluster_topology_invalid() {
+        assert!(KVSClient::decode_cluster_topology(b"not valid").is_none());
+    }
+
+    #[test]
+    fn decode_monitoring_ips_roundtrip() {
         use crate::proto::shared::StringSet;
 
         let set = StringSet {
             keys: vec!["10.0.0.1".into(), "10.0.0.2".into()],
         };
         let encoded = set.encode_to_vec();
-        let decoded =
-            StringSet::decode(encoded.as_slice()).expect("failed to decode StringSet");
-        assert_eq!(decoded.keys.len(), 2);
-        assert!(decoded.keys.contains(&"10.0.0.1".to_string()));
-        assert!(decoded.keys.contains(&"10.0.0.2".to_string()));
+        let decoded = KVSClient::decode_monitoring_ips(&encoded);
+        assert_eq!(decoded.len(), 2);
+        assert!(decoded.contains(&"10.0.0.1".to_string()));
+        assert!(decoded.contains(&"10.0.0.2".to_string()));
     }
 
     #[test]
-    fn monitoring_ips_metadata_key_format() {
-        let key = "ANNA_METADATA|monitoring_ips";
-        assert!(key.starts_with("ANNA_METADATA|"));
+    fn decode_monitoring_ips_invalid() {
+        let decoded = KVSClient::decode_monitoring_ips(b"not valid");
+        assert!(decoded.is_empty());
     }
 
     #[test]
-    fn cluster_topology_metadata_key_format() {
-        let key = "ANNA_METADATA|cluster_topology";
-        assert!(key.starts_with("ANNA_METADATA|"));
+    fn decode_monitoring_ips_empty() {
+        use crate::proto::shared::StringSet;
+
+        let set = StringSet { keys: vec![] };
+        let encoded = set.encode_to_vec();
+        let decoded = KVSClient::decode_monitoring_ips(&encoded);
+        assert!(decoded.is_empty());
     }
 }

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -461,6 +461,31 @@ impl KVSClient {
             .map_err(|e| Error::Kvs(format!("Failed to decode KeySizeData: {}", e)))
     }
 
+    /// Retrieve cluster topology (thread counts) from the metadata key.
+    ///
+    /// Returns `None` if the metadata key hasn't been written yet.
+    pub async fn get_cluster_topology(
+        &mut self,
+    ) -> Option<crate::proto::metadata::ClusterTopology> {
+        let bytes = self
+            .get_bytes("ANNA_METADATA|cluster_topology")
+            .await
+            .ok()?;
+        crate::proto::metadata::ClusterTopology::decode(bytes.as_slice()).ok()
+    }
+
+    /// Retrieve monitoring IPs from the metadata key.
+    ///
+    /// Returns an empty vec if the metadata key hasn't been written yet.
+    pub async fn get_monitoring_ips(&mut self) -> Vec<String> {
+        match self.get_bytes("ANNA_METADATA|monitoring_ips").await {
+            Ok(bytes) => crate::proto::shared::StringSet::decode(bytes.as_slice())
+                .map(|s| s.keys)
+                .unwrap_or_default(),
+            Err(_) => vec![],
+        }
+    }
+
     /// Store a key-value pair (Last-Writer-Wins lattice).
     ///
     /// ```rust

--- a/clients/rust/src/lib/value_change_subscriber.rs
+++ b/clients/rust/src/lib/value_change_subscriber.rs
@@ -63,12 +63,27 @@ impl ValueChangeSubscriber {
     ///
     /// The `tid` parameter selects which port to listen on for updates.
     /// Pass `None` for the default (tid=0).
+    ///
+    /// Memory thread count defaults to 1. Use
+    /// [`KVSClient::get_cluster_topology()`] to discover the actual count
+    /// at runtime, then pass it to [`Self::with_memory_threads()`].
     pub async fn new(config: &ClientConfig, tid: Option<usize>) -> Result<Self> {
+        Self::with_memory_threads(config, tid, 1).await
+    }
+
+    /// Create a cache client with an explicit memory thread count.
+    ///
+    /// Use this when you've queried the cluster topology and know the
+    /// actual number of memory threads per KVS node.
+    pub async fn with_memory_threads(
+        config: &ClientConfig,
+        tid: Option<usize>,
+        memory_threads: usize,
+    ) -> Result<Self> {
         let tid = tid.unwrap_or(0);
         let base_offset = config.base_offset();
         let cache_ip = config.client_ip.clone();
         let server_ip = config.routing_ip().unwrap_or("127.0.0.1").to_string();
-        let memory_threads = 1;
 
         let bind_addr = format!(
             "tcp://{}:{}",

--- a/clients/rust/src/lib/value_change_subscriber.rs
+++ b/clients/rust/src/lib/value_change_subscriber.rs
@@ -404,4 +404,13 @@ mod tests {
         assert_eq!(sub.watched_keys().len(), 2);
         assert_eq!(sub.watched_keys()[0], "a");
     }
+
+    #[tokio::test]
+    async fn with_memory_threads_sets_count() {
+        let config = crate::client_config::ClientConfig::default();
+        let sub = ValueChangeSubscriber::with_memory_threads(&config, Some(89), 4)
+            .await
+            .expect("create failed");
+        assert_eq!(sub.memory_threads, 4);
+    }
 }

--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -726,3 +726,44 @@ async fn monitoring_ips_metadata() {
         "ANNA_METADATA|monitoring_ips was not written within timeout"
     );
 }
+
+/// Verify that the KVS server publishes cluster topology (thread counts)
+/// as a metadata key that clients can read to discover the cluster shape.
+///
+/// Uses base_offset=10100 to avoid conflicts with other monitor tests.
+#[tokio::test]
+#[cfg(unix)]
+async fn cluster_topology_metadata() {
+    use annalib::kvs_client::KVSClient;
+
+    if !server_bin_dir().join("anna-kvs").exists() {
+        eprintln!("SKIP: server binaries not built");
+        return;
+    }
+
+    let mut cluster = MonitorTestCluster::new(10100);
+    cluster.start();
+
+    let config = cluster.client_config();
+    let mut client = KVSClient::new(&config, Some(97)).await;
+
+    // Poll until the topology metadata key appears.
+    let mut topology = None;
+    for _ in 0..10 {
+        std::thread::sleep(Duration::from_secs(2));
+        topology = client.get_cluster_topology().await;
+        if topology.is_some() {
+            break;
+        }
+    }
+
+    let topo = topology.expect("ANNA_METADATA|cluster_topology was not written within timeout");
+    assert_eq!(
+        topo.memory_thread_count, 1,
+        "Expected 1 memory thread in test config"
+    );
+    assert_eq!(
+        topo.ebs_thread_count, 1,
+        "Expected 1 ebs thread in test config"
+    );
+}

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -651,6 +651,29 @@ void run(unsigned thread_id, string ebs_root, Address public_ip, Address private
                               &pushers[wt.key_request_connect_address()]);
       }
 
+      // Publish cluster topology so clients can discover thread counts
+      {
+        ClusterTopology topology;
+        topology.set_memory_thread_count(kMemoryThreadCount);
+        topology.set_ebs_thread_count(kEbsThreadCount);
+        string serialized_topology;
+        topology.SerializeToString(&serialized_topology);
+
+        req.Clear();
+        req.set_type(kvs::RequestType::PUT);
+        prepare_put_tuple(
+            req,
+            kMetadataIdentifier + kMetadataDelimiter + "cluster_topology",
+            kvs::LatticeType::LWW, serialize(ts, serialized_topology));
+
+        {
+          string serialized;
+          req.SerializeToString(&serialized);
+          kZmqUtil->send_string(serialized,
+                                &pushers[wt.key_request_connect_address()]);
+        }
+      }
+
       // Publish monitoring IPs as a metadata key so clients can discover them
       if (!monitoring_ips.empty()) {
         shared::StringSet monitoring_set;

--- a/server/protobuf/metadata.proto
+++ b/server/protobuf/metadata.proto
@@ -130,3 +130,16 @@ message ReplicationFactorUpdate {
   // The set of replication factor updates being sent.
   repeated ReplicationFactor updates = 1;
 }
+
+// Cluster topology information published as ANNA_METADATA|cluster_topology
+// so clients can discover thread counts at runtime.
+message ClusterTopology {
+  // Number of routing threads per routing node.
+  uint32 routing_thread_count = 1;
+
+  // Number of memory-tier threads per KVS node.
+  uint32 memory_thread_count = 2;
+
+  // Number of EBS-tier threads per KVS node.
+  uint32 ebs_thread_count = 3;
+}


### PR DESCRIPTION
## Summary

- KVS server writes `ANNA_METADATA|cluster_topology` (a `ClusterTopology` protobuf) every `server_report_period`, containing memory and EBS thread counts
- Add `ClusterTopology` message to `metadata.proto`
- Add `KVSClient::get_cluster_topology()` and `get_monitoring_ips()` convenience methods
- Add `ValueChangeSubscriber::with_memory_threads()` constructor for explicit thread count
- System test verifies the topology metadata key is written and readable

Closes #413

**Note:** This PR is based on #422 (`monitor_metadata_ips_415`). Merge #422 first.

## Test plan

- [x] C++ server builds cleanly
- [x] `make clippy` — no errors
- [x] `make fmt` — clean
- [ ] CI: `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)