### PR TITLE
Exercise management_node_response_handler via mock

### DIFF
--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -451,16 +451,24 @@ async fn cross_tier_data_movement() {
     let config = cluster.client_config();
     let mut client = KVSClient::new(&config, Some(97)).await;
 
-    // PUT keys to generate data on both tiers
+    // PUT hot keys (will be accessed) and cold keys (won't be accessed).
+    // Hot keys exercise the promotion path, cold keys exercise demotion.
     for i in 0..3 {
         let key = format!("tier_move_key_{}", i);
         client
             .put(&key, &"x".repeat(1000))
             .await
-            .expect("PUT failed");
+            .expect("PUT hot key failed");
+    }
+    for i in 0..3 {
+        let key = format!("tier_cold_key_{}", i);
+        client
+            .put(&key, &"y".repeat(500))
+            .await
+            .expect("PUT cold key failed");
     }
 
-    // Access keys to generate stats (needed for tiering policy)
+    // Only access hot keys — cold keys remain unaccessed to trigger demotion
     for i in 0..3 {
         let key = format!("tier_move_key_{}", i);
         for _ in 0..5 {

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1845,9 +1845,26 @@ async fn management_node_integration() {
                     if let Ok(msg) = result {
                         let data: Vec<u8> = msg.into_vec()
                             .into_iter().flat_map(|f| f.to_vec()).collect();
-                        eprintln!("Mock mgmt: func nodes query: {:?}", String::from_utf8_lossy(&data));
+                        let response_addr = String::from_utf8_lossy(&data).to_string();
+                        eprintln!("Mock mgmt: func nodes query, response addr: {}", response_addr);
                         func_count += 1;
-                        // PULL socket — no reply needed (KVS sends via PUSH)
+
+                        // Send back a StringSet of cache IPs to the KVS's
+                        // management_node_response port. This exercises
+                        // management_node_response_handler.cpp.
+                        if func_count == 1 && !response_addr.is_empty() {
+                            use annalib::proto::shared::StringSet;
+                            use prost::Message;
+                            let cache_ips = StringSet { keys: vec![] };
+                            let mut push = zeromq::PushSocket::new();
+                            if push.connect(&response_addr).await.is_ok() {
+                                tokio::time::sleep(Duration::from_millis(100)).await;
+                                push.send(zeromq::ZmqMessage::from(cache_ips.encode_to_vec()))
+                                    .await
+                                    .ok();
+                                eprintln!("Mock mgmt: sent empty cache IP list to {}", response_addr);
+                            }
+                        }
                     }
                 }
             }

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1847,24 +1847,24 @@ async fn management_node_integration() {
                             .into_iter().flat_map(|f| f.to_vec()).collect();
                         let response_addr = String::from_utf8_lossy(&data).to_string();
                         eprintln!("Mock mgmt: func nodes query, response addr: {}", response_addr);
-                        func_count += 1;
 
                         // Send back a StringSet of cache IPs to the KVS's
                         // management_node_response port. This exercises
                         // management_node_response_handler.cpp.
-                        if func_count == 1 && !response_addr.is_empty() {
+                        if func_count == 0 && !response_addr.is_empty() {
                             use annalib::proto::shared::StringSet;
                             use prost::Message;
                             let cache_ips = StringSet { keys: vec![] };
                             let mut push = zeromq::PushSocket::new();
-                            if push.connect(&response_addr).await.is_ok() {
-                                tokio::time::sleep(Duration::from_millis(100)).await;
-                                push.send(zeromq::ZmqMessage::from(cache_ips.encode_to_vec()))
-                                    .await
-                                    .ok();
-                                eprintln!("Mock mgmt: sent empty cache IP list to {}", response_addr);
-                            }
+                            push.connect(&response_addr).await
+                                .expect("Failed to connect to KVS response addr");
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            push.send(zeromq::ZmqMessage::from(cache_ips.encode_to_vec()))
+                                .await
+                                .expect("Failed to send cache IPs to KVS");
+                            eprintln!("Mock mgmt: sent empty cache IP list to {}", response_addr);
                         }
+                        func_count += 1;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Extend the `management_node_integration` test to exercise `management_node_response_handler.cpp` (~62 previously uncovered lines).

The mock management node now sends a `StringSet` of cache IPs back to the KVS's management_node_response port after receiving a func_nodes query. This triggers the KVS to process the response, update its `extant_caches` set, and handle any deleted caches.

Continued progress on #353

## Test plan

- [x] `management_node_integration` passes locally
- [ ] CI: `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)