### PR TITLE
Improve KVS disk serializer and management handler coverage

### DIFF
--- a/clients/rust/tests/consistency.rs
+++ b/clients/rust/tests/consistency.rs
@@ -24,12 +24,18 @@ async fn consistency_all_lattice_types() {
     let mut client = KVSClient::new(&config, Some(30)).await;
 
     // === LWW: last writer wins ===
-    client.put("lww_key", "first").await.expect("PUT first failed");
+    client
+        .put("lww_key", "first")
+        .await
+        .expect("PUT first failed");
     let val = client.get("lww_key").await.expect("GET first failed");
     assert_eq!(val, "first");
 
     std::thread::sleep(std::time::Duration::from_millis(10));
-    client.put("lww_key", "second").await.expect("PUT second failed");
+    client
+        .put("lww_key", "second")
+        .await
+        .expect("PUT second failed");
     let val = client.get("lww_key").await.expect("GET second failed");
     assert_eq!(val, "second", "LWW: later timestamp should win");
 

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1866,7 +1866,7 @@ async fn management_node_integration() {
                             push.send(zeromq::ZmqMessage::from(cache_ips.encode_to_vec()))
                                 .await
                                 .expect("Failed to send cache IPs to KVS");
-                            eprintln!("Mock mgmt: sent empty cache IP list to {}", response_addr);
+                            eprintln!("Mock mgmt: sent cache IP list to {}", response_addr);
                         }
                         func_count += 1;
                     }

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1255,7 +1255,8 @@ async fn disk_tier_basic() {
 
     let mut cluster = MultiNodeCluster::new(18015);
 
-    // Start full cluster with replication_ebs=1 so routing assigns to disk tier
+    // Start full cluster with replication_ebs=1 so routing knows about disk tier.
+    // With both memory and disk replication, some keys hash to the disk node.
     cluster.start_full_node_with_config(NodeConfig {
         replication_ebs: 1,
         base_offset: 18015,
@@ -1268,15 +1269,16 @@ async fn disk_tier_basic() {
     let config = cluster.client_config();
     let mut client = KVSClient::new(&config, Some(71)).await;
 
-    // PUT and GET data — routing may direct to either memory or disk node
-    for i in 0..5 {
+    // PUT many keys with varied prefixes — with consistent hashing, some
+    // will map to the disk node, exercising disk serializers.
+    for i in 0..20 {
         client
             .put(&format!("disk_key_{}", i), &format!("disk_val_{}", i))
             .await
             .unwrap_or_else(|e| panic!("PUT disk_key_{} failed: {}", i, e));
     }
 
-    for i in 0..5 {
+    for i in 0..20 {
         let key = format!("disk_key_{}", i);
         let val = client
             .get(&key)
@@ -1854,7 +1856,9 @@ async fn management_node_integration() {
                         if func_count == 0 && !response_addr.is_empty() {
                             use annalib::proto::shared::StringSet;
                             use prost::Message;
-                            let cache_ips = StringSet { keys: vec![] };
+                            let cache_ips = StringSet {
+                                keys: vec!["10.0.0.99".to_string()],
+                            };
                             let mut push = zeromq::PushSocket::new();
                             push.connect(&response_addr).await
                                 .expect("Failed to connect to KVS response addr");

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1255,8 +1255,8 @@ async fn disk_tier_basic() {
 
     let mut cluster = MultiNodeCluster::new(18015);
 
-    // Start full cluster with replication_ebs=1 so routing knows about disk tier.
-    // With both memory and disk replication, some keys hash to the disk node.
+    // Start full cluster with both memory and disk replication.
+    // Some keys will hash to the disk node, exercising disk serializers.
     cluster.start_full_node_with_config(NodeConfig {
         replication_ebs: 1,
         base_offset: 18015,


### PR DESCRIPTION
## Summary

- More disk tier keys (5→20) to increase disk serializer code coverage
- Non-empty cache IP list in management mock to exercise response handler loop

Continued progress on #353

## Test plan

- [x] `disk_tier_basic` passes locally
- [x] `management_node_integration` passes locally
- [ ] CI: `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)