### PR TITLE
Fix management_node_response_handler 0% coverage

### DIFF
--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1930,10 +1930,8 @@ async fn management_node_integration() {
         Err(_) => panic!("Management mock did not receive expected queries within timeout"),
     }
 
-    // Allow the KVS time to process the management_node_response we sent back.
-    // Without this, the cluster drops (SIGTERM) before the KVS polls the
-    // management_node_response_puller socket, so the handler never runs.
-    tokio::time::sleep(Duration::from_secs(TEST_SERVER_REPORT_PERIOD as u64)).await;
+    // Allow the KVS one poll cycle to process the management_node_response.
+    tokio::time::sleep(Duration::from_secs(1)).await;
 }
 
 /// Test the storage policy elasticity path: with memory-cap-kb set very low

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1929,6 +1929,11 @@ async fn management_node_integration() {
         Ok(Err(e)) => panic!("Management mock task failed: {}", e),
         Err(_) => panic!("Management mock did not receive expected queries within timeout"),
     }
+
+    // Allow the KVS time to process the management_node_response we sent back.
+    // Without this, the cluster drops (SIGTERM) before the KVS polls the
+    // management_node_response_puller socket, so the handler never runs.
+    tokio::time::sleep(Duration::from_secs(TEST_SERVER_REPORT_PERIOD as u64)).await;
 }
 
 /// Test the storage policy elasticity path: with memory-cap-kb set very low


### PR DESCRIPTION
## Summary

- Add a sleep after the management_node_integration test sends its response back to the KVS, giving the KVS time to poll and process the `management_node_response_puller` message before the cluster is dropped (SIGTERM)

## Root cause

The test verified the full request-response path (KVS queries management node for func_nodes, mock responds with StringSet of cache IPs), but the mock task returned immediately after sending. The cluster dropped, killing the KVS before its ZMQ poll loop processed the response. Result: `management_node_response_handler.cpp` showed 0% coverage despite the test exercising the code path.

Confirmed locally via gcov: `GCOV_TAG_COUNTER_ARCS mismatch` errors and `DA:xx,0` for all lines in the handler.

## Test plan

- [x] `management_node_integration` test passes locally (10.84s)
- [ ] CI green
- [ ] Codecov shows non-zero coverage for `management_node_response_handler.cpp` in server-system-tests flag

Closes #353 (partially — addresses one remaining coverage gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)