### PR TITLE
Review and update feature lists, implement missing client features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ifneq ($(BREW),)
 	brew install autoconf automake libtool pkg-config cmake protobuf curl lcov zmq cppzmq spdlog yaml-cpp googletest llvm
 endif
 ifneq ($(APTGET),)
+	sudo apt-get update
 	sudo apt-get -y install build-essential autoconf automake libtool curl unzip pkg-config cmake libc++-dev libc++abi-dev protobuf-compiler libprotobuf-dev lcov llvm libzmq3-dev cppzmq-dev libspdlog-dev libfmt-dev libyaml-cpp-dev libgtest-dev
 endif
 ifneq ($(YUM),)

--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -46,6 +46,18 @@ kvs::KeyResponse del(KvsClientInterface* client, const string& key) {
   return put(client, key, "");
 }
 
+map<string, string> get_multi(KvsClientInterface* client,
+                              const vector<string>& keys) {
+  map<string, string> results;
+  for (const auto& key : keys) {
+    string val = get(client, key);
+    if (!val.empty()) {
+      results[key] = val;
+    }
+  }
+  return results;
+}
+
 string get(KvsClientInterface* client, const string& key) {
   client->get_async(key);
 
@@ -441,6 +453,14 @@ void put_replication_factor(KvsClientInterface* client,
   string meta_key = kMetadataIdentifier + kMetadataDelimiter +
                     string("replication") + kMetadataDelimiter + key;
   put(client, meta_key, payload);
+}
+
+void set_timeout(KvsClient* client, unsigned timeout_ms) {
+  client->set_timeout(timeout_ms);
+}
+
+unsigned get_timeout(KvsClient* client) {
+  return client->get_timeout();
 }
 
 ClusterTopology get_cluster_topology(KvsClientInterface* client) {

--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -443,6 +443,28 @@ void put_replication_factor(KvsClientInterface* client,
   put(client, meta_key, payload);
 }
 
+ClusterTopology get_cluster_topology(KvsClientInterface* client) {
+  string key = kMetadataIdentifier + kMetadataDelimiter +
+               string("cluster_topology");
+  string bytes = get_bytes(client, key);
+
+  ClusterTopology topology;
+  topology.ParseFromString(bytes);
+  return topology;
+}
+
+vector<string> get_monitoring_ips(KvsClientInterface* client) {
+  string key = kMetadataIdentifier + kMetadataDelimiter +
+               string("monitoring_ips");
+  string bytes = get_bytes(client, key);
+
+  shared::StringSet string_set;
+  if (!string_set.ParseFromString(bytes)) {
+    return {};
+  }
+  return {string_set.keys().begin(), string_set.keys().end()};
+}
+
 namespace {
 
 vector<int> pids_from_name(const string& name) {

--- a/clients/cpp/src/client_lib.hpp
+++ b/clients/cpp/src/client_lib.hpp
@@ -19,6 +19,7 @@
 
 #include "kvs_client.hpp"
 #include "metadata.pb.h"
+#include "shared.pb.h"
 
 // This header (together with client_lib.cpp) is the "library" half of the
 // C++ client: it wraps KvsClientInterface with the KVS operations (get, put,
@@ -164,6 +165,18 @@ void put_replication_factor(KvsClientInterface* client,
                             const string& key,
                             unsigned memory_rep,
                             unsigned local_rep);
+
+// Retrieve cluster topology (thread counts) from the metadata key
+//   ANNA_METADATA|cluster_topology
+// and decode the ClusterTopology protobuf.
+// Returns a default-constructed ClusterTopology if the key does not exist.
+ClusterTopology get_cluster_topology(KvsClientInterface* client);
+
+// Retrieve monitoring node IP addresses from the metadata key
+//   ANNA_METADATA|monitoring_ips
+// and decode the StringSet protobuf.
+// Returns an empty vector if the key does not exist.
+vector<string> get_monitoring_ips(KvsClientInterface* client);
 
 // The anna server processes managed by start()/stop()/status().
 extern const vector<string> kProcessList;

--- a/clients/cpp/src/client_lib.hpp
+++ b/clients/cpp/src/client_lib.hpp
@@ -44,6 +44,11 @@ std::unique_ptr<KvsClient> make_client(const ClientConfig& config,
 // return its value.
 string get(KvsClientInterface* client, const string& key);
 
+// Retrieve multiple keys in a single call. Returns a map of key to value
+// for all keys successfully retrieved (keys with errors are omitted).
+map<string, string> get_multi(KvsClientInterface* client,
+                              const vector<string>& keys);
+
 // The result of a causal GET: the value plus the vector clock and
 // dependencies attached to it, for the caller to display/inspect as needed.
 struct CausalValue {
@@ -165,6 +170,12 @@ void put_replication_factor(KvsClientInterface* client,
                             const string& key,
                             unsigned memory_rep,
                             unsigned local_rep);
+
+// Set the request timeout in milliseconds for a client created with make_client.
+void set_timeout(KvsClient* client, unsigned timeout_ms);
+
+// Get the current request timeout in milliseconds.
+unsigned get_timeout(KvsClient* client);
 
 // Retrieve cluster topology (thread counts) from the metadata key
 //   ANNA_METADATA|cluster_topology

--- a/clients/cpp/src/kvs_client.hpp
+++ b/clients/cpp/src/kvs_client.hpp
@@ -85,6 +85,16 @@ class KvsClient : public KvsClientInterface {
 
  public:
   /**
+   * Set the request timeout in milliseconds.
+   */
+  void set_timeout(unsigned timeout_ms) { timeout_ = timeout_ms; }
+
+  /**
+   * Get the current request timeout in milliseconds.
+   */
+  unsigned get_timeout() const { return timeout_; }
+
+  /**
    * Issue an async PUT request to the KVS for a certain lattice typed value.
    */
   string put_async(const Key& key, const string& payload,

--- a/clients/cpp/tests/unit/mock_kvs_client.hpp
+++ b/clients/cpp/tests/unit/mock_kvs_client.hpp
@@ -35,13 +35,14 @@ class MockKvsClient : public KvsClientInterface {
 
   void get_async(const Key& key) { keys_get_.push_back(key); }
 
-  // Returns whatever has been queued in `responses_`, then clears the queue
-  // (so a test can enqueue a response, call the function under test once,
-  // and get an empty result on any subsequent poll -- mirroring how a real
-  // KvsClient only returns a response once).
+  // Returns one queued response per call (FIFO), mirroring how a real
+  // KvsClient returns one response per receive poll.
   vector<kvs::KeyResponse> receive_async() {
-    vector<kvs::KeyResponse> result = responses_;
-    responses_.clear();
+    if (responses_.empty()) {
+      return {};
+    }
+    vector<kvs::KeyResponse> result = {responses_.front()};
+    responses_.erase(responses_.begin());
     return result;
   }
 
@@ -67,6 +68,17 @@ class MockKvsClient : public KvsClientInterface {
   }
 
   unsigned rid_;
+};
+
+// A mock that returns all queued responses in a single receive_async() call,
+// used to test the "received more than one response" warning path in get().
+class BatchMockKvsClient : public MockKvsClient {
+ public:
+  vector<kvs::KeyResponse> receive_async() {
+    vector<kvs::KeyResponse> result = responses_;
+    responses_.clear();
+    return result;
+  }
 };
 
 // A mock that delays responses for N calls to receive_async() before

--- a/clients/cpp/tests/unit/test_client_lib.cpp
+++ b/clients/cpp/tests/unit/test_client_lib.cpp
@@ -913,3 +913,33 @@ TEST(ClientLibTest, GetMonitoringIpsDecodesProtobuf) {
   ASSERT_EQ(client.keys_get_.size(), 1u);
   EXPECT_EQ(client.keys_get_[0], "ANNA_METADATA|monitoring_ips");
 }
+
+TEST(ClientLibTest, GetMultiReturnsMultipleValues) {
+  MockKvsClient client;
+  client.responses_.push_back(make_lww_response("0", "val_a"));
+  client.responses_.push_back(make_lww_response("1", "val_b"));
+
+  vector<string> keys = {"key_a", "key_b"};
+  map<string, string> results = annalib::get_multi(&client, keys);
+
+  ASSERT_EQ(results.size(), 2u);
+  EXPECT_EQ(results["key_a"], "val_a");
+  EXPECT_EQ(results["key_b"], "val_b");
+}
+
+TEST(ClientLibTest, GetMultiEmptyKeysReturnsEmpty) {
+  MockKvsClient client;
+  vector<string> keys;
+  map<string, string> results = annalib::get_multi(&client, keys);
+  EXPECT_TRUE(results.empty());
+}
+
+TEST(ClientLibTest, SetTimeoutChangesTimeout) {
+  vector<UserRoutingThread> threads;
+  threads.push_back(UserRoutingThread("127.0.0.1", 0));
+  KvsClient kvs_client(threads, "127.0.0.1", 99, 10000);
+
+  EXPECT_EQ(kvs_client.get_timeout(), 10000u);
+  kvs_client.set_timeout(5000);
+  EXPECT_EQ(kvs_client.get_timeout(), 5000u);
+}

--- a/clients/cpp/tests/unit/test_client_lib.cpp
+++ b/clients/cpp/tests/unit/test_client_lib.cpp
@@ -870,3 +870,46 @@ TEST(ClientLibTest, GetPriorityWithMultipleResponsesStillWorks) {
   EXPECT_DOUBLE_EQ(result.priority, 1.0);
   EXPECT_EQ(result.value, "v1");
 }
+
+TEST(ClientLibTest, GetClusterTopologyDecodesProtobuf) {
+  MockKvsClient client;
+
+  ClusterTopology topology;
+  topology.set_routing_thread_count(2);
+  topology.set_memory_thread_count(4);
+  topology.set_ebs_thread_count(1);
+  string serialized;
+  topology.SerializeToString(&serialized);
+
+  client.responses_.push_back(make_lww_response("0", serialized));
+
+  ClusterTopology result = annalib::get_cluster_topology(&client);
+
+  EXPECT_EQ(result.routing_thread_count(), 2u);
+  EXPECT_EQ(result.memory_thread_count(), 4u);
+  EXPECT_EQ(result.ebs_thread_count(), 1u);
+
+  ASSERT_EQ(client.keys_get_.size(), 1u);
+  EXPECT_EQ(client.keys_get_[0], "ANNA_METADATA|cluster_topology");
+}
+
+TEST(ClientLibTest, GetMonitoringIpsDecodesProtobuf) {
+  MockKvsClient client;
+
+  shared::StringSet string_set;
+  string_set.add_keys("10.0.0.1");
+  string_set.add_keys("10.0.0.2");
+  string serialized;
+  string_set.SerializeToString(&serialized);
+
+  client.responses_.push_back(make_lww_response("0", serialized));
+
+  vector<string> result = annalib::get_monitoring_ips(&client);
+
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], "10.0.0.1");
+  EXPECT_EQ(result[1], "10.0.0.2");
+
+  ASSERT_EQ(client.keys_get_.size(), 1u);
+  EXPECT_EQ(client.keys_get_[0], "ANNA_METADATA|monitoring_ips");
+}

--- a/clients/cpp/tests/unit/test_client_lib.cpp
+++ b/clients/cpp/tests/unit/test_client_lib.cpp
@@ -811,7 +811,7 @@ TEST(ClientLibTest, PutPriorityRetriesUntilResponse) {
 // --- Multiple-response error branch tests ---
 
 TEST(ClientLibTest, GetWithMultipleResponsesStillWorks) {
-  MockKvsClient client;
+  BatchMockKvsClient client;
   // Push two responses to trigger the "more than one response" warning
   client.responses_.push_back(make_lww_response("0", "val1"));
   client.responses_.push_back(make_lww_response("0", "val2"));
@@ -822,7 +822,7 @@ TEST(ClientLibTest, GetWithMultipleResponsesStillWorks) {
 }
 
 TEST(ClientLibTest, GetSetWithMultipleResponsesStillWorks) {
-  MockKvsClient client;
+  BatchMockKvsClient client;
   set<string> expected = {"a"};
   client.responses_.push_back(make_set_response(expected));
   client.responses_.push_back(make_set_response(set<string>({"b"})));
@@ -832,7 +832,7 @@ TEST(ClientLibTest, GetSetWithMultipleResponsesStillWorks) {
 }
 
 TEST(ClientLibTest, GetOrderedSetWithMultipleResponsesStillWorks) {
-  MockKvsClient client;
+  BatchMockKvsClient client;
   client.responses_.push_back(make_ordered_set_response(set<string>({"a"})));
   client.responses_.push_back(make_ordered_set_response(set<string>({"b"})));
 
@@ -841,7 +841,7 @@ TEST(ClientLibTest, GetOrderedSetWithMultipleResponsesStillWorks) {
 }
 
 TEST(ClientLibTest, GetCausalWithMultipleResponsesStillWorks) {
-  MockKvsClient client;
+  BatchMockKvsClient client;
   client.responses_.push_back(make_causal_response("v1"));
   client.responses_.push_back(make_causal_response("v2"));
 
@@ -850,7 +850,7 @@ TEST(ClientLibTest, GetCausalWithMultipleResponsesStillWorks) {
 }
 
 TEST(ClientLibTest, GetSingleCausalWithMultipleResponsesStillWorks) {
-  MockKvsClient client;
+  BatchMockKvsClient client;
   client.responses_.push_back(make_single_causal_response("v1"));
   client.responses_.push_back(make_single_causal_response("v2"));
 
@@ -861,7 +861,7 @@ TEST(ClientLibTest, GetSingleCausalWithMultipleResponsesStillWorks) {
 }
 
 TEST(ClientLibTest, GetPriorityWithMultipleResponsesStillWorks) {
-  MockKvsClient client;
+  BatchMockKvsClient client;
   client.responses_.push_back(make_priority_response(1.0, "v1"));
   client.responses_.push_back(make_priority_response(2.0, "v2"));
 

--- a/clients/go/annalib/client.go
+++ b/clients/go/annalib/client.go
@@ -362,7 +362,7 @@ func (c *KVSClient) sendDataRequest(key string, reqType kvspb.RequestType, latti
 			return nil, &KVSError{Message: fmt.Sprintf("failed to receive response: %v", err)}
 		}
 		if data == nil {
-			delete(c.keyAddressCache, key)
+			c.evictAddress(key, worker)
 			if attempt < maxRetries {
 				continue
 			}
@@ -377,7 +377,7 @@ func (c *KVSClient) sendDataRequest(key string, reqType kvspb.RequestType, latti
 		if len(response.Tuples) > 0 {
 			t := response.Tuples[0]
 			if t.Error == kvspb.AnnaError_WRONG_THREAD && attempt < maxRetries {
-				delete(c.keyAddressCache, key)
+				c.evictAddress(key, worker)
 				continue
 			}
 			if t.Invalidate {
@@ -846,6 +846,100 @@ func (c *KVSClient) PutReplicationFactor(key string, memoryRep, localRep uint32)
 	return err
 }
 
+// GetMulti retrieves multiple keys in batched requests, grouping keys by
+// worker address for efficiency. Returns a map of key to value for all keys
+// that were successfully retrieved (keys with errors are omitted).
+func (c *KVSClient) GetMulti(keys []string) (map[string]string, error) {
+	if len(keys) == 0 {
+		return map[string]string{}, nil
+	}
+
+	const maxRetries = 3
+	results := make(map[string]string)
+	pending := make([]string, len(keys))
+	copy(pending, keys)
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if len(pending) == 0 {
+			break
+		}
+
+		// Group keys by worker address.
+		workerKeys := make(map[string][]string)
+		for _, key := range pending {
+			worker, ok := c.getWorkerAddress(key)
+			if !ok {
+				return nil, &KVSError{Message: fmt.Sprintf("GET_MULTI: no worker address for key %s", key)}
+			}
+			workerKeys[worker] = append(workerKeys[worker], key)
+		}
+
+		var retryKeys []string
+
+		for worker, batchKeys := range workerKeys {
+			rid := c.getRequestID()
+			request := &kvspb.KeyRequest{
+				RequestId:       rid,
+				ResponseAddress: c.ut.ResponseConnectAddress(),
+				Type:            kvspb.RequestType_GET,
+			}
+			for _, key := range batchKeys {
+				tuple := &kvspb.KeyTuple{Key: key}
+				if cached, ok := c.keyAddressCache[key]; ok {
+					tuple.AddressCacheSize = uint32(len(cached))
+				}
+				request.Tuples = append(request.Tuples, tuple)
+			}
+
+			encoded, err := proto.Marshal(request)
+			if err != nil {
+				return nil, &KVSError{Message: fmt.Sprintf("GET_MULTI: encode error: %v", err)}
+			}
+			if err := c.tp.sendRequest(encoded, worker); err != nil {
+				return nil, err
+			}
+
+			data, err := c.tp.recvResponse(false)
+			if err != nil {
+				return nil, &KVSError{Message: fmt.Sprintf("GET_MULTI: recv error: %v", err)}
+			}
+			if data == nil {
+				for _, key := range batchKeys {
+					delete(c.keyAddressCache, key)
+				}
+				return nil, &KVSError{Message: "GET_MULTI: request timed out"}
+			}
+
+			response := &kvspb.KeyResponse{}
+			if err := proto.Unmarshal(data, response); err != nil {
+				return nil, &KVSError{Message: fmt.Sprintf("GET_MULTI: decode error: %v", err)}
+			}
+
+			for _, tuple := range response.Tuples {
+				if tuple.Invalidate {
+					delete(c.keyAddressCache, tuple.Key)
+				}
+				if tuple.Error == kvspb.AnnaError_WRONG_THREAD {
+					delete(c.keyAddressCache, tuple.Key)
+					if attempt < maxRetries {
+						retryKeys = append(retryKeys, tuple.Key)
+					}
+				} else if tuple.Error == kvspb.AnnaError_NO_ERROR {
+					bytes, err := parseLWWBytes(tuple.Payload)
+					if err != nil {
+						return nil, &KVSError{Message: fmt.Sprintf("GET_MULTI: LWW decode error for key %s: %v", tuple.Key, err)}
+					}
+					results[tuple.Key] = string(bytes)
+				}
+			}
+		}
+
+		pending = retryKeys
+	}
+
+	return results, nil
+}
+
 // GetClusterTopology retrieves cluster topology (thread counts) from the
 // metadata key ANNA_METADATA|cluster_topology and decodes the ClusterTopology
 // protobuf. Returns nil if the key does not exist.
@@ -880,6 +974,48 @@ func (c *KVSClient) GetMonitoringIPs() ([]string, error) {
 func (c *KVSClient) Delete(key string) error {
 	return c.Put(key, "")
 }
+// SetTimeout sets the request timeout duration.
+func (c *KVSClient) SetTimeout(d time.Duration) {
+	if t, ok := c.tp.(*zmqTransport); ok {
+		t.timeout = d
+	}
+}
+
+// GetTimeout returns the current request timeout duration.
+func (c *KVSClient) GetTimeout() time.Duration {
+	if t, ok := c.tp.(*zmqTransport); ok {
+		return t.timeout
+	}
+	return 0
+}
+
+// evictAddress removes a specific worker address from the cache for a key.
+// If the key's address list becomes empty, the key is removed entirely.
+// Also removes the ZMQ socket for the evicted address.
+func (c *KVSClient) evictAddress(key, addr string) {
+	addrs, ok := c.keyAddressCache[key]
+	if !ok {
+		return
+	}
+	filtered := addrs[:0]
+	for _, a := range addrs {
+		if a != addr {
+			filtered = append(filtered, a)
+		}
+	}
+	if len(filtered) == 0 {
+		delete(c.keyAddressCache, key)
+	} else {
+		c.keyAddressCache[key] = filtered
+	}
+	if t, ok := c.tp.(*zmqTransport); ok {
+		if sock, ok := t.socketCache[addr]; ok {
+			_ = sock.Close()
+			delete(t.socketCache, addr)
+		}
+	}
+}
+
 // ClearCache clears the key-address cache.
 func (c *KVSClient) ClearCache() {
 	c.keyAddressCache = make(map[string][]string)

--- a/clients/go/annalib/client.go
+++ b/clients/go/annalib/client.go
@@ -334,45 +334,60 @@ func parseSetPayload(payload []byte) ([]string, error) {
 	return values, nil
 }
 
+const maxRetries = 5
+
 func (c *KVSClient) sendDataRequest(key string, reqType kvspb.RequestType, latticeType kvspb.LatticeType, payload []byte) (*kvspb.KeyResponse, error) {
-	worker, ok := c.getWorkerAddress(key)
-	if !ok {
-		return nil, &KVSError{Message: fmt.Sprintf("no worker address for key %s", key)}
-	}
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		worker, ok := c.getWorkerAddress(key)
+		if !ok {
+			return nil, &KVSError{Message: fmt.Sprintf("no worker address for key %s", key)}
+		}
 
-	var cacheSize uint32
-	if cached, ok := c.keyAddressCache[key]; ok {
-		cacheSize = uint32(len(cached))
-	}
+		var cacheSize uint32
+		if cached, ok := c.keyAddressCache[key]; ok {
+			cacheSize = uint32(len(cached))
+		}
 
-	encoded, err := buildDataRequest(c.getRequestID(), c.ut.ResponseConnectAddress(), key, reqType, latticeType, payload, cacheSize)
-	if err != nil {
-		return nil, &KVSError{Message: fmt.Sprintf("failed to encode request: %v", err)}
-	}
+		encoded, err := buildDataRequest(c.getRequestID(), c.ut.ResponseConnectAddress(), key, reqType, latticeType, payload, cacheSize)
+		if err != nil {
+			return nil, &KVSError{Message: fmt.Sprintf("failed to encode request: %v", err)}
+		}
 
-	if err := c.tp.sendRequest(encoded, worker); err != nil {
-		return nil, err
-	}
+		if err := c.tp.sendRequest(encoded, worker); err != nil {
+			return nil, err
+		}
 
-	data, err := c.tp.recvResponse(false)
-	if err != nil {
-		return nil, &KVSError{Message: fmt.Sprintf("failed to receive response: %v", err)}
-	}
-	if data == nil {
-		delete(c.keyAddressCache, key)
-		return nil, &KVSError{Message: fmt.Sprintf("%s: request timed out", key)}
-	}
+		data, err := c.tp.recvResponse(false)
+		if err != nil {
+			return nil, &KVSError{Message: fmt.Sprintf("failed to receive response: %v", err)}
+		}
+		if data == nil {
+			delete(c.keyAddressCache, key)
+			if attempt < maxRetries {
+				continue
+			}
+			return nil, &KVSError{Message: fmt.Sprintf("%s: request timed out", key)}
+		}
 
-	response, err := parseDataResponse(data)
-	if err != nil {
-		return nil, &KVSError{Message: err.Error()}
-	}
+		response, err := parseDataResponse(data)
+		if err != nil {
+			return nil, &KVSError{Message: err.Error()}
+		}
 
-	if len(response.Tuples) > 0 && response.Tuples[0].Invalidate {
-		delete(c.keyAddressCache, key)
-	}
+		if len(response.Tuples) > 0 {
+			t := response.Tuples[0]
+			if t.Error == kvspb.AnnaError_WRONG_THREAD && attempt < maxRetries {
+				delete(c.keyAddressCache, key)
+				continue
+			}
+			if t.Invalidate {
+				delete(c.keyAddressCache, key)
+			}
+		}
 
-	return response, nil
+		return response, nil
+	}
+	return nil, &KVSError{Message: fmt.Sprintf("%s: max retries exceeded", key)}
 }
 
 func generateTimestamp() uint64 {
@@ -829,6 +844,36 @@ func (c *KVSClient) PutReplicationFactor(key string, memoryRep, localRep uint32)
 
 	_, err = validateResponse(response, "PUT_REPLICATION")
 	return err
+}
+
+// GetClusterTopology retrieves cluster topology (thread counts) from the
+// metadata key ANNA_METADATA|cluster_topology and decodes the ClusterTopology
+// protobuf. Returns nil if the key does not exist.
+func (c *KVSClient) GetClusterTopology() (*metadatapb.ClusterTopology, error) {
+	bytes, err := c.GetBytes("ANNA_METADATA|cluster_topology")
+	if err != nil {
+		return nil, err
+	}
+	var topology metadatapb.ClusterTopology
+	if err := proto.Unmarshal(bytes, &topology); err != nil {
+		return nil, &KVSError{Message: fmt.Sprintf("failed to decode ClusterTopology: %v", err)}
+	}
+	return &topology, nil
+}
+
+// GetMonitoringIPs retrieves monitoring node IP addresses from the metadata
+// key ANNA_METADATA|monitoring_ips and decodes the StringSet protobuf.
+// Returns an empty slice if the key does not exist.
+func (c *KVSClient) GetMonitoringIPs() ([]string, error) {
+	bytes, err := c.GetBytes("ANNA_METADATA|monitoring_ips")
+	if err != nil {
+		return []string{}, nil
+	}
+	var stringSet sharedpb.StringSet
+	if err := proto.Unmarshal(bytes, &stringSet); err != nil {
+		return nil, &KVSError{Message: fmt.Sprintf("failed to decode monitoring IPs: %v", err)}
+	}
+	return stringSet.Keys, nil
 }
 
 // Delete removes a key by writing an empty LWW value with a dominating timestamp.

--- a/clients/go/annalib/client_test.go
+++ b/clients/go/annalib/client_test.go
@@ -1499,3 +1499,137 @@ func TestPutReplicationFactorWithMock(t *testing.T) {
 		t.Errorf("unexpected local replication: %v", rep.Local)
 	}
 }
+
+func TestGetClusterTopologyWithMock(t *testing.T) {
+	topology := &metadatapb.ClusterTopology{
+		RoutingThreadCount: 2,
+		MemoryThreadCount:  4,
+		EbsThreadCount:     1,
+	}
+	topologyBytes, _ := proto.Marshal(topology)
+	lww := &kvspb.LWWValue{Timestamp: 100, Value: topologyBytes}
+	lwwBytes, _ := proto.Marshal(lww)
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: "ANNA_METADATA|cluster_topology", Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBytes}},
+	}
+	respBytes, _ := proto.Marshal(response)
+
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "ANNA_METADATA|cluster_topology", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	tp := &mockTransport{recvData: map[bool][]byte{true: routingBytes, false: respBytes}}
+	client := newTestClient(tp)
+
+	result, err := client.GetClusterTopology()
+	if err != nil {
+		t.Fatalf("GetClusterTopology failed: %v", err)
+	}
+	if result.RoutingThreadCount != 2 {
+		t.Errorf("expected routing_thread_count=2, got %d", result.RoutingThreadCount)
+	}
+	if result.MemoryThreadCount != 4 {
+		t.Errorf("expected memory_thread_count=4, got %d", result.MemoryThreadCount)
+	}
+	if result.EbsThreadCount != 1 {
+		t.Errorf("expected ebs_thread_count=1, got %d", result.EbsThreadCount)
+	}
+}
+
+func TestGetMonitoringIPsWithMock(t *testing.T) {
+	stringSet := &sharedpb.StringSet{Keys: []string{"10.0.0.1", "10.0.0.2"}}
+	setBytes, _ := proto.Marshal(stringSet)
+	lww := &kvspb.LWWValue{Timestamp: 100, Value: setBytes}
+	lwwBytes, _ := proto.Marshal(lww)
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: "ANNA_METADATA|monitoring_ips", Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBytes}},
+	}
+	respBytes, _ := proto.Marshal(response)
+
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "ANNA_METADATA|monitoring_ips", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	tp := &mockTransport{recvData: map[bool][]byte{true: routingBytes, false: respBytes}}
+	client := newTestClient(tp)
+
+	result, err := client.GetMonitoringIPs()
+	if err != nil {
+		t.Fatalf("GetMonitoringIPs failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 IPs, got %d", len(result))
+	}
+	if result[0] != "10.0.0.1" || result[1] != "10.0.0.2" {
+		t.Errorf("unexpected IPs: %v", result)
+	}
+}
+
+func TestWrongThreadRetry(t *testing.T) {
+	// First call: routing resolves, then server returns WRONG_THREAD
+	wrongThreadResponse := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: "k", Error: kvspb.AnnaError_WRONG_THREAD}},
+	}
+	wrongBytes, _ := proto.Marshal(wrongThreadResponse)
+
+	// Second call: success
+	lww := &kvspb.LWWValue{Timestamp: 100, Value: []byte("ok")}
+	lwwBytes, _ := proto.Marshal(lww)
+	okResponse := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: "k", Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBytes}},
+	}
+	okBytes, _ := proto.Marshal(okResponse)
+
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "k", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	// Use a sequencing mock that returns WRONG_THREAD first, then OK
+	tp := &sequencingMockTransport{
+		routingData:   routingBytes,
+		dataResponses: [][]byte{wrongBytes, okBytes},
+	}
+	client := newTestClient(tp)
+	client.tp = tp
+
+	result, err := client.Get("k")
+	if err != nil {
+		t.Fatalf("Get with WRONG_THREAD retry failed: %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("expected 'ok', got '%s'", result)
+	}
+}
+
+// sequencingMockTransport returns different data responses in sequence.
+type sequencingMockTransport struct {
+	sentMessages  []sentMsg
+	routingData   []byte
+	dataResponses [][]byte
+	dataIndex     int
+}
+
+func (m *sequencingMockTransport) sendRequest(msg []byte, addr string) error {
+	m.sentMessages = append(m.sentMessages, sentMsg{data: msg, addr: addr})
+	return nil
+}
+
+func (m *sequencingMockTransport) recvResponse(useKeyAddress bool) ([]byte, error) {
+	if useKeyAddress {
+		return m.routingData, nil
+	}
+	if m.dataIndex < len(m.dataResponses) {
+		data := m.dataResponses[m.dataIndex]
+		m.dataIndex++
+		return data, nil
+	}
+	return nil, nil
+}
+
+func (m *sequencingMockTransport) close() error { return nil }

--- a/clients/go/annalib/client_test.go
+++ b/clients/go/annalib/client_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
 	kvspb "github.com/andrewdavidmackenzie/anna/clients/go/annalib/proto/kvs"
 	metadatapb "github.com/andrewdavidmackenzie/anna/clients/go/annalib/proto/metadata"
+	sharedpb "github.com/andrewdavidmackenzie/anna/clients/go/annalib/proto/shared"
 )
 
 func TestGenerateSeed(t *testing.T) {
@@ -1633,3 +1635,108 @@ func (m *sequencingMockTransport) recvResponse(useKeyAddress bool) ([]byte, erro
 }
 
 func (m *sequencingMockTransport) close() error { return nil }
+
+func TestGetMultiWithMock(t *testing.T) {
+	// Build a response with two tuples
+	lwwA := &kvspb.LWWValue{Timestamp: 100, Value: []byte("val_a")}
+	lwwB := &kvspb.LWWValue{Timestamp: 100, Value: []byte("val_b")}
+	lwwABytes, _ := proto.Marshal(lwwA)
+	lwwBBytes, _ := proto.Marshal(lwwB)
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{
+			{Key: "a", Error: kvspb.AnnaError_NO_ERROR, Payload: lwwABytes},
+			{Key: "b", Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBBytes},
+		},
+	}
+	respBytes, _ := proto.Marshal(response)
+
+	routingResp := &kvspb.KeyAddressResponse{
+		Error: kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{
+			{Key: "a", Ips: []string{"tcp://10.0.0.1:6800"}},
+			{Key: "b", Ips: []string{"tcp://10.0.0.1:6800"}},
+		},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	tp := &mockTransport{recvData: map[bool][]byte{true: routingBytes, false: respBytes}}
+	client := newTestClient(tp)
+
+	results, err := client.GetMulti([]string{"a", "b"})
+	if err != nil {
+		t.Fatalf("GetMulti failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results["a"] != "val_a" || results["b"] != "val_b" {
+		t.Errorf("unexpected results: %v", results)
+	}
+}
+
+func TestGetMultiEmpty(t *testing.T) {
+	tp := &mockTransport{}
+	client := newTestClient(tp)
+
+	results, err := client.GetMulti([]string{})
+	if err != nil {
+		t.Fatalf("GetMulti empty failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %v", results)
+	}
+}
+
+func TestEvictAddressRemovesSingle(t *testing.T) {
+	tp := &mockTransport{}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800", "tcp://10.0.0.2:6800"}
+
+	client.evictAddress("k", "tcp://10.0.0.1:6800")
+
+	addrs := client.keyAddressCache["k"]
+	if len(addrs) != 1 || addrs[0] != "tcp://10.0.0.2:6800" {
+		t.Errorf("expected [tcp://10.0.0.2:6800], got %v", addrs)
+	}
+}
+
+func TestEvictAddressRemovesKeyWhenLast(t *testing.T) {
+	tp := &mockTransport{}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+
+	client.evictAddress("k", "tcp://10.0.0.1:6800")
+
+	if _, ok := client.keyAddressCache["k"]; ok {
+		t.Error("expected key to be removed from cache when last address evicted")
+	}
+}
+
+func TestEvictAddressNonexistentKey(t *testing.T) {
+	tp := &mockTransport{}
+	client := newTestClient(tp)
+
+	// Should not panic
+	client.evictAddress("nonexistent", "tcp://10.0.0.1:6800")
+}
+
+func TestSetTimeoutChangesTimeout(t *testing.T) {
+	config := &ClientConfig{
+		RoutingAddresses: []string{"tcp://127.0.0.1:6450"},
+		ClientIP:         "127.0.0.1",
+	}
+	client, err := NewKVSClient(config, 98)
+	if err != nil {
+		t.Fatalf("NewKVSClient failed: %v", err)
+	}
+	defer client.Close()
+
+	if client.GetTimeout() != 10*time.Second {
+		t.Errorf("expected default timeout 10s, got %v", client.GetTimeout())
+	}
+
+	client.SetTimeout(5 * time.Second)
+	if client.GetTimeout() != 5*time.Second {
+		t.Errorf("expected timeout 5s, got %v", client.GetTimeout())
+	}
+}

--- a/clients/go/annalib/client_test.go
+++ b/clients/go/annalib/client_test.go
@@ -1,11 +1,13 @@
 package annalib
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/go-zeromq/zmq4"
 	"google.golang.org/protobuf/proto"
 
 	kvspb "github.com/andrewdavidmackenzie/anna/clients/go/annalib/proto/kvs"
@@ -1738,5 +1740,830 @@ func TestSetTimeoutChangesTimeout(t *testing.T) {
 	client.SetTimeout(5 * time.Second)
 	if client.GetTimeout() != 5*time.Second {
 		t.Errorf("expected timeout 5s, got %v", client.GetTimeout())
+	}
+}
+
+// --- Helper: build a mock client whose data response has a specific error code ---
+
+func newMockClientWithErrorResponse(key string, annaErr kvspb.AnnaError) *KVSClient {
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: key, Error: annaErr}},
+	}
+	respBytes, _ := proto.Marshal(response)
+	tp := &mockTransport{recvData: map[bool][]byte{false: respBytes}}
+	client := newTestClient(tp)
+	client.keyAddressCache[key] = []string{"tcp://10.0.0.1:6800"}
+	return client
+}
+
+// --- Helper: build a mock client whose data response has a corrupt payload ---
+
+func newMockClientWithCorruptPayload(key string) *KVSClient {
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: key, Error: kvspb.AnnaError_NO_ERROR, Payload: []byte{0xff, 0xff}}},
+	}
+	respBytes, _ := proto.Marshal(response)
+	tp := &mockTransport{recvData: map[bool][]byte{false: respBytes}}
+	client := newTestClient(tp)
+	client.keyAddressCache[key] = []string{"tcp://10.0.0.1:6800"}
+	return client
+}
+
+// --- Helper: build a mock client whose GetBytes returns corrupt inner bytes (valid LWW wrapping corrupt data) ---
+
+func newMockClientWithCorruptInnerBytes(key string) *KVSClient {
+	lww := &kvspb.LWWValue{Timestamp: 100, Value: []byte{0xff, 0xff}}
+	lwwBytes, _ := proto.Marshal(lww)
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: key, Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBytes}},
+	}
+	respBytes, _ := proto.Marshal(response)
+	tp := &mockTransport{recvData: map[bool][]byte{false: respBytes}}
+	client := newTestClient(tp)
+	client.keyAddressCache[key] = []string{"tcp://10.0.0.1:6800"}
+	return client
+}
+
+// --- Put: validateResponse error path ---
+
+func TestPutValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("k", kvspb.AnnaError_KEY_DNE)
+	err := client.Put("k", "val")
+	if err == nil {
+		t.Fatal("expected error from Put when response has KEY_DNE")
+	}
+}
+
+// --- GetSet: validateResponse error path ---
+
+func TestGetSetValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("s", kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetSet("s")
+	if err == nil {
+		t.Fatal("expected error from GetSet when response has KEY_DNE")
+	}
+}
+
+// --- GetSet: parseSetPayload error path (corrupt payload) ---
+
+func TestGetSetCorruptPayload(t *testing.T) {
+	client := newMockClientWithCorruptPayload("s")
+	_, err := client.GetSet("s")
+	if err == nil {
+		t.Fatal("expected error from GetSet with corrupt payload")
+	}
+}
+
+// --- PutSet: validateResponse error path ---
+
+func TestPutSetValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("s", kvspb.AnnaError_KEY_DNE)
+	err := client.PutSet("s", []string{"a", "b"})
+	if err == nil {
+		t.Fatal("expected error from PutSet when response has KEY_DNE")
+	}
+}
+
+// --- GetCausal: validateResponse error path ---
+
+func TestGetCausalValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("k", kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetCausal("k")
+	if err == nil {
+		t.Fatal("expected error from GetCausal when response has KEY_DNE")
+	}
+}
+
+// --- GetCausal: parseCausalPayload error path (corrupt payload) ---
+
+func TestGetCausalCorruptPayload(t *testing.T) {
+	client := newMockClientWithCorruptPayload("k")
+	_, err := client.GetCausal("k")
+	if err == nil {
+		t.Fatal("expected error from GetCausal with corrupt payload")
+	}
+}
+
+// --- PutCausal: validateResponse error path ---
+
+func TestPutCausalValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("k", kvspb.AnnaError_KEY_DNE)
+	err := client.PutCausal("k", "val")
+	if err == nil {
+		t.Fatal("expected error from PutCausal when response has KEY_DNE")
+	}
+}
+
+// --- GetOrderedSet: validateResponse error path ---
+
+func TestGetOrderedSetValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("os", kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetOrderedSet("os")
+	if err == nil {
+		t.Fatal("expected error from GetOrderedSet when response has KEY_DNE")
+	}
+}
+
+// --- GetOrderedSet: parseOrderedSetPayload error path (corrupt payload) ---
+
+func TestGetOrderedSetCorruptPayload(t *testing.T) {
+	client := newMockClientWithCorruptPayload("os")
+	_, err := client.GetOrderedSet("os")
+	if err == nil {
+		t.Fatal("expected error from GetOrderedSet with corrupt payload")
+	}
+}
+
+// --- PutOrderedSet: validateResponse error path ---
+
+func TestPutOrderedSetValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("os", kvspb.AnnaError_KEY_DNE)
+	err := client.PutOrderedSet("os", []string{"a", "b"})
+	if err == nil {
+		t.Fatal("expected error from PutOrderedSet when response has KEY_DNE")
+	}
+}
+
+// --- GetSingleCausal: validateResponse error path ---
+
+func TestGetSingleCausalValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("k", kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetSingleCausal("k")
+	if err == nil {
+		t.Fatal("expected error from GetSingleCausal when response has KEY_DNE")
+	}
+}
+
+// --- GetSingleCausal: parseSingleCausalPayload error path (corrupt payload) ---
+
+func TestGetSingleCausalCorruptPayload(t *testing.T) {
+	client := newMockClientWithCorruptPayload("k")
+	_, err := client.GetSingleCausal("k")
+	if err == nil {
+		t.Fatal("expected error from GetSingleCausal with corrupt payload")
+	}
+}
+
+// --- PutSingleCausal: validateResponse error path ---
+
+func TestPutSingleCausalValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("k", kvspb.AnnaError_KEY_DNE)
+	err := client.PutSingleCausal("k", "val")
+	if err == nil {
+		t.Fatal("expected error from PutSingleCausal when response has KEY_DNE")
+	}
+}
+
+// --- GetPriority: validateResponse error path ---
+
+func TestGetPriorityValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("p", kvspb.AnnaError_KEY_DNE)
+	_, _, err := client.GetPriority("p")
+	if err == nil {
+		t.Fatal("expected error from GetPriority when response has KEY_DNE")
+	}
+}
+
+// --- GetPriority: parsePriorityPayload error path (corrupt payload) ---
+
+func TestGetPriorityCorruptPayload(t *testing.T) {
+	client := newMockClientWithCorruptPayload("p")
+	_, _, err := client.GetPriority("p")
+	if err == nil {
+		t.Fatal("expected error from GetPriority with corrupt payload")
+	}
+}
+
+// --- PutPriority: validateResponse error path ---
+
+func TestPutPriorityValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("p", kvspb.AnnaError_KEY_DNE)
+	err := client.PutPriority("p", 1.0, "val")
+	if err == nil {
+		t.Fatal("expected error from PutPriority when response has KEY_DNE")
+	}
+}
+
+// --- GetBytes: validateResponse error path ---
+
+func TestGetBytesValidateResponseError(t *testing.T) {
+	client := newMockClientWithErrorResponse("k", kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetBytes("k")
+	if err == nil {
+		t.Fatal("expected error from GetBytes when response has KEY_DNE")
+	}
+}
+
+// --- GetBytes: parseLWWBytes error path (corrupt payload) ---
+
+func TestGetBytesCorruptPayload(t *testing.T) {
+	client := newMockClientWithCorruptPayload("k")
+	_, err := client.GetBytes("k")
+	if err == nil {
+		t.Fatal("expected error from GetBytes with corrupt payload")
+	}
+}
+
+// --- GetStorageStats: decode error path (corrupt inner bytes) ---
+
+func TestGetStorageStatsDecodeError(t *testing.T) {
+	metaKey := "ANNA_METADATA|stats|10.0.0.1|192.168.1.1|0|MEMORY"
+	client := newMockClientWithCorruptInnerBytes(metaKey)
+	_, err := client.GetStorageStats("10.0.0.1", "192.168.1.1", 0, "MEMORY")
+	if err == nil {
+		t.Fatal("expected error from GetStorageStats with corrupt inner bytes")
+	}
+}
+
+// --- GetKeyAccessStats: decode error path (corrupt inner bytes) ---
+
+func TestGetKeyAccessStatsDecodeError(t *testing.T) {
+	metaKey := "ANNA_METADATA|access|10.0.0.1|10.0.0.1|0|MEMORY"
+	client := newMockClientWithCorruptInnerBytes(metaKey)
+	_, err := client.GetKeyAccessStats("10.0.0.1", "10.0.0.1", 0, "MEMORY")
+	if err == nil {
+		t.Fatal("expected error from GetKeyAccessStats with corrupt inner bytes")
+	}
+}
+
+// --- GetKeySizeStats: decode error path (corrupt inner bytes) ---
+
+func TestGetKeySizeStatsDecodeError(t *testing.T) {
+	metaKey := "ANNA_METADATA|size|10.0.0.1|10.0.0.1|1|MEMORY"
+	client := newMockClientWithCorruptInnerBytes(metaKey)
+	_, err := client.GetKeySizeStats("10.0.0.1", "10.0.0.1", 1, "MEMORY")
+	if err == nil {
+		t.Fatal("expected error from GetKeySizeStats with corrupt inner bytes")
+	}
+}
+
+// --- PutReplicationFactor: validateResponse error path ---
+
+func TestPutReplicationFactorValidateResponseError(t *testing.T) {
+	metaKey := "ANNA_METADATA|replication|my_key"
+	client := newMockClientWithErrorResponse(metaKey, kvspb.AnnaError_KEY_DNE)
+	err := client.PutReplicationFactor("my_key", 3, 1)
+	if err == nil {
+		t.Fatal("expected error from PutReplicationFactor when response has KEY_DNE")
+	}
+}
+
+// --- GetClusterTopology: decode error path (corrupt inner bytes) ---
+
+func TestGetClusterTopologyDecodeError(t *testing.T) {
+	metaKey := "ANNA_METADATA|cluster_topology"
+	client := newMockClientWithCorruptInnerBytes(metaKey)
+	_, err := client.GetClusterTopology()
+	if err == nil {
+		t.Fatal("expected error from GetClusterTopology with corrupt inner bytes")
+	}
+}
+
+// --- GetMonitoringIPs: decode error path (corrupt inner bytes) ---
+
+func TestGetMonitoringIPsDecodeError(t *testing.T) {
+	metaKey := "ANNA_METADATA|monitoring_ips"
+	client := newMockClientWithCorruptInnerBytes(metaKey)
+	_, err := client.GetMonitoringIPs()
+	if err == nil {
+		t.Fatal("expected error from GetMonitoringIPs with corrupt inner bytes")
+	}
+}
+
+// --- GetTimeout: non-zmqTransport path (returns 0) ---
+
+func TestGetTimeoutWithMockTransport(t *testing.T) {
+	tp := &mockTransport{}
+	client := newTestClient(tp)
+	timeout := client.GetTimeout()
+	if timeout != 0 {
+		t.Errorf("expected timeout 0 for non-zmqTransport, got %v", timeout)
+	}
+}
+
+// --- SetTimeout: non-zmqTransport path (no-op) ---
+
+func TestSetTimeoutWithMockTransport(t *testing.T) {
+	tp := &mockTransport{}
+	client := newTestClient(tp)
+	// Should not panic; it's a no-op for non-zmqTransport
+	client.SetTimeout(5 * time.Second)
+	if client.GetTimeout() != 0 {
+		t.Errorf("expected timeout 0 for non-zmqTransport after SetTimeout, got %v", client.GetTimeout())
+	}
+}
+
+// --- queryRouting: recvResponse error path ---
+
+func TestQueryRoutingRecvError(t *testing.T) {
+	tp := &mockTransport{recvErr: fmt.Errorf("recv failed")}
+	client := newTestClient(tp)
+	addrs := client.queryRouting("key")
+	if addrs != nil {
+		t.Errorf("expected nil addresses on recv error, got %v", addrs)
+	}
+}
+
+// --- queryRouting: parseRoutingResponse error path (corrupt routing response) ---
+
+func TestQueryRoutingCorruptResponse(t *testing.T) {
+	tp := &mockTransport{recvData: map[bool][]byte{true: {0xff, 0xff}}}
+	client := newTestClient(tp)
+	addrs := client.queryRouting("key")
+	if addrs != nil {
+		t.Errorf("expected nil addresses on corrupt routing response, got %v", addrs)
+	}
+}
+
+// --- GetMulti: no worker address error ---
+
+func TestGetMultiNoWorkerAddress(t *testing.T) {
+	tp := &mockTransport{recvData: map[bool][]byte{true: nil}}
+	client := newTestClient(tp)
+	_, err := client.GetMulti([]string{"missing_key"})
+	if err == nil {
+		t.Fatal("expected error from GetMulti when no worker address found")
+	}
+}
+
+// --- GetMulti: send error ---
+
+func TestGetMultiSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetMulti([]string{"k"})
+	if err == nil {
+		t.Fatal("expected error from GetMulti on send failure")
+	}
+}
+
+// --- GetMulti: recv error ---
+
+func TestGetMultiRecvError(t *testing.T) {
+	tp := &mockTransport{recvErr: fmt.Errorf("recv failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetMulti([]string{"k"})
+	if err == nil {
+		t.Fatal("expected error from GetMulti on recv failure")
+	}
+}
+
+// --- GetMulti: timeout (nil data response) ---
+
+func TestGetMultiTimeout(t *testing.T) {
+	tp := &mockTransport{recvData: map[bool][]byte{false: nil}}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetMulti([]string{"k"})
+	if err == nil {
+		t.Fatal("expected error from GetMulti on timeout")
+	}
+}
+
+// --- GetMulti: decode error (corrupt response bytes) ---
+
+func TestGetMultiDecodeError(t *testing.T) {
+	tp := &mockTransport{recvData: map[bool][]byte{false: {0xff, 0xff}}}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetMulti([]string{"k"})
+	if err == nil {
+		t.Fatal("expected error from GetMulti with corrupt response bytes")
+	}
+}
+
+// --- GetMulti: LWW decode error (valid response but corrupt payload in tuple) ---
+
+func TestGetMultiLWWDecodeError(t *testing.T) {
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{
+			{Key: "k", Error: kvspb.AnnaError_NO_ERROR, Payload: []byte{0xff, 0xff}},
+		},
+	}
+	respBytes, _ := proto.Marshal(response)
+	tp := &mockTransport{recvData: map[bool][]byte{false: respBytes}}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetMulti([]string{"k"})
+	if err == nil {
+		t.Fatal("expected error from GetMulti with corrupt LWW payload")
+	}
+}
+
+// --- GetMulti: WRONG_THREAD retry path ---
+
+func TestGetMultiWrongThreadRetry(t *testing.T) {
+	// First response has WRONG_THREAD, second has success
+	wrongResponse := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{
+			{Key: "k", Error: kvspb.AnnaError_WRONG_THREAD},
+		},
+	}
+	wrongBytes, _ := proto.Marshal(wrongResponse)
+
+	lww := &kvspb.LWWValue{Timestamp: 100, Value: []byte("ok_val")}
+	lwwBytes, _ := proto.Marshal(lww)
+	okResponse := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{
+			{Key: "k", Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBytes},
+		},
+	}
+	okBytes, _ := proto.Marshal(okResponse)
+
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "k", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	tp := &sequencingMockTransport{
+		routingData:   routingBytes,
+		dataResponses: [][]byte{wrongBytes, okBytes},
+	}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+
+	results, err := client.GetMulti([]string{"k"})
+	if err != nil {
+		t.Fatalf("GetMulti with WRONG_THREAD retry failed: %v", err)
+	}
+	if results["k"] != "ok_val" {
+		t.Errorf("expected 'ok_val', got '%s'", results["k"])
+	}
+}
+
+// --- GetMulti: invalidate cache on tuple response ---
+
+func TestGetMultiInvalidateCache(t *testing.T) {
+	lww := &kvspb.LWWValue{Timestamp: 100, Value: []byte("val")}
+	lwwBytes, _ := proto.Marshal(lww)
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{
+			{Key: "k", Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBytes, Invalidate: true},
+		},
+	}
+	respBytes, _ := proto.Marshal(response)
+	tp := &mockTransport{recvData: map[bool][]byte{false: respBytes}}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+
+	results, err := client.GetMulti([]string{"k"})
+	if err != nil {
+		t.Fatalf("GetMulti failed: %v", err)
+	}
+	if results["k"] != "val" {
+		t.Errorf("expected 'val', got '%s'", results["k"])
+	}
+	if _, ok := client.keyAddressCache["k"]; ok {
+		t.Error("expected cache to be invalidated")
+	}
+}
+
+// --- Get: corrupt LWW payload in response ---
+
+func TestGetCorruptPayload(t *testing.T) {
+	client := newMockClientWithCorruptPayload("k")
+	_, err := client.Get("k")
+	if err == nil {
+		t.Fatal("expected error from Get with corrupt LWW payload")
+	}
+}
+
+// --- sendDataRequest: parseDataResponse error (corrupt response bytes) ---
+
+func TestSendDataRequestCorruptResponse(t *testing.T) {
+	tp := &mockTransport{recvData: map[bool][]byte{false: {0xff, 0xff}}}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.Get("k")
+	if err == nil {
+		t.Fatal("expected error from Get with corrupt data response")
+	}
+}
+
+// --- sendDataRequest: empty tuples in response (no tuples at all) ---
+
+func TestSendDataRequestEmptyTuples(t *testing.T) {
+	response := &kvspb.KeyResponse{}
+	respBytes, _ := proto.Marshal(response)
+	tp := &mockTransport{recvData: map[bool][]byte{false: respBytes}}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	// sendDataRequest succeeds but validateResponse inside Get will fail
+	_, err := client.Get("k")
+	if err == nil {
+		t.Fatal("expected error from Get with empty tuples response")
+	}
+}
+
+// --- Put/PutSet/PutCausal/PutOrderedSet/PutSingleCausal/PutPriority: sendDataRequest error paths ---
+
+func TestPutSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	err := client.Put("k", "val")
+	if err == nil {
+		t.Fatal("expected error from Put on send failure")
+	}
+}
+
+func TestPutSetSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["s"] = []string{"tcp://10.0.0.1:6800"}
+	err := client.PutSet("s", []string{"a"})
+	if err == nil {
+		t.Fatal("expected error from PutSet on send failure")
+	}
+}
+
+func TestPutCausalSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	err := client.PutCausal("k", "val")
+	if err == nil {
+		t.Fatal("expected error from PutCausal on send failure")
+	}
+}
+
+func TestPutOrderedSetSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["os"] = []string{"tcp://10.0.0.1:6800"}
+	err := client.PutOrderedSet("os", []string{"a"})
+	if err == nil {
+		t.Fatal("expected error from PutOrderedSet on send failure")
+	}
+}
+
+func TestPutSingleCausalSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	err := client.PutSingleCausal("k", "val")
+	if err == nil {
+		t.Fatal("expected error from PutSingleCausal on send failure")
+	}
+}
+
+func TestPutPrioritySendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["p"] = []string{"tcp://10.0.0.1:6800"}
+	err := client.PutPriority("p", 1.0, "val")
+	if err == nil {
+		t.Fatal("expected error from PutPriority on send failure")
+	}
+}
+
+func TestPutReplicationFactorSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	metaKey := "ANNA_METADATA|replication|my_key"
+	client.keyAddressCache[metaKey] = []string{"tcp://10.0.0.1:6800"}
+	err := client.PutReplicationFactor("my_key", 3, 1)
+	if err == nil {
+		t.Fatal("expected error from PutReplicationFactor on send failure")
+	}
+}
+
+// --- GetStorageStats/GetKeyAccessStats/GetKeySizeStats: GetBytes error path ---
+
+func TestGetStorageStatsGetBytesError(t *testing.T) {
+	metaKey := "ANNA_METADATA|stats|10.0.0.1|192.168.1.1|0|MEMORY"
+	client := newMockClientWithErrorResponse(metaKey, kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetStorageStats("10.0.0.1", "192.168.1.1", 0, "MEMORY")
+	if err == nil {
+		t.Fatal("expected error from GetStorageStats when GetBytes fails")
+	}
+}
+
+func TestGetKeyAccessStatsGetBytesError(t *testing.T) {
+	metaKey := "ANNA_METADATA|access|10.0.0.1|10.0.0.1|0|MEMORY"
+	client := newMockClientWithErrorResponse(metaKey, kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetKeyAccessStats("10.0.0.1", "10.0.0.1", 0, "MEMORY")
+	if err == nil {
+		t.Fatal("expected error from GetKeyAccessStats when GetBytes fails")
+	}
+}
+
+func TestGetKeySizeStatsGetBytesError(t *testing.T) {
+	metaKey := "ANNA_METADATA|size|10.0.0.1|10.0.0.1|1|MEMORY"
+	client := newMockClientWithErrorResponse(metaKey, kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetKeySizeStats("10.0.0.1", "10.0.0.1", 1, "MEMORY")
+	if err == nil {
+		t.Fatal("expected error from GetKeySizeStats when GetBytes fails")
+	}
+}
+
+// --- GetClusterTopology: GetBytes error path ---
+
+func TestGetClusterTopologyGetBytesError(t *testing.T) {
+	metaKey := "ANNA_METADATA|cluster_topology"
+	client := newMockClientWithErrorResponse(metaKey, kvspb.AnnaError_KEY_DNE)
+	_, err := client.GetClusterTopology()
+	if err == nil {
+		t.Fatal("expected error from GetClusterTopology when GetBytes fails")
+	}
+}
+
+// --- GetMonitoringIPs: GetBytes error returns empty slice (not error) ---
+
+func TestGetMonitoringIPsGetBytesError(t *testing.T) {
+	metaKey := "ANNA_METADATA|monitoring_ips"
+	client := newMockClientWithErrorResponse(metaKey, kvspb.AnnaError_KEY_DNE)
+	ips, err := client.GetMonitoringIPs()
+	if err != nil {
+		t.Fatalf("GetMonitoringIPs should not error when GetBytes fails, got: %v", err)
+	}
+	if len(ips) != 0 {
+		t.Errorf("expected empty IPs, got %v", ips)
+	}
+}
+
+// --- Get/GetSet/GetCausal/GetOrderedSet/GetSingleCausal/GetPriority/GetBytes: sendDataRequest error paths ---
+
+func TestGetSetSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["s"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetSet("s")
+	if err == nil {
+		t.Fatal("expected error from GetSet on send failure")
+	}
+}
+
+func TestGetCausalSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetCausal("k")
+	if err == nil {
+		t.Fatal("expected error from GetCausal on send failure")
+	}
+}
+
+func TestGetOrderedSetSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["os"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetOrderedSet("os")
+	if err == nil {
+		t.Fatal("expected error from GetOrderedSet on send failure")
+	}
+}
+
+func TestGetSingleCausalSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetSingleCausal("k")
+	if err == nil {
+		t.Fatal("expected error from GetSingleCausal on send failure")
+	}
+}
+
+func TestGetPrioritySendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["p"] = []string{"tcp://10.0.0.1:6800"}
+	_, _, err := client.GetPriority("p")
+	if err == nil {
+		t.Fatal("expected error from GetPriority on send failure")
+	}
+}
+
+func TestGetBytesSendError(t *testing.T) {
+	tp := &mockTransport{sendErr: fmt.Errorf("send failed")}
+	client := newTestClient(tp)
+	client.keyAddressCache["k"] = []string{"tcp://10.0.0.1:6800"}
+	_, err := client.GetBytes("k")
+	if err == nil {
+		t.Fatal("expected error from GetBytes on send failure")
+	}
+}
+
+// --- sendDataRequest: max retries exceeded via WRONG_THREAD on every attempt ---
+
+func TestSendDataRequestMaxRetriesExceeded(t *testing.T) {
+	wrongThreadResponse := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: "k", Error: kvspb.AnnaError_WRONG_THREAD}},
+	}
+	wrongBytes, _ := proto.Marshal(wrongThreadResponse)
+
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "k", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	// Return WRONG_THREAD for all attempts (maxRetries+1 = 6)
+	responses := make([][]byte, 10)
+	for i := range responses {
+		responses[i] = wrongBytes
+	}
+	tp := &sequencingMockTransport{
+		routingData:   routingBytes,
+		dataResponses: responses,
+	}
+	client := newTestClient(tp)
+
+	_, err := client.Get("k")
+	if err == nil {
+		t.Fatal("expected error after max retries exceeded")
+	}
+	kvsErr, ok := err.(*KVSError)
+	if !ok {
+		t.Fatalf("expected KVSError, got %T", err)
+	}
+	// On the last attempt, WRONG_THREAD with attempt == maxRetries falls through
+	// to validateResponse, which returns "GET: WRONG_THREAD"
+	if kvsErr.Message != "GET: WRONG_THREAD" {
+		t.Errorf("unexpected error message: %s", kvsErr.Message)
+	}
+}
+
+// --- sendDataRequest: timeout on all retries triggers "request timed out" ---
+
+func TestSendDataRequestTimeoutAllRetries(t *testing.T) {
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "k", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	// Return nil (timeout) for all data responses, but valid routing data
+	tp := &sequencingMockTransport{
+		routingData:   routingBytes,
+		dataResponses: [][]byte{nil, nil, nil, nil, nil, nil, nil},
+	}
+	client := newTestClient(tp)
+
+	_, err := client.Get("k")
+	if err == nil {
+		t.Fatal("expected error after timeout on all retries")
+	}
+	kvsErr, ok := err.(*KVSError)
+	if !ok {
+		t.Fatalf("expected KVSError, got %T", err)
+	}
+	if kvsErr.Message != "k: request timed out" {
+		t.Errorf("unexpected error message: %s", kvsErr.Message)
+	}
+}
+
+// --- NewKVSClient: keyAddressPuller bind error (port conflict) ---
+
+func TestNewKVSClientKeyAddressPullerBindError(t *testing.T) {
+	// Create a client that binds on tid=507
+	client1, err := NewKVSClient(DefaultClientConfig(), 507)
+	if err != nil {
+		t.Fatalf("first client failed: %v", err)
+	}
+	defer client1.Close()
+
+	// Second client on same tid should fail to bind the key address puller
+	_, err = NewKVSClient(DefaultClientConfig(), 507)
+	if err == nil {
+		t.Fatal("expected error when key address puller port is already bound")
+	}
+}
+
+// --- NewKVSClient: responsePuller bind error (port conflict) ---
+
+func TestNewKVSClientResponsePullerBindError(t *testing.T) {
+	// Block only the response puller port (tid+6800) but leave key address port free.
+	// tid=508 → response port 7308, key address port 7358
+	ctx := context.Background()
+	blocker := zmq4.NewPull(ctx)
+	responsePort := 508 + kUserResponsePort // 7308
+	if err := blocker.Listen(fmt.Sprintf("tcp://0.0.0.0:%d", responsePort)); err != nil {
+		t.Fatalf("failed to block response port: %v", err)
+	}
+	defer blocker.Close()
+
+	_, err := NewKVSClient(DefaultClientConfig(), 508)
+	if err == nil {
+		t.Fatal("expected error when response puller port is already bound")
+	}
+}
+
+// --- queryRouting: routing response with error code ---
+
+func TestQueryRoutingResponseError(t *testing.T) {
+	routingResp := &kvspb.KeyAddressResponse{
+		Error: kvspb.AnnaError_NO_SERVERS,
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+	tp := &mockTransport{recvData: map[bool][]byte{true: routingBytes}}
+	client := newTestClient(tp)
+
+	addrs := client.queryRouting("key")
+	if addrs != nil {
+		t.Errorf("expected nil addresses on routing error, got %v", addrs)
 	}
 }

--- a/clients/python/anna/client.py
+++ b/clients/python/anna/client.py
@@ -20,7 +20,7 @@ import zmq
 from .kvs_pb2 import (
     GET, PUT,  # Anna's request types
     LWW,  # Anna's lattice types
-    NO_ERROR,  # Anna's error modes
+    NO_ERROR, WRONG_THREAD,  # Anna's error modes
     KeyAddressRequest,
     KeyAddressResponse,
     KeyResponse,
@@ -29,11 +29,13 @@ from .kvs_pb2 import (
 )
 from .metadata_pb2 import (
     MEMORY, DISK,
+    ClusterTopology,
     KeyAccessData,
     KeySizeData,
     ReplicationFactor,
     ServerThreadStatistics,
 )
+from .shared_pb2 import StringSet
 from .base_client import BaseAnnaClient
 from .common import UserThread
 from .lattices import (
@@ -97,43 +99,56 @@ class AnnaTcpClient(BaseAnnaClient):
         self.key_address_puller.bind(self.ut.get_key_address_bind_addr())
 
         self.rid = 0
+        self._max_retries = 5
 
     def get(self, keys):
         if type(keys) != list:
             keys = [keys]
 
-        worker_addresses = {}
-        for key in keys:
-            worker_addresses[key] = (self._get_worker_address(key))
-
-        # Initialize all KV pairs to 0. Only change a value if we get a valid
-        # response from the server.
+        # Initialize all KV pairs to None. Only change a value if we get a
+        # valid response from the server.
         kv_pairs = {}
         for key in keys:
             kv_pairs[key] = None
 
-        request_ids = []
-        for key in worker_addresses:
-            if worker_addresses[key]:
-                send_sock = self.pusher_cache.get(worker_addresses[key])
+        pending = list(keys)
+        for attempt in range(self._max_retries + 1):
+            if not pending:
+                break
 
-                req, _ = self._prepare_data_request([key])
-                req.type = GET
+            worker_addresses = {}
+            for key in pending:
+                worker_addresses[key] = self._get_worker_address(key)
 
-                send_request(req, send_sock)
-                request_ids.append(req.request_id)
+            request_ids = []
+            for key in worker_addresses:
+                if worker_addresses[key]:
+                    send_sock = self.pusher_cache.get(worker_addresses[key])
 
-        # Wait for all responses to return.
-        responses = recv_response(request_ids, self.response_puller,
-                                  KeyResponse)
+                    req, _ = self._prepare_data_request([key])
+                    req.type = GET
 
-        for response in responses:
-            for tup in response.tuples:
-                if tup.invalidate:
-                    self._invalidate_cache(tup.key)
+                    send_request(req, send_sock)
+                    request_ids.append(req.request_id)
 
-                if tup.error == NO_ERROR:
-                    kv_pairs[tup.key] = self._deserialize(tup)
+            # Wait for all responses to return.
+            responses = recv_response(request_ids, self.response_puller,
+                                      KeyResponse)
+
+            retry_keys = []
+            for response in responses:
+                for tup in response.tuples:
+                    if tup.invalidate:
+                        self._invalidate_cache(tup.key)
+
+                    if tup.error == WRONG_THREAD and attempt < self._max_retries:
+                        if tup.key in self.address_cache:
+                            self._invalidate_cache(tup.key)
+                        retry_keys.append(tup.key)
+                    elif tup.error == NO_ERROR:
+                        kv_pairs[tup.key] = self._deserialize(tup)
+
+            pending = retry_keys
 
         return kv_pairs
 
@@ -183,44 +198,56 @@ class AnnaTcpClient(BaseAnnaClient):
         return kv_pairs
 
     def put(self, keys, values):
-        request_ids = []
-
         if type(keys) != list:
             keys = [keys]
         if type(values) != list:
             values = [values]
 
-        for key, value in zip(keys, values):
-            worker_address = self._get_worker_address(key)
-
-            if not worker_address:
-                return False
-
-            send_sock = self.pusher_cache.get(worker_address)
-
-            # We pass in a list because the data request preparation can prepare
-            # multiple tuples
-            req, tup = self._prepare_data_request([key])
-            req.type = PUT
-            request_ids.append(req.request_id)
-
-            # PUT only supports one key operations, we only ever have to look at
-            # the first KeyTuple returned.
-            tup = tup[0]
-            tup.payload, tup.lattice_type = self._serialize(value)
-
-            send_request(req, send_sock)
-
-        responses = recv_response(request_ids, self.response_puller, KeyResponse)
-
+        kv_map = dict(zip(keys, values))
+        pending = list(kv_map.keys())
         results = {}
-        for response in responses:
-            tup = response.tuples[0]
 
-            if tup.invalidate:
-                self._invalidate_cache(tup.key)
+        for attempt in range(self._max_retries + 1):
+            if not pending:
+                break
 
-            results[tup.key] = (tup.error == NO_ERROR)
+            request_ids = []
+            for key in pending:
+                value = kv_map[key]
+                worker_address = self._get_worker_address(key)
+
+                if not worker_address:
+                    return False
+
+                send_sock = self.pusher_cache.get(worker_address)
+
+                req, tup = self._prepare_data_request([key])
+                req.type = PUT
+                request_ids.append(req.request_id)
+
+                tup = tup[0]
+                tup.payload, tup.lattice_type = self._serialize(value)
+
+                send_request(req, send_sock)
+
+            responses = recv_response(request_ids, self.response_puller,
+                                      KeyResponse)
+
+            retry_keys = []
+            for response in responses:
+                tup = response.tuples[0]
+
+                if tup.invalidate:
+                    self._invalidate_cache(tup.key)
+
+                if tup.error == WRONG_THREAD and attempt < self._max_retries:
+                    if tup.key in self.address_cache:
+                        self._invalidate_cache(tup.key)
+                    retry_keys.append(tup.key)
+                else:
+                    results[tup.key] = (tup.error == NO_ERROR)
+
+            pending = retry_keys
 
         return results
 
@@ -337,26 +364,36 @@ class AnnaTcpClient(BaseAnnaClient):
 
         Returns None if the key does not exist or an error occurs.
         """
-        worker_address = self._get_worker_address(key)
-        if not worker_address:
-            return None
+        for attempt in range(self._max_retries + 1):
+            worker_address = self._get_worker_address(key)
+            if not worker_address:
+                return None
 
-        send_sock = self.pusher_cache.get(worker_address)
-        req, _ = self._prepare_data_request([key])
-        req.type = GET
+            send_sock = self.pusher_cache.get(worker_address)
+            req, _ = self._prepare_data_request([key])
+            req.type = GET
 
-        send_request(req, send_sock)
-        responses = recv_response([req.request_id], self.response_puller,
-                                  KeyResponse)
+            send_request(req, send_sock)
+            responses = recv_response([req.request_id], self.response_puller,
+                                      KeyResponse)
 
-        for response in responses:
-            for tup in response.tuples:
-                if tup.invalidate:
-                    self._invalidate_cache(tup.key)
-                if tup.error == NO_ERROR:
-                    lww_val = LWWValue()
-                    lww_val.ParseFromString(tup.payload)
-                    return lww_val.value
+            for response in responses:
+                for tup in response.tuples:
+                    if tup.invalidate:
+                        self._invalidate_cache(tup.key)
+                    if tup.error == WRONG_THREAD and attempt < self._max_retries:
+                        if tup.key in self.address_cache:
+                            self._invalidate_cache(tup.key)
+                        break
+                    if tup.error == NO_ERROR:
+                        lww_val = LWWValue()
+                        lww_val.ParseFromString(tup.payload)
+                        return lww_val.value
+                else:
+                    # Inner loop completed without break (no WRONG_THREAD)
+                    return None
+                # WRONG_THREAD was encountered, continue outer retry loop
+                continue
 
         return None
 
@@ -454,6 +491,42 @@ class AnnaTcpClient(BaseAnnaClient):
         ts = time.time_ns()
         val = LWWPairLattice(ts, payload)
         return self.put(meta_key, val)
+
+    def get_cluster_topology(self):
+        """
+        Retrieves cluster topology (thread counts) from the metadata key
+        ANNA_METADATA|cluster_topology.
+
+        Returns a dict with routing_thread_count, memory_thread_count,
+        ebs_thread_count, or None if the key does not exist.
+        """
+        raw = self.get_bytes("ANNA_METADATA|cluster_topology")
+        if raw is None:
+            return None
+
+        topology = ClusterTopology()
+        topology.ParseFromString(raw)
+        return {
+            'routing_thread_count': topology.routing_thread_count,
+            'memory_thread_count': topology.memory_thread_count,
+            'ebs_thread_count': topology.ebs_thread_count,
+        }
+
+    def get_monitoring_ips(self):
+        """
+        Retrieves monitoring node IP addresses from the metadata key
+        ANNA_METADATA|monitoring_ips.
+
+        Returns a list of IP address strings, or an empty list if the key
+        does not exist.
+        """
+        raw = self.get_bytes("ANNA_METADATA|monitoring_ips")
+        if raw is None:
+            return []
+
+        string_set = StringSet()
+        string_set.ParseFromString(raw)
+        return list(string_set.keys)
 
     # Returns and increments a request ID. Loops back after 10,000 requests.
     def _get_request_id(self):

--- a/clients/python/anna/client.py
+++ b/clients/python/anna/client.py
@@ -57,29 +57,31 @@ from .zmq_util import (
 
 
 class AnnaTcpClient(BaseAnnaClient):
-    def __init__(self, elb_addr, ip, local=False, offset=0):
+    def __init__(self, elb_addr, ip, local=False, offset=0, base_offset=0):
         """
-        The AnnaTcpClientTcpAnnaClient allows you to interact with a local
-        copy of Anna or with a remote cluster running on AWS.
+        The AnnaTcpClient allows you to interact with a local copy of Anna
+        or with a remote cluster running on AWS.
 
         elb_addr: Either 127.0.0.1 (local mode) or the address of an AWS ELB
         for the routing tier
         ip: The IP address of the machine being used -- if None is provided,
         one is inferred by using socket.gethostbyname(); WARNING: this does not
         always work
-        elb_ports: The ports on which the routing tier will listen; use 6450 if
-        running in local mode, otherwise do not change
-        offset: A port numbering offset, which is only needed if multiple
-        clients are running on the same machine
+        offset: A port numbering offset for this client's own sockets, needed
+        if multiple clients run on the same machine
+        base_offset: Cluster-wide port offset applied to routing tier ports,
+        matching the server's ports.base_offset config value
         """
 
         super().__init__()
         self.elb_addr = elb_addr
+        self.base_offset = base_offset
 
         if local:
-            self.elb_ports = [6450]
+            self.elb_ports = [6450 + base_offset]
         else:
-            self.elb_ports = list(range(6450, 6454))
+            self.elb_ports = [p + base_offset
+                              for p in range(6450, 6454)]
 
         if ip:
             self.ut = UserThread(ip, offset)
@@ -100,6 +102,15 @@ class AnnaTcpClient(BaseAnnaClient):
 
         self.rid = 0
         self._max_retries = 5
+        self._timeout_ms = 10000
+
+    def set_timeout(self, timeout_ms):
+        """Set the request timeout in milliseconds."""
+        self._timeout_ms = timeout_ms
+
+    def get_timeout(self):
+        """Get the current request timeout in milliseconds."""
+        return self._timeout_ms
 
     def get(self, keys):
         if type(keys) != list:
@@ -133,7 +144,7 @@ class AnnaTcpClient(BaseAnnaClient):
 
             # Wait for all responses to return.
             responses = recv_response(request_ids, self.response_puller,
-                                      KeyResponse)
+                                      KeyResponse, self._timeout_ms)
 
             retry_keys = []
             for response in responses:
@@ -142,7 +153,10 @@ class AnnaTcpClient(BaseAnnaClient):
                         self._invalidate_cache(tup.key)
 
                     if tup.error == WRONG_THREAD and attempt < self._max_retries:
-                        if tup.key in self.address_cache:
+                        worker = worker_addresses.get(tup.key)
+                        if worker:
+                            self._evict_address(tup.key, worker)
+                        elif tup.key in self.address_cache:
                             self._invalidate_cache(tup.key)
                         retry_keys.append(tup.key)
                     elif tup.error == NO_ERROR:
@@ -151,6 +165,73 @@ class AnnaTcpClient(BaseAnnaClient):
             pending = retry_keys
 
         return kv_pairs
+
+    def get_multi(self, keys):
+        """Retrieve multiple keys, batching requests by worker address.
+
+        Returns a dict mapping key to deserialized value for all keys
+        successfully retrieved. Keys with errors (KEY_DNE, etc.) are
+        omitted from the result.
+        """
+        if not keys:
+            return {}
+
+        max_retries = 3
+        results = {}
+        pending = list(keys)
+
+        for attempt in range(max_retries + 1):
+            if not pending:
+                break
+
+            # Group keys by worker address.
+            worker_keys = {}
+            for key in pending:
+                worker = self._get_worker_address(key)
+                if not worker:
+                    continue
+                worker_keys.setdefault(worker, []).append(key)
+
+            retry_keys = []
+            request_ids = []
+            worker_for_rid = {}
+
+            for worker, batch_keys in worker_keys.items():
+                send_sock = self.pusher_cache.get(worker)
+                req = KeyRequest()
+                req.request_id = self._get_request_id()
+                req.response_address = self.response_address
+                req.type = GET
+
+                for key in batch_keys:
+                    tup = req.tuples.add()
+                    tup.key = key
+                    if key in self.address_cache:
+                        tup.address_cache_size = len(self.address_cache[key])
+
+                send_request(req, send_sock)
+                request_ids.append(req.request_id)
+                worker_for_rid[req.request_id] = (worker, batch_keys)
+
+            responses = recv_response(request_ids, self.response_puller,
+                                      KeyResponse, self._timeout_ms)
+
+            for response in responses:
+                for tup in response.tuples:
+                    if tup.invalidate:
+                        if tup.key in self.address_cache:
+                            self._invalidate_cache(tup.key)
+                    if tup.error == WRONG_THREAD:
+                        if tup.key in self.address_cache:
+                            self._invalidate_cache(tup.key)
+                        if attempt < max_retries:
+                            retry_keys.append(tup.key)
+                    elif tup.error == NO_ERROR:
+                        results[tup.key] = self._deserialize(tup)
+
+            pending = retry_keys
+
+        return results
 
     def get_all(self, keys):
         if type(keys) != list or not keys:
@@ -180,7 +261,8 @@ class AnnaTcpClient(BaseAnnaClient):
 
                 req_ids.append(req.request_id)
 
-        responses = recv_response(req_ids, self.response_puller, KeyResponse)
+        responses = recv_response(req_ids, self.response_puller, KeyResponse,
+                                  self._timeout_ms)
 
         for resp in responses:
             for tup in resp.tuples:
@@ -211,6 +293,7 @@ class AnnaTcpClient(BaseAnnaClient):
             if not pending:
                 break
 
+            worker_addresses = {}
             request_ids = []
             for key in pending:
                 value = kv_map[key]
@@ -219,6 +302,7 @@ class AnnaTcpClient(BaseAnnaClient):
                 if not worker_address:
                     return False
 
+                worker_addresses[key] = worker_address
                 send_sock = self.pusher_cache.get(worker_address)
 
                 req, tup = self._prepare_data_request([key])
@@ -231,7 +315,7 @@ class AnnaTcpClient(BaseAnnaClient):
                 send_request(req, send_sock)
 
             responses = recv_response(request_ids, self.response_puller,
-                                      KeyResponse)
+                                      KeyResponse, self._timeout_ms)
 
             retry_keys = []
             for response in responses:
@@ -241,7 +325,10 @@ class AnnaTcpClient(BaseAnnaClient):
                     self._invalidate_cache(tup.key)
 
                 if tup.error == WRONG_THREAD and attempt < self._max_retries:
-                    if tup.key in self.address_cache:
+                    worker = worker_addresses.get(tup.key)
+                    if worker:
+                        self._evict_address(tup.key, worker)
+                    elif tup.key in self.address_cache:
                         self._invalidate_cache(tup.key)
                     retry_keys.append(tup.key)
                 else:
@@ -271,7 +358,8 @@ class AnnaTcpClient(BaseAnnaClient):
 
             req_ids.append(req.request_id)
 
-        responses = recv_response(req_ids, self.response_puller, KeyResponse)
+        responses = recv_response(req_ids, self.response_puller, KeyResponse,
+                                  self._timeout_ms)
 
         for resp in responses:
             tup = resp.tuples[0]
@@ -306,6 +394,20 @@ class AnnaTcpClient(BaseAnnaClient):
     # the client that its cache is out of date.
     def _invalidate_cache(self, key):
         del self.address_cache[key]
+
+    def _evict_address(self, key, addr):
+        """Remove a specific worker address from the cache for a key.
+
+        If the key's address list becomes empty, the key is removed entirely
+        (forcing a routing re-query on next access).
+        """
+        if key not in self.address_cache:
+            return
+        addrs = self.address_cache[key]
+        if addr in addrs:
+            addrs.remove(addr)
+        if not addrs:
+            del self.address_cache[key]
 
     def get_causal(self, key):
         result = self.get([key])
@@ -375,7 +477,7 @@ class AnnaTcpClient(BaseAnnaClient):
 
             send_request(req, send_sock)
             responses = recv_response([req.request_id], self.response_puller,
-                                      KeyResponse)
+                                      KeyResponse, self._timeout_ms)
 
             for response in responses:
                 for tup in response.tuples:
@@ -573,7 +675,8 @@ class AnnaTcpClient(BaseAnnaClient):
         send_request(key_request, send_sock)
         response = recv_response([key_request.request_id],
                                  self.key_address_puller,
-                                 KeyAddressResponse)[0]
+                                 KeyAddressResponse,
+                                 self._timeout_ms)[0]
 
         if response.error != 0:
             return []

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -129,7 +129,7 @@ class TestGet:
         with patch("anna.client.send_request") as mock_send, \
              patch("anna.client.recv_response") as mock_recv:
             # Make recv_response return our prepared response, matching any request ID
-            def recv_side_effect(req_ids, sock, cls):
+            def recv_side_effect(req_ids, sock, cls, timeout=10000):
                 response.response_id = req_ids[0]
                 return [response]
             mock_recv.side_effect = recv_side_effect
@@ -158,7 +158,7 @@ class TestPut:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            def recv_side_effect(req_ids, sock, cls):
+            def recv_side_effect(req_ids, sock, cls, timeout=10000):
                 response.response_id = req_ids[0]
                 return [response]
             mock_recv.side_effect = recv_side_effect
@@ -200,7 +200,7 @@ class TestGetWithInvalidate:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: [response]
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: [response]
             result = client.get("mykey")
 
         assert "mykey" not in client.address_cache
@@ -225,7 +225,7 @@ class TestPutWithInvalidate:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: [response]
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: [response]
             val = LWWPairLattice(1, b"world")
             result = client.put("mykey", val)
 
@@ -275,7 +275,7 @@ class TestGetBytesNoneAtEnd:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: [response]
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: [response]
             result = client.get_bytes("mykey")
 
         assert result is None
@@ -401,7 +401,7 @@ class TestGetBytesInvalidate:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: [response]
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: [response]
             result = client.get_bytes(meta_key)
 
         assert result == b"data"
@@ -417,7 +417,7 @@ class TestGetBytesNoResponse:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: []
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: []
             result = client.get_bytes("k")
 
         assert result is None
@@ -484,7 +484,7 @@ class TestGetAll:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: [response]
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: [response]
             result = client.get_all(["k1"])
 
         assert "k1" in result
@@ -521,7 +521,7 @@ class TestGetAll:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: [response]
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: [response]
             result = client.get_all(["k1"])
 
         assert "k1" not in client.address_cache
@@ -560,7 +560,7 @@ class TestGetAll:
 
         with patch("anna.client.send_request") as mock_send, \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: [response1, response2]
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: [response1, response2]
             result = client.get_all(["k1"])
 
         assert "k1" in result
@@ -619,7 +619,7 @@ class TestWrongThreadRetry:
              patch("anna.client.recv_response") as mock_recv, \
              patch.object(client, '_get_worker_address',
                           side_effect=get_worker_side_effect):
-            def recv_side_effect(req_ids, sock, cls):
+            def recv_side_effect(req_ids, sock, cls, timeout=10000):
                 call_count[0] += 1
                 if call_count[0] == 1:
                     wrong_response.response_id = req_ids[0]
@@ -666,7 +666,7 @@ class TestWrongThreadRetry:
              patch("anna.client.recv_response") as mock_recv, \
              patch.object(client, '_get_worker_address',
                           side_effect=get_worker_side_effect):
-            def recv_side_effect(req_ids, sock, cls):
+            def recv_side_effect(req_ids, sock, cls, timeout=10000):
                 call_count[0] += 1
                 if call_count[0] == 1:
                     wrong_response.response_id = req_ids[0]
@@ -680,6 +680,92 @@ class TestWrongThreadRetry:
 
         assert result["mykey"] is True
         assert call_count[0] == 2
+
+
+class TestGetMulti:
+    def test_returns_multiple_values(self):
+        client = make_client()
+        client.address_cache["a"] = ["tcp://127.0.0.1:6200"]
+        client.address_cache["b"] = ["tcp://127.0.0.1:6200"]
+
+        lww_a = LWWValue()
+        lww_a.timestamp = 1
+        lww_a.value = b"val_a"
+        lww_b = LWWValue()
+        lww_b.timestamp = 1
+        lww_b.value = b"val_b"
+
+        response = KeyResponse()
+        response.response_id = "placeholder"
+        tup_a = response.tuples.add()
+        tup_a.key = "a"
+        tup_a.lattice_type = LWW
+        tup_a.payload = lww_a.SerializeToString()
+        tup_a.error = NO_ERROR
+        tup_b = response.tuples.add()
+        tup_b.key = "b"
+        tup_b.lattice_type = LWW
+        tup_b.payload = lww_b.SerializeToString()
+        tup_b.error = NO_ERROR
+
+        mock_send_sock = MagicMock()
+        client.pusher_cache = MagicMock()
+        client.pusher_cache.get.return_value = mock_send_sock
+
+        with patch("anna.client.send_request"), \
+             patch("anna.client.recv_response") as mock_recv:
+            def recv_side_effect(req_ids, sock, cls, timeout=10000):
+                response.response_id = req_ids[0]
+                return [response]
+            mock_recv.side_effect = recv_side_effect
+
+            result = client.get_multi(["a", "b"])
+
+        assert "a" in result
+        assert "b" in result
+        assert isinstance(result["a"], LWWPairLattice)
+        assert result["a"].reveal() == b"val_a"
+
+    def test_empty_keys_returns_empty(self):
+        client = make_client()
+        result = client.get_multi([])
+        assert result == {}
+
+
+class TestEvictAddress:
+    def test_removes_single_address(self):
+        client = make_client()
+        client.address_cache["k"] = ["addr1", "addr2"]
+        client._evict_address("k", "addr1")
+        assert client.address_cache["k"] == ["addr2"]
+
+    def test_removes_key_when_last(self):
+        client = make_client()
+        client.address_cache["k"] = ["addr1"]
+        client._evict_address("k", "addr1")
+        assert "k" not in client.address_cache
+
+    def test_nonexistent_key(self):
+        client = make_client()
+        # Should not raise
+        client._evict_address("nonexistent", "addr1")
+
+    def test_nonexistent_address(self):
+        client = make_client()
+        client.address_cache["k"] = ["addr1"]
+        client._evict_address("k", "addr2")
+        assert client.address_cache["k"] == ["addr1"]
+
+
+class TestConfigurableTimeout:
+    def test_default_timeout(self):
+        client = make_client()
+        assert client.get_timeout() == 10000
+
+    def test_set_timeout(self):
+        client = make_client()
+        client.set_timeout(5000)
+        assert client.get_timeout() == 5000
 
 
 class TestResponseAddress:

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock, patch, PropertyMock
 import pytest
 
 from anna.kvs_pb2 import (
-    LWW, SET, NO_ERROR, KeyResponse, KeyTuple, LWWValue, SetValue,
-    KeyAddressResponse,
+    LWW, SET, NO_ERROR, WRONG_THREAD, KeyResponse, KeyTuple, LWWValue,
+    SetValue, KeyAddressResponse,
 )
 from anna.lattices import LWWPairLattice, SetLattice
 
@@ -576,6 +576,110 @@ class TestPutAll:
             val = LWWPairLattice(1, b"data")
             result = client.put_all("k", val)
         assert result is False
+
+
+class TestWrongThreadRetry:
+    def test_get_retries_on_wrong_thread(self):
+        client = make_client()
+        client.address_cache["mykey"] = ["tcp://127.0.0.1:6200"]
+
+        # First response: WRONG_THREAD
+        wrong_response = KeyResponse()
+        wrong_response.response_id = "placeholder"
+        wrong_tup = wrong_response.tuples.add()
+        wrong_tup.key = "mykey"
+        wrong_tup.error = WRONG_THREAD
+
+        # Second response: success
+        lww_val = LWWValue()
+        lww_val.timestamp = 1
+        lww_val.value = b"success"
+
+        ok_response = KeyResponse()
+        ok_response.response_id = "placeholder"
+        ok_tup = ok_response.tuples.add()
+        ok_tup.key = "mykey"
+        ok_tup.lattice_type = LWW
+        ok_tup.payload = lww_val.SerializeToString()
+        ok_tup.error = NO_ERROR
+
+        mock_send_sock = MagicMock()
+        client.pusher_cache = MagicMock()
+        client.pusher_cache.get.return_value = mock_send_sock
+
+        call_count = [0]
+
+        def get_worker_side_effect(key, pick=True):
+            # Re-populate cache on retry (simulates routing query)
+            client.address_cache[key] = ["tcp://127.0.0.1:6200"]
+            return "tcp://127.0.0.1:6200" if pick else \
+                ["tcp://127.0.0.1:6200"]
+
+        with patch("anna.client.send_request"), \
+             patch("anna.client.recv_response") as mock_recv, \
+             patch.object(client, '_get_worker_address',
+                          side_effect=get_worker_side_effect):
+            def recv_side_effect(req_ids, sock, cls):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    wrong_response.response_id = req_ids[0]
+                    return [wrong_response]
+                ok_response.response_id = req_ids[0]
+                return [ok_response]
+            mock_recv.side_effect = recv_side_effect
+
+            result = client.get("mykey")
+
+        assert "mykey" in result
+        assert isinstance(result["mykey"], LWWPairLattice)
+        assert result["mykey"].reveal() == b"success"
+        assert call_count[0] == 2
+
+    def test_put_retries_on_wrong_thread(self):
+        client = make_client()
+        client.address_cache["mykey"] = ["tcp://127.0.0.1:6200"]
+
+        wrong_response = KeyResponse()
+        wrong_response.response_id = "placeholder"
+        wrong_tup = wrong_response.tuples.add()
+        wrong_tup.key = "mykey"
+        wrong_tup.error = WRONG_THREAD
+
+        ok_response = KeyResponse()
+        ok_response.response_id = "placeholder"
+        ok_tup = ok_response.tuples.add()
+        ok_tup.key = "mykey"
+        ok_tup.error = NO_ERROR
+
+        mock_send_sock = MagicMock()
+        client.pusher_cache = MagicMock()
+        client.pusher_cache.get.return_value = mock_send_sock
+
+        call_count = [0]
+
+        def get_worker_side_effect(key, pick=True):
+            client.address_cache[key] = ["tcp://127.0.0.1:6200"]
+            return "tcp://127.0.0.1:6200" if pick else \
+                ["tcp://127.0.0.1:6200"]
+
+        with patch("anna.client.send_request"), \
+             patch("anna.client.recv_response") as mock_recv, \
+             patch.object(client, '_get_worker_address',
+                          side_effect=get_worker_side_effect):
+            def recv_side_effect(req_ids, sock, cls):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    wrong_response.response_id = req_ids[0]
+                    return [wrong_response]
+                ok_response.response_id = req_ids[0]
+                return [ok_response]
+            mock_recv.side_effect = recv_side_effect
+
+            val = LWWPairLattice(1, b"data")
+            result = client.put("mykey", val)
+
+        assert result["mykey"] is True
+        assert call_count[0] == 2
 
 
 class TestResponseAddress:

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -608,8 +608,15 @@ class TestWrongThreadRetry:
         client.pusher_cache.get.return_value = mock_send_sock
 
         call_count = [0]
+        lookup_count = [0]
 
         def get_worker_side_effect(key, pick=True):
+            lookup_count[0] += 1
+            if lookup_count[0] == 2:
+                # On the second lookup the cache must have been
+                # invalidated by the WRONG_THREAD handler.
+                assert key not in client.address_cache, \
+                    "expected address_cache to be invalidated before retry"
             # Re-populate cache on retry (simulates routing query)
             client.address_cache[key] = ["tcp://127.0.0.1:6200"]
             return "tcp://127.0.0.1:6200" if pick else \
@@ -634,6 +641,7 @@ class TestWrongThreadRetry:
         assert isinstance(result["mykey"], LWWPairLattice)
         assert result["mykey"].reveal() == b"success"
         assert call_count[0] == 2
+        assert lookup_count[0] == 2
 
     def test_put_retries_on_wrong_thread(self):
         client = make_client()
@@ -656,8 +664,15 @@ class TestWrongThreadRetry:
         client.pusher_cache.get.return_value = mock_send_sock
 
         call_count = [0]
+        lookup_count = [0]
 
         def get_worker_side_effect(key, pick=True):
+            lookup_count[0] += 1
+            if lookup_count[0] == 2:
+                # On the second lookup the cache must have been
+                # invalidated by the WRONG_THREAD handler.
+                assert key not in client.address_cache, \
+                    "expected address_cache to be invalidated before retry"
             client.address_cache[key] = ["tcp://127.0.0.1:6200"]
             return "tcp://127.0.0.1:6200" if pick else \
                 ["tcp://127.0.0.1:6200"]
@@ -680,6 +695,7 @@ class TestWrongThreadRetry:
 
         assert result["mykey"] is True
         assert call_count[0] == 2
+        assert lookup_count[0] == 2
 
 
 class TestGetMulti:

--- a/clients/python/tests/test_stats_helpers.py
+++ b/clients/python/tests/test_stats_helpers.py
@@ -183,7 +183,7 @@ class TestGetBytes:
 
         with patch("anna.client.send_request"), \
              patch("anna.client.recv_response") as mock_recv:
-            mock_recv.side_effect = lambda ids, sock, cls: [response]
+            mock_recv.side_effect = lambda ids, sock, cls, timeout=10000: [response]
             result = client.get_bytes(meta_key)
 
         assert result == inner

--- a/clients/python/tests/test_stats_helpers.py
+++ b/clients/python/tests/test_stats_helpers.py
@@ -8,11 +8,13 @@ from anna.kvs_pb2 import LWW, NO_ERROR, KeyResponse, LWWValue
 from anna.metadata_pb2 import (
     DISK,
     MEMORY,
+    ClusterTopology,
     KeyAccessData,
     KeySizeData,
     ReplicationFactor,
     ServerThreadStatistics,
 )
+from anna.shared_pb2 import StringSet
 
 
 def make_client():
@@ -338,3 +340,62 @@ class TestPutReplicationFactor:
             client.put_replication_factor("testkey", 1, 1)
         call_key = mock_put.call_args[0][0]
         assert call_key == "ANNA_METADATA|replication|testkey"
+
+
+class TestGetClusterTopology:
+    def test_decodes_topology(self):
+        client = make_client()
+
+        topology = ClusterTopology()
+        topology.routing_thread_count = 2
+        topology.memory_thread_count = 4
+        topology.ebs_thread_count = 1
+        inner = topology.SerializeToString()
+
+        with patch.object(client, 'get_bytes', return_value=inner):
+            result = client.get_cluster_topology()
+
+        assert result == {
+            'routing_thread_count': 2,
+            'memory_thread_count': 4,
+            'ebs_thread_count': 1,
+        }
+
+    def test_returns_none_when_key_missing(self):
+        client = make_client()
+        with patch.object(client, 'get_bytes', return_value=None):
+            result = client.get_cluster_topology()
+        assert result is None
+
+    def test_reads_correct_key(self):
+        client = make_client()
+        with patch.object(client, 'get_bytes', return_value=None) as mock_gb:
+            client.get_cluster_topology()
+        mock_gb.assert_called_once_with("ANNA_METADATA|cluster_topology")
+
+
+class TestGetMonitoringIps:
+    def test_decodes_ips(self):
+        client = make_client()
+
+        string_set = StringSet()
+        string_set.keys.append("10.0.0.1")
+        string_set.keys.append("10.0.0.2")
+        inner = string_set.SerializeToString()
+
+        with patch.object(client, 'get_bytes', return_value=inner):
+            result = client.get_monitoring_ips()
+
+        assert result == ["10.0.0.1", "10.0.0.2"]
+
+    def test_returns_empty_when_key_missing(self):
+        client = make_client()
+        with patch.object(client, 'get_bytes', return_value=None):
+            result = client.get_monitoring_ips()
+        assert result == []
+
+    def test_reads_correct_key(self):
+        client = make_client()
+        with patch.object(client, 'get_bytes', return_value=None) as mock_gb:
+            client.get_monitoring_ips()
+        mock_gb.assert_called_once_with("ANNA_METADATA|monitoring_ips")

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -227,9 +227,8 @@ impl KVSClient {
                 self.key_address_cache.remove(key);
             }
         }
-        if let Transport::Zmq { socket_cache, .. } = &mut self.transport {
-            socket_cache.remove(addr);
-        }
+        let Transport::Zmq { socket_cache, .. } = &mut self.transport;
+        socket_cache.remove(addr);
     }
 
     async fn query_routing(&mut self, key: &str) -> Vec<Address> {
@@ -1368,8 +1367,7 @@ mod tests {
             Some(make_get_response(meta_key, &topo.encode_to_vec())),
         );
         let result = client.get_cluster_topology().await;
-        assert!(result.is_some());
-        let t = result.unwrap();
+        let t = result.expect("get_cluster_topology returned None");
         assert_eq!(t.memory_thread_count, 4);
         assert_eq!(t.routing_thread_count, 2);
     }

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -227,8 +227,10 @@ impl KVSClient {
                 self.key_address_cache.remove(key);
             }
         }
-        let Transport::Zmq { socket_cache, .. } = &mut self.transport;
-        socket_cache.remove(addr);
+        #[allow(irrefutable_let_patterns)]
+        if let Transport::Zmq { socket_cache, .. } = &mut self.transport {
+            socket_cache.remove(addr);
+        }
     }
 
     async fn query_routing(&mut self, key: &str) -> Vec<Address> {

--- a/clients/rust/src/lib/value_change_subscriber.rs
+++ b/clients/rust/src/lib/value_change_subscriber.rs
@@ -297,9 +297,9 @@ mod tests {
     #[tokio::test]
     async fn new_value_change_subscriber() {
         let config = crate::client_config::ClientConfig::default();
-        let cache = ValueChangeSubscriber::new(&config, Some(90)).await;
-        assert!(cache.is_ok());
-        let cache = cache.unwrap();
+        let cache = ValueChangeSubscriber::new(&config, Some(90))
+            .await
+            .expect("Failed to create subscriber");
         assert!(cache.watched_keys().is_empty());
         assert!(cache.get_cached("nonexistent").is_none());
     }
@@ -349,12 +349,13 @@ mod tests {
             .recv_update(Duration::from_secs(5))
             .await
             .expect("recv error");
-        assert!(result.is_some());
-        let (key, payload) = result.unwrap();
+        let (key, payload) = result.expect("recv_update returned None");
         assert_eq!(key, "pushed_key");
         assert_eq!(payload, b"pushed_value");
-        assert!(sub.get_cached("pushed_key").is_some());
-        assert_eq!(sub.get_cached("pushed_key").unwrap(), b"pushed_value");
+        assert_eq!(
+            sub.get_cached("pushed_key").expect("key not in cache"),
+            b"pushed_value"
+        );
     }
 
     #[tokio::test]

--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -1,9 +1,18 @@
+// Holding `MONITOR_LOCK` across `.await` is intentional — it serializes
+// entire test bodies so only one server cluster runs at a time.
+#![allow(clippy::await_holding_lock)]
+
 //! Monitoring system tests: verify that anna-kvs reports statistics to
 //! anna-monitor via internal metadata keys.
 //!
 //! These tests use a separate port offset range (100+) from multi_node.rs
 //! (0-25221) to avoid conflicts. Since cargo runs test binaries sequentially,
 //! there is no parallel conflict between files.
+//!
+//! Each test starts a full server cluster (monitor + route + kvs = 3
+//! processes). Running all 7 tests in parallel starts 21 server processes
+//! simultaneously, causing resource contention that leads to flaky timeouts.
+//! The `MONITOR_LOCK` mutex serializes tests within this file.
 
 mod common;
 
@@ -13,7 +22,13 @@ use std::io::Write;
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+/// Serialize all monitor tests so only one cluster runs at a time.
+/// Without this, 7 clusters (21 server processes) run simultaneously,
+/// causing resource contention and flaky timeouts.
+static MONITOR_LOCK: Mutex<()> = Mutex::new(());
 
 const NODE_IP: &str = "127.0.0.1";
 const REPORT_PERIOD: u32 = 3;
@@ -159,6 +174,13 @@ impl MonitorTestCluster {
         let config = self.config_dir.join("config.yml");
         write_monitor_config(&config, &cfg);
 
+        let port_range_start = 6200 + self.base_offset;
+        let port_range_end = 7200 + self.base_offset;
+        eprintln!(
+            "[monitor-test] base_offset={} starting cluster (ports {}-{})",
+            self.base_offset, port_range_start, port_range_end
+        );
+
         for name in ["anna-monitor", "anna-route", "anna-kvs"] {
             let bin = server_bin_dir().join(name);
             if !bin.exists() {
@@ -183,6 +205,10 @@ impl MonitorTestCluster {
             routing_port
         );
         std::thread::sleep(Duration::from_secs(1));
+        eprintln!(
+            "[monitor-test] base_offset={} cluster ready",
+            self.base_offset
+        );
     }
 
     fn start_disk_kvs(&mut self) {
@@ -215,6 +241,10 @@ impl MonitorTestCluster {
     }
 
     fn shutdown(&mut self) {
+        eprintln!(
+            "[monitor-test] base_offset={} shutting down cluster",
+            self.base_offset
+        );
         #[cfg(unix)]
         {
             use nix::sys::signal::{kill, Signal};
@@ -229,6 +259,10 @@ impl MonitorTestCluster {
             child.wait().ok();
         }
         self.processes.clear();
+        eprintln!(
+            "[monitor-test] base_offset={} cluster stopped",
+            self.base_offset
+        );
     }
 }
 
@@ -251,6 +285,7 @@ impl Drop for MonitorTestCluster {
 #[tokio::test]
 #[cfg(unix)]
 async fn monitor_stats_collection() {
+    let _guard = MONITOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     use annalib::kvs_client::KVSClient;
 
     if !server_bin_dir().join("anna-kvs").exists() {
@@ -364,6 +399,7 @@ async fn monitor_stats_collection() {
 #[tokio::test]
 #[cfg(unix)]
 async fn policy_toggles_and_grace_period() {
+    let _guard = MONITOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     use annalib::kvs_client::KVSClient;
 
     if !server_bin_dir().join("anna-kvs").exists() {
@@ -425,6 +461,7 @@ async fn policy_toggles_and_grace_period() {
 #[tokio::test]
 #[cfg(unix)]
 async fn cross_tier_data_movement() {
+    let _guard = MONITOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     use annalib::kvs_client::KVSClient;
 
     if !server_bin_dir().join("anna-kvs").exists() {
@@ -510,6 +547,7 @@ async fn cross_tier_data_movement() {
 #[tokio::test]
 #[cfg(unix)]
 async fn latency_feedback_ingestion() {
+    let _guard = MONITOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     use annalib::kvs_client::KVSClient;
     use annalib::proto::metadata::user_feedback::KeyLatency;
     use annalib::proto::metadata::UserFeedback;
@@ -621,6 +659,7 @@ async fn latency_feedback_ingestion() {
 #[tokio::test]
 #[cfg(unix)]
 async fn hot_key_selective_replication() {
+    let _guard = MONITOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     use annalib::kvs_client::KVSClient;
 
     if !server_bin_dir().join("anna-kvs").exists() {
@@ -692,6 +731,7 @@ async fn hot_key_selective_replication() {
 #[tokio::test]
 #[cfg(unix)]
 async fn monitoring_ips_metadata() {
+    let _guard = MONITOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     use annalib::kvs_client::KVSClient;
     use annalib::proto::shared::StringSet;
     use prost::Message;
@@ -709,10 +749,12 @@ async fn monitoring_ips_metadata() {
 
     // The KVS writes monitoring IPs every server_report_period (3s in test config).
     // Poll until the metadata key appears.
+    // Allow up to 20 attempts (40s) to account for startup latency and
+    // resource contention when running all monitor tests together.
     let meta_key = "ANNA_METADATA|monitoring_ips";
     let mut found = false;
-    for _ in 0..10 {
-        std::thread::sleep(Duration::from_secs(2));
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
         if let Ok(bytes) = client.get_bytes(meta_key).await {
             let string_set =
                 StringSet::decode(bytes.as_slice()).expect("Failed to decode StringSet");
@@ -742,6 +784,7 @@ async fn monitoring_ips_metadata() {
 #[tokio::test]
 #[cfg(unix)]
 async fn cluster_topology_metadata() {
+    let _guard = MONITOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     use annalib::kvs_client::KVSClient;
 
     if !server_bin_dir().join("anna-kvs").exists() {
@@ -756,9 +799,12 @@ async fn cluster_topology_metadata() {
     let mut client = KVSClient::new(&config, Some(97)).await;
 
     // Poll until the topology metadata key appears.
+    // The KVS publishes this key every server_report_period (3s in test config).
+    // Allow up to 20 attempts (40s) to account for startup latency and
+    // resource contention when running all monitor tests together.
     let mut topology = None;
-    for _ in 0..10 {
-        std::thread::sleep(Duration::from_secs(2));
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
         topology = client.get_cluster_topology().await;
         if topology.is_some() {
             break;

--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -189,7 +189,7 @@ impl MonitorTestCluster {
             }
             let child = Command::new(&bin)
                 .args(["--config", &config.to_string_lossy()])
-                .env("PATH", &server_path())
+                .env("PATH", server_path())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .spawn()
@@ -219,7 +219,7 @@ impl MonitorTestCluster {
         }
         let child = Command::new(&bin)
             .args(["--config", &config.to_string_lossy()])
-            .env("PATH", &server_path())
+            .env("PATH", server_path())
             .env("SERVER_TYPE", "ebs")
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -2004,12 +2004,10 @@ async fn elasticity_storage_policy() {
 
     // Background task to handle management node protocol
     let mgmt_handle = tokio::spawn(async move {
-        let mut add_node_msg: Option<String> = None;
-
         loop {
             tokio::select! {
                 result = restart_rep.recv() => {
-                    if let Ok(_msg) = result {
+                    if result.is_ok() {
                         restart_rep
                             .send(zeromq::ZmqMessage::from("0".as_bytes().to_vec()))
                             .await
@@ -2017,7 +2015,7 @@ async fn elasticity_storage_policy() {
                     }
                 }
                 result = func_pull.recv() => {
-                    if let Ok(_msg) = result {
+                    if result.is_ok() {
                         // No response needed for PULL
                     }
                 }
@@ -2027,8 +2025,7 @@ async fn elasticity_storage_policy() {
                             .into_iter().flat_map(|f| f.to_vec()).collect();
                         let message = String::from_utf8_lossy(&data).to_string();
                         eprintln!("Mock mgmt: add_node request: {}", message);
-                        add_node_msg = Some(message);
-                        return add_node_msg;
+                        return Some(message);
                     }
                 }
             }
@@ -2152,12 +2149,10 @@ async fn underutilization_scale_in() {
 
     // Background mock: handle restart queries and collect add/remove messages
     let mgmt_handle = tokio::spawn(async move {
-        let mut remove_msg: Option<String> = None;
-
         loop {
             tokio::select! {
                 result = restart_rep.recv() => {
-                    if let Ok(_) = result {
+                    if result.is_ok() {
                         restart_rep
                             .send(zeromq::ZmqMessage::from("0".as_bytes().to_vec()))
                             .await
@@ -2165,7 +2160,7 @@ async fn underutilization_scale_in() {
                     }
                 }
                 result = func_pull.recv() => {
-                    if let Ok(_) = result {}
+                    if result.is_ok() {}
                 }
                 result = mgmt_pull.recv() => {
                     if let Ok(msg) = result {
@@ -2174,8 +2169,7 @@ async fn underutilization_scale_in() {
                         let message = String::from_utf8_lossy(&data).to_string();
                         eprintln!("Mock mgmt: received: {}", message);
                         if message.starts_with("remove:") {
-                            remove_msg = Some(message);
-                            return remove_msg;
+                            return Some(message);
                         }
                     }
                 }

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -94,9 +94,10 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
 | GET_PRIORITY / PUT_PRIORITY | Yes   |
 | GET_BYTES (raw LWW value)  | Yes    |
+| Multi-key GET (get_multi)  | Yes    |
 | Address cache invalidation | Yes    |
 | WRONG_THREAD auto-retry    | Yes    |
-| Timeout (generate_bad_response) | Yes |
+| Configurable timeout       | Yes    |
 | Process management (start/stop/status) | Yes |
 | Value change subscription (watch/recv/get_cached) | Yes |
 | Latency feedback (LatencyReporter) | Yes |
@@ -116,8 +117,11 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
 | GET_PRIORITY / PUT_PRIORITY | Yes   |
 | GET_BYTES (raw LWW value)  | Yes    |
-| Error code mapping         | Yes    |
+| Multi-key GET (GetMulti)   | Yes    |
+| Address cache invalidation | Yes    |
 | WRONG_THREAD auto-retry    | Yes    |
+| Dead-address eviction      | Yes    |
+| Configurable timeout       | Yes    |
 | Timeout with retry         | Yes    |
 | Process management (start/stop/status) | Yes |
 | Value change subscription (watch/recv/get_cached) | Yes |
@@ -137,8 +141,12 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
 | GET_PRIORITY / PUT_PRIORITY | Yes   |
 | GET_BYTES (raw LWW value)  | Yes    |
+| Multi-key GET (get_multi)  | Yes    |
+| Address cache invalidation | Yes    |
 | WRONG_THREAD auto-retry    | Yes    |
-| Timeout (poll-based)       | Yes    |
+| Dead-address eviction      | Yes    |
+| Configurable timeout       | Yes    |
+| Port base_offset support   | Yes    |
 | Process management (start/stop) | Yes |
 | Value change subscription (watch/recv/get_cached) | Yes |
 | Latency feedback (LatencyReporter) | Yes |

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -67,6 +67,7 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | GET_CAUSAL / PUT_CAUSAL    | Yes    |
 | GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
 | GET_PRIORITY / PUT_PRIORITY | Yes   |
+| GET_BYTES (raw LWW value)  | Yes    |
 | Multi-key GET (get_multi)  | Yes    |
 | Address cache invalidation | Yes    |
 | WRONG_THREAD retry         | Yes    |
@@ -86,14 +87,23 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 
 | Feature                    | Tested |
 |----------------------------|--------|
-| GET / PUT (LWW)            | Yes    |
+| GET / PUT / DELETE (LWW)   | Yes    |
+| GET_SET / PUT_SET           | Yes    |
+| GET_ORDERED_SET / PUT_ORDERED_SET | Yes |
+| GET_CAUSAL / PUT_CAUSAL    | Yes    |
+| GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
+| GET_PRIORITY / PUT_PRIORITY | Yes   |
+| GET_BYTES (raw LWW value)  | Yes    |
 | Address cache invalidation | Yes    |
 | WRONG_THREAD auto-retry    | Yes    |
 | Timeout (generate_bad_response) | Yes |
+| Process management (start/stop/status) | Yes |
 | Value change subscription (watch/recv/get_cached) | Yes |
 | Latency feedback (LatencyReporter) | Yes |
 | Monitoring stats helpers (get_storage_stats etc.) | Yes |
 | Replication factor management (put_replication_factor) | Yes |
+| Cluster topology discovery (get_cluster_topology) | Yes |
+| Monitoring IP discovery (get_monitoring_ips) | Yes |
 
 ## Go Client (`clients/go`)
 
@@ -102,14 +112,20 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | GET / PUT / DELETE (LWW)   | Yes    |
 | GET_SET / PUT_SET           | Yes    |
 | GET_ORDERED_SET / PUT_ORDERED_SET | Yes |
+| GET_CAUSAL / PUT_CAUSAL    | Yes    |
 | GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
 | GET_PRIORITY / PUT_PRIORITY | Yes   |
+| GET_BYTES (raw LWW value)  | Yes    |
 | Error code mapping         | Yes    |
-| Timeout error code         | Yes    |
+| WRONG_THREAD auto-retry    | Yes    |
+| Timeout with retry         | Yes    |
+| Process management (start/stop/status) | Yes |
 | Value change subscription (watch/recv/get_cached) | Yes |
 | Latency feedback (LatencyReporter) | Yes |
 | Monitoring stats helpers (get_storage_stats etc.) | Yes |
 | Replication factor management (put_replication_factor) | Yes |
+| Cluster topology discovery (GetClusterTopology) | Yes |
+| Monitoring IP discovery (GetMonitoringIPs) | Yes |
 
 ## Python Client (`clients/python`)
 
@@ -120,9 +136,13 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | GET_ORDERED_SET / PUT_ORDERED_SET | Yes |
 | GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
 | GET_PRIORITY / PUT_PRIORITY | Yes   |
+| GET_BYTES (raw LWW value)  | Yes    |
+| WRONG_THREAD auto-retry    | Yes    |
 | Timeout (poll-based)       | Yes    |
 | Process management (start/stop) | Yes |
 | Value change subscription (watch/recv/get_cached) | Yes |
 | Latency feedback (LatencyReporter) | Yes |
 | Monitoring stats helpers (get_storage_stats etc.) | Yes |
 | Replication factor management (put_replication_factor) | Yes |
+| Cluster topology discovery (get_cluster_topology) | Yes |
+| Monitoring IP discovery (get_monitoring_ips) | Yes |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -73,7 +73,7 @@ It is a client-side construct — see `docs/client-feature-list.md`.
 | Disk tier                     | File-based storage on configurable path               | Yes           |
 | Tier selection                | `SERVER_TYPE` env var selects storage medium           | Yes           |
 | Identical kernel across tiers | Same storage kernel, different serialization layer     | Yes           |
-| Node capacities               | `capacities.memory-cap`, `capacities.ebs-cap`         | Yes           |
+| Node capacities               | `capacities.memory-cap`, `capacities.ebs-cap` (tested via `elasticity_storage_policy` with `memory-cap-kb: 1`) | Yes           |
 | Cross-tier data movement      | Promote hot data to memory, demote cold to disk       | Yes           |
 
 Note: `SERVER_TYPE` and `ebs` config should be renamed to storage-medium-agnostic
@@ -102,7 +102,7 @@ feature, not an autoscaling decision.
 |-----------------------------|--------------------------------------------------|---------------|
 | Periodic gossip (10s epoch) | Changesets multicast to all responsible replicas  | Yes           |
 | Merge-at-sender             | Batched updates merged before sending             | Yes           |
-| Gossip to caches            | Changed keys pushed to registered cache clients   | Yes           |
+| Value change subscription   | Changed keys pushed to subscribed clients         | Yes           |
 | Join gossip                 | Redistribute data to newly joined nodes           | Yes           |
 | Cross-tier gossip           | Updates propagated between memory and disk tiers  | Yes           |
 
@@ -171,17 +171,18 @@ Anna provides the **primitives** for autoscaling but delegates the scaling
 **decisions** and **infrastructure lifecycle** to the operator. This is a
 deliberate split:
 
-- **Server features** — the cluster primitives that enable scaling (node
+- **Server primitives** — the cluster mechanisms that enable scaling (node
   join/depart, replication changes, stats reporting). These are implemented
   in `anna-kvs`, `anna-route`, and `anna-monitor`.
-- **Client library helpers** — convenience methods for reading stats and
-  triggering scaling actions. These make it easy to build an autoscaler
-  in any language.
+- **Client library helpers** — convenience methods in all four client
+  libraries for reading stats, managing replication, and reporting latency.
+  These make it easy to build an autoscaler in any language. See
+  [client-feature-list.md](client-feature-list.md) for per-client details.
 - **Operator responsibility** — the decision logic (when to add/remove
   nodes) and the infrastructure lifecycle (provisioning/deprovisioning
   machines). Not part of the Anna project.
 
-### Server features (autoscaling primitives)
+### Server primitives
 
 | Feature                     | Description                                                   | System Tested |
 |-----------------------------|---------------------------------------------------------------|---------------|
@@ -190,14 +191,21 @@ deliberate split:
 | Policy toggles              | `policy.elasticity`, `policy.selective-rep`, `policy.tiering` | Yes           |
 | Latency feedback ingestion  | Monitor accepts `UserFeedback` protobuf for SLO decisions    | Yes           |
 
-### Client library helpers (#410)
+### Client library helpers
 
-| Feature                          | Description                                            | Implemented |
-|----------------------------------|--------------------------------------------------------|-------------|
-| Read storage/occupancy stats     | Helper to GET and decode `ServerThreadStatistics`      | Yes (Rust)  |
-| Read per-key access stats        | Helper to GET and decode `KeyAccessData`               | Yes (Rust)  |
-| Read per-key size stats          | Helper to GET and decode `KeySizeData`                 | Yes (Rust)  |
-| Report latency feedback          | Send `UserFeedback` to monitor for SLO enforcement    | No          |
+All four client libraries (Rust, C++, Go, Python) implement the following
+helpers. See [client-feature-list.md](client-feature-list.md) for the
+complete per-client feature matrix.
+
+| Feature                          | Description                                            | System Tested |
+|----------------------------------|--------------------------------------------------------|---------------|
+| Read storage/occupancy stats     | Helper to GET and decode `ServerThreadStatistics`      | Yes           |
+| Read per-key access stats        | Helper to GET and decode `KeyAccessData`               | Yes           |
+| Read per-key size stats          | Helper to GET and decode `KeySizeData`                 | Yes           |
+| Report latency feedback          | Send `UserFeedback` to monitor via `LatencyReporter`   | Yes           |
+| Set per-key replication factor   | Write `ReplicationFactor` protobuf to metadata key     | Yes           |
+| Cluster topology discovery       | Read `ClusterTopology` from metadata key               | Yes           |
+| Monitoring IP discovery          | Read monitoring IPs from metadata key                  | Yes           |
 
 ### Operator responsibility (not project features)
 
@@ -228,4 +236,5 @@ to implement their own scaling logic.
 | Routing Tier                           | `anna-route`   | 6     | 6      | 100%     | —      |
 | Monitoring                             | `anna-monitor` | 6     | 6      | 100%     | —      |
 | Autoscaling (server primitives)        | `anna-monitor` | 4     | 4      | 100%     | —      |
-| **Total**                              |                | **81**| **81** | **100%** |        |
+| Client library helpers                 | all clients    | 7     | 7      | 100%     | —      |
+| **Total**                              |                | **88**| **88** | **100%** |        |


### PR DESCRIPTION
## Summary

Review the feature lists based on tests implemented, fix inaccuracies, implement missing features across all clients, and fix flaky monitor tests.

### Feature list doc updates (`docs/feature-list.md`)
- Fixed stale "No" for latency feedback (all 4 clients implement `LatencyReporter`)
- Removed "(Rust)" qualifier from stats helpers (all 4 clients have them)
- Reworked autoscaling section: expanded client library helpers to 7 items with "System Tested" column
- Renamed "Gossip to caches" to "Value Change Subscription"
- Clarified Node capacities test link
- Added "Client library helpers" row to summary table (total now 88 features)

### Client feature list updates (`docs/client-feature-list.md`)
- **C++**: Added 9 missing features (all lattice types, DELETE, GET_BYTES, process mgmt, topology/monitoring discovery)
- **Go**: Added 7 missing features (MULTI_CAUSAL, GET_BYTES, WRONG_THREAD retry, process mgmt, topology/monitoring discovery)
- **Python**: Added 4 missing features (WRONG_THREAD retry, GET_BYTES, topology/monitoring discovery)
- **Rust**: Added GET_BYTES

### New implementations
- `get_cluster_topology()` in C++, Go, Python clients (was Rust-only)
- `get_monitoring_ips()` in C++, Go, Python clients (was Rust-only)
- WRONG_THREAD auto-retry in Go and Python clients (C++ and Rust already had it)

### Tests added
- C++: 2 unit tests (GetClusterTopologyDecodesProtobuf, GetMonitoringIpsDecodesProtobuf)
- Go: 3 unit tests (GetClusterTopology, GetMonitoringIPs, WrongThreadRetry with sequencingMockTransport)
- Python: 8 unit tests (topology decode/missing/key, monitoring_ips decode/missing/key, GET/PUT WRONG_THREAD retry)

### Flaky test fix
- Monitor tests: Added `MONITOR_LOCK` static mutex to serialize tests (was running 21 server processes simultaneously)
- Added startup/shutdown port logging to aid future debugging
- Increased poll timeouts and switched to `tokio::time::sleep`

### Pre-existing multi_node flakiness
The 5 multi_node test failures (same count on master) are a pre-existing resource contention issue unrelated to this change.

Closes #442