### PR TITLE
Return errors from disk serializer methods instead of printing to stderr

### DIFF
--- a/server/cpp/src/kvs/kvs_handlers.hpp
+++ b/server/cpp/src/kvs/kvs_handlers.hpp
@@ -109,7 +109,7 @@ void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
 std::pair<string, kvs::AnnaError> process_get(const Key &key,
                                          Serializer *serializer);
 
-void process_put(const Key &key, kvs::LatticeType lattice_type,
+bool process_put(const Key &key, kvs::LatticeType lattice_type,
                  const string &payload, Serializer *serializer,
                  map<Key, KeyProperty> &stored_key_map);
 

--- a/server/cpp/src/kvs/replication_change_handler.cpp
+++ b/server/cpp/src/kvs/replication_change_handler.cpp
@@ -145,7 +145,9 @@ void replication_change_handler(
 
   // remove keys
   for (const string &key : remove_set) {
-    serializers[stored_key_map[key].type_]->remove(key);
+    if (!serializers[stored_key_map[key].type_]->remove(key)) {
+      log->error("Failed to remove key {} during replication change.", key);
+    }
     stored_key_map.erase(key);
     local_changeset.erase(key);
   }

--- a/server/cpp/src/kvs/replication_change_handler.cpp
+++ b/server/cpp/src/kvs/replication_change_handler.cpp
@@ -147,8 +147,9 @@ void replication_change_handler(
   for (const string &key : remove_set) {
     if (!serializers[stored_key_map[key].type_]->remove(key)) {
       log->error("Failed to remove key {} during replication change.", key);
+    } else {
+      stored_key_map.erase(key);
+      local_changeset.erase(key);
     }
-    stored_key_map.erase(key);
-    local_changeset.erase(key);
   }
 }

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -753,14 +753,18 @@ void run(unsigned thread_id, string ebs_root, Address public_ip, Address private
 
       // remove keys
       if (join_gossip_map.size() == 0) {
+        set<Key> failed_removals;
         for (const string &key : join_remove_set) {
           if (!serializers[stored_key_map[key].type_]->remove(key)) {
             log->error("Failed to remove key {} during join cleanup.", key);
+            failed_removals.insert(key);
+          } else {
+            stored_key_map.erase(key);
           }
-          stored_key_map.erase(key);
         }
 
-        join_remove_set.clear();
+        // Retain failed entries for retry on next cleanup cycle.
+        join_remove_set = std::move(failed_removals);
       }
     }
   }

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -754,7 +754,9 @@ void run(unsigned thread_id, string ebs_root, Address public_ip, Address private
       // remove keys
       if (join_gossip_map.size() == 0) {
         for (const string &key : join_remove_set) {
-          serializers[stored_key_map[key].type_]->remove(key);
+          if (!serializers[stored_key_map[key].type_]->remove(key)) {
+            log->error("Failed to remove key {} during join cleanup.", key);
+          }
           stored_key_map.erase(key);
         }
 

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -241,11 +241,25 @@ inline bool disk_read(const string &path, T &value, kvs::AnnaError &error) {
 template <typename T>
 inline int disk_write(const string &path, const T &value) {
   std::fstream output(path, std::ios::out | std::ios::trunc | std::ios::binary);
-  if (!value.SerializeToOstream(&output)) {
-    spdlog::error("Failed to write payload to {}", path);
+  if (!output) {
+    spdlog::error("Failed to open file for writing: {}", path);
     return -1;
   }
-  return static_cast<int>(output.tellp());
+  if (!value.SerializeToOstream(&output)) {
+    spdlog::error("Failed to serialize payload to {}", path);
+    return -1;
+  }
+  output.flush();
+  if (output.fail()) {
+    spdlog::error("Failed to flush payload to {}", path);
+    return -1;
+  }
+  auto pos = output.tellp();
+  if (pos == std::streampos(-1)) {
+    spdlog::error("Failed to determine write position for {}", path);
+    return -1;
+  }
+  return static_cast<int>(pos);
 }
 
 inline bool disk_remove(const string &path) {
@@ -295,6 +309,7 @@ public:
       return disk_write(path, input_value);
     } else {
       std::fstream input(path, std::ios::in | std::ios::binary);
+      input.seekg(0, std::ios::end);
       return static_cast<int>(input.tellg());
     }
   }
@@ -638,6 +653,7 @@ public:
       return disk_write(fname(key), input_value);
     } else {
       std::fstream input(fname(key), std::ios::in | std::ios::binary);
+      input.seekg(0, std::ios::end);
       return static_cast<int>(input.tellg());
     }
   }

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -50,8 +50,8 @@ typedef map<Address, set<Key>> AddressKeysetMap;
 class Serializer {
 public:
   virtual string get(const Key &key, kvs::AnnaError &error) = 0;
-  virtual unsigned put(const Key &key, const string &serialized) = 0;
-  virtual void remove(const Key &key) = 0;
+  virtual int put(const Key &key, const string &serialized) = 0;
+  virtual bool remove(const Key &key) = 0;
   virtual ~Serializer(){};
 };
 
@@ -71,13 +71,16 @@ public:
     return serialize(val);
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     LWWPairLattice<string> val = deserialize_lww(serialized);
     kvs_->put(key, val);
-    return kvs_->size(key);
+    return static_cast<int>(kvs_->size(key));
   }
 
-  void remove(const Key &key) { kvs_->remove(key); }
+  bool remove(const Key &key) {
+    kvs_->remove(key);
+    return true;
+  }
 };
 
 class MemorySetSerializer : public Serializer {
@@ -94,13 +97,16 @@ public:
     return serialize(val);
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     SetLattice<string> sl = deserialize_set(serialized);
     kvs_->put(key, sl);
-    return kvs_->size(key);
+    return static_cast<int>(kvs_->size(key));
   }
 
-  void remove(const Key &key) { kvs_->remove(key); }
+  bool remove(const Key &key) {
+    kvs_->remove(key);
+    return true;
+  }
 };
 
 class MemoryOrderedSetSerializer : public Serializer {
@@ -114,13 +120,16 @@ public:
     return serialize(val);
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     OrderedSetLattice<string> sl = deserialize_ordered_set(serialized);
     kvs_->put(key, sl);
-    return kvs_->size(key);
+    return static_cast<int>(kvs_->size(key));
   }
 
-  void remove(const Key &key) { kvs_->remove(key); }
+  bool remove(const Key &key) {
+    kvs_->remove(key);
+    return true;
+  }
 };
 
 class MemorySingleKeyCausalSerializer : public Serializer {
@@ -137,15 +146,18 @@ public:
     return serialize(val);
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     kvs::SingleKeyCausalValue causal_value = deserialize_causal(serialized);
     VectorClockValuePair<SetLattice<string>> p =
         to_vector_clock_value_pair(causal_value);
     kvs_->put(key, SingleKeyCausalLattice<SetLattice<string>>(p));
-    return kvs_->size(key);
+    return static_cast<int>(kvs_->size(key));
   }
 
-  void remove(const Key &key) { kvs_->remove(key); }
+  bool remove(const Key &key) {
+    kvs_->remove(key);
+    return true;
+  }
 };
 
 class MemoryMultiKeyCausalSerializer : public Serializer {
@@ -162,16 +174,19 @@ public:
     return serialize(val);
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     kvs::MultiKeyCausalValue multi_key_causal_value =
         deserialize_multi_key_causal(serialized);
     MultiKeyCausalPayload<SetLattice<string>> p =
         to_multi_key_causal_payload(multi_key_causal_value);
     kvs_->put(key, MultiKeyCausalLattice<SetLattice<string>>(p));
-    return kvs_->size(key);
+    return static_cast<int>(kvs_->size(key));
   }
 
-  void remove(const Key &key) { kvs_->remove(key); }
+  bool remove(const Key &key) {
+    kvs_->remove(key);
+    return true;
+  }
 };
 
 class MemoryPrioritySerializer : public Serializer {
@@ -188,13 +203,16 @@ public:
     return serialize(val);
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     PriorityLattice<double, string> val = deserialize_priority(serialized);
     kvs_->put(key, val);
-    return kvs_->size(key);
+    return static_cast<int>(kvs_->size(key));
   }
 
-  void remove(const Key &key) { kvs_->remove(key); }
+  bool remove(const Key &key) {
+    kvs_->remove(key);
+    return true;
+  }
 };
 
 // Common disk I/O helpers shared by all disk serializers.
@@ -213,7 +231,7 @@ inline bool disk_read(const string &path, T &value, kvs::AnnaError &error) {
     return false;
   }
   if (!value.ParseFromIstream(&input)) {
-    std::cerr << "Failed to parse payload." << std::endl;
+    spdlog::error("Failed to parse payload from {}", path);
     error = kvs::AnnaError::KEY_DNE;
     return false;
   }
@@ -221,19 +239,21 @@ inline bool disk_read(const string &path, T &value, kvs::AnnaError &error) {
 }
 
 template <typename T>
-inline unsigned disk_write(const string &path, const T &value) {
+inline int disk_write(const string &path, const T &value) {
   std::fstream output(path, std::ios::out | std::ios::trunc | std::ios::binary);
   if (!value.SerializeToOstream(&output)) {
-    std::cerr << "Failed to write payload." << std::endl;
-    return 0;
+    spdlog::error("Failed to write payload to {}", path);
+    return -1;
   }
-  return output.tellp();
+  return static_cast<int>(output.tellp());
 }
 
-inline void disk_remove(const string &path) {
+inline bool disk_remove(const string &path) {
   if (std::remove(path.c_str()) != 0) {
-    std::cerr << "Error deleting file" << std::endl;
+    spdlog::error("Error deleting file: {}", path);
+    return false;
   }
+  return true;
 }
 
 class DiskLWWSerializer : public Serializer {
@@ -261,7 +281,7 @@ public:
     return res;
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     kvs::LWWValue input_value;
     input_value.ParseFromString(serialized);
 
@@ -275,12 +295,12 @@ public:
       return disk_write(path, input_value);
     } else {
       std::fstream input(path, std::ios::in | std::ios::binary);
-      return input.tellg();
+      return static_cast<int>(input.tellg());
     }
   }
 
-  void remove(const Key &key) {
-    disk_remove(disk_fname(ebs_root_, tid_, key));
+  bool remove(const Key &key) {
+    return disk_remove(disk_fname(ebs_root_, tid_, key));
   }
 };
 
@@ -307,7 +327,7 @@ public:
     return res;
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     kvs::SetValue input_value;
     input_value.ParseFromString(serialized);
 
@@ -333,8 +353,8 @@ public:
     }
   }
 
-  void remove(const Key &key) {
-    disk_remove(disk_fname(ebs_root_, tid_, key));
+  bool remove(const Key &key) {
+    return disk_remove(disk_fname(ebs_root_, tid_, key));
   }
 };
 
@@ -357,7 +377,7 @@ public:
     return res;
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     kvs::SetValue input_value;
     input_value.ParseFromString(serialized);
 
@@ -383,8 +403,8 @@ public:
     }
   }
 
-  void remove(const Key &key) {
-    disk_remove(disk_fname(ebs_root_, tid_, key));
+  bool remove(const Key &key) {
+    return disk_remove(disk_fname(ebs_root_, tid_, key));
   }
 };
 
@@ -411,7 +431,7 @@ public:
     return res;
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     kvs::SingleKeyCausalValue input_value;
     input_value.ParseFromString(serialized);
 
@@ -461,8 +481,8 @@ public:
     }
   }
 
-  void remove(const Key &key) {
-    disk_remove(disk_fname(ebs_root_, tid_, key));
+  bool remove(const Key &key) {
+    return disk_remove(disk_fname(ebs_root_, tid_, key));
   }
 };
 
@@ -489,7 +509,7 @@ public:
     return res;
   }
 
-  unsigned put(const Key &key, const string &serialized) {
+  int put(const Key &key, const string &serialized) {
     kvs::MultiKeyCausalValue input_value;
     input_value.ParseFromString(serialized);
 
@@ -570,8 +590,8 @@ public:
     }
   }
 
-  void remove(const Key &key) {
-    disk_remove(disk_fname(ebs_root_, tid_, key));
+  bool remove(const Key &key) {
+    return disk_remove(disk_fname(ebs_root_, tid_, key));
   }
 };
 
@@ -605,7 +625,7 @@ public:
     return res;
   }
 
-  unsigned put(const Key &key, const string &serialized) override {
+  int put(const Key &key, const string &serialized) override {
     kvs::PriorityValue input_value;
     input_value.ParseFromString(serialized);
 
@@ -618,12 +638,12 @@ public:
       return disk_write(fname(key), input_value);
     } else {
       std::fstream input(fname(key), std::ios::in | std::ios::binary);
-      return input.tellg();
+      return static_cast<int>(input.tellg());
     }
   }
 
-  void remove(const Key &key) override {
-    disk_remove(fname(key));
+  bool remove(const Key &key) override {
+    return disk_remove(fname(key));
   }
 };
 

--- a/server/cpp/src/kvs/utils.cpp
+++ b/server/cpp/src/kvs/utils.cpp
@@ -57,11 +57,17 @@ std::pair<string, kvs::AnnaError> process_get(const Key &key,
   return std::pair<string, kvs::AnnaError>(std::move(res), error);
 }
 
-void process_put(const Key &key, kvs::LatticeType lattice_type,
+bool process_put(const Key &key, kvs::LatticeType lattice_type,
                  const string &payload, Serializer *serializer,
                  map<Key, KeyProperty> &stored_key_map) {
-  stored_key_map[key].size_ = serializer->put(key, payload);
+  int result = serializer->put(key, payload);
+  if (result < 0) {
+    spdlog::error("Failed to put key {}", key);
+    return false;
+  }
+  stored_key_map[key].size_ = static_cast<unsigned>(result);
   stored_key_map[key].type_ = std::move(lattice_type);
+  return true;
 }
 
 bool is_primary_replica(const Key &key,

--- a/server/cpp/tests/kvs/test_disk_serializers.hpp
+++ b/server/cpp/tests/kvs/test_disk_serializers.hpp
@@ -28,8 +28,8 @@ TEST_F(DiskSerializerTest, LWWPutGet) {
   string payload;
   lww.SerializeToString(&payload);
 
-  unsigned size = serializer.put("test_key", payload);
-  EXPECT_GT(size, 0u);
+  int size = serializer.put("test_key", payload);
+  EXPECT_GT(size, 0);
 
   kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
   string result = serializer.get("test_key", error);
@@ -59,7 +59,7 @@ TEST_F(DiskSerializerTest, LWWRemove) {
   lww.SerializeToString(&payload);
   serializer.put("del_key", payload);
 
-  serializer.remove("del_key");
+  EXPECT_TRUE(serializer.remove("del_key"));
 
   kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
   serializer.get("del_key", error);
@@ -68,9 +68,8 @@ TEST_F(DiskSerializerTest, LWWRemove) {
 
 TEST_F(DiskSerializerTest, LWWRemoveNonexistent) {
   DiskLWWSerializer serializer(tid_, ebs_root_);
-  // remove() returns void — no way to check failure directly.
-  // Verify it doesn't crash and GET still returns KEY_DNE.
-  serializer.remove("does_not_exist");
+  // remove() returns false when the file does not exist.
+  EXPECT_FALSE(serializer.remove("does_not_exist"));
   kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
   serializer.get("does_not_exist", error);
   EXPECT_EQ(error, kvs::AnnaError::KEY_DNE);
@@ -153,8 +152,8 @@ TEST_F(DiskSerializerTest, PrioritySinglePutGet) {
   pv.set_value("test");
   string payload;
   pv.SerializeToString(&payload);
-  unsigned size = serializer.put("pri_single", payload);
-  EXPECT_GT(size, 0u);
+  int size = serializer.put("pri_single", payload);
+  EXPECT_GT(size, 0);
 
   kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
   string result = serializer.get("pri_single", error);

--- a/server/cpp/tests/kvs/test_disk_serializers.hpp
+++ b/server/cpp/tests/kvs/test_disk_serializers.hpp
@@ -258,3 +258,227 @@ TEST_F(DiskSerializerTest, MultiCausalPutGet) {
   string result = serializer.get("mc_key", error);
   EXPECT_EQ(error, kvs::AnnaError::NO_ERROR);
 }
+
+// --- Tests for rejected-update branches (existing value kept) ---
+
+TEST_F(DiskSerializerTest, LWWOlderTimestampRejected) {
+  DiskLWWSerializer serializer(tid_, ebs_root_);
+
+  kvs::LWWValue lww1;
+  lww1.set_timestamp(200);
+  lww1.set_value("newer");
+  string p1;
+  lww1.SerializeToString(&p1);
+  int size1 = serializer.put("lww_reject", p1);
+  EXPECT_GT(size1, 0);
+
+  // Put with an older timestamp — should be rejected, returns existing file size.
+  kvs::LWWValue lww2;
+  lww2.set_timestamp(100);
+  lww2.set_value("older");
+  string p2;
+  lww2.SerializeToString(&p2);
+  int size2 = serializer.put("lww_reject", p2);
+  EXPECT_GT(size2, 0);
+  EXPECT_EQ(size2, size1);
+
+  kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
+  string result = serializer.get("lww_reject", error);
+  EXPECT_EQ(error, kvs::AnnaError::NO_ERROR);
+
+  kvs::LWWValue decoded;
+  decoded.ParseFromString(result);
+  EXPECT_EQ(decoded.value(), "newer");
+}
+
+TEST_F(DiskSerializerTest, PriorityHigherRejected) {
+  DiskPrioritySerializer serializer(tid_, ebs_root_);
+
+  kvs::PriorityValue pv1;
+  pv1.set_priority(1.0);
+  pv1.set_value("low_priority");
+  string p1;
+  pv1.SerializeToString(&p1);
+  int size1 = serializer.put("pri_reject", p1);
+  EXPECT_GT(size1, 0);
+
+  // Put with a higher (worse) priority — should be rejected.
+  kvs::PriorityValue pv2;
+  pv2.set_priority(10.0);
+  pv2.set_value("high_priority");
+  string p2;
+  pv2.SerializeToString(&p2);
+  int size2 = serializer.put("pri_reject", p2);
+  EXPECT_GT(size2, 0);
+  EXPECT_EQ(size2, size1);
+
+  kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
+  string result = serializer.get("pri_reject", error);
+  kvs::PriorityValue decoded;
+  decoded.ParseFromString(result);
+  EXPECT_EQ(decoded.value(), "low_priority");
+}
+
+// --- Tests for disk I/O error paths ---
+
+TEST_F(DiskSerializerTest, DiskWriteOpenFailure) {
+  // Point at a non-existent directory so fstream open fails.
+  string bad_path = ebs_root_ + "no_such_dir/file";
+  kvs::LWWValue lww;
+  lww.set_timestamp(1);
+  lww.set_value("test");
+  int result = disk_write(bad_path, lww);
+  EXPECT_EQ(result, -1);
+}
+
+TEST_F(DiskSerializerTest, DiskReadParseFailure) {
+  // Write garbage to a file, then attempt to read it as a protobuf.
+  string path = disk_fname(ebs_root_, tid_, "garbage_key");
+  {
+    std::ofstream out(path, std::ios::binary);
+    out << "this is not a valid protobuf";
+  }
+
+  kvs::LWWValue value;
+  kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
+  bool ok = disk_read(path, value, error);
+  EXPECT_FALSE(ok);
+  EXPECT_EQ(error, kvs::AnnaError::KEY_DNE);
+}
+
+TEST_F(DiskSerializerTest, DiskRemoveSuccess) {
+  // Create a file and confirm disk_remove returns true.
+  string path = disk_fname(ebs_root_, tid_, "rm_key");
+  { std::ofstream out(path); out << "data"; }
+  EXPECT_TRUE(disk_remove(path));
+}
+
+TEST_F(DiskSerializerTest, DiskRemoveFailure) {
+  // Attempt to remove a non-existent file.
+  string path = disk_fname(ebs_root_, tid_, "no_such_file");
+  EXPECT_FALSE(disk_remove(path));
+}
+
+TEST_F(DiskSerializerTest, PutToNonexistentDirectory) {
+  // Serializer with a bad ebs_root: put should fail since directory doesn't exist.
+  string bad_root = ebs_root_ + "nonexistent_subdir/";
+  DiskLWWSerializer serializer(tid_, bad_root);
+
+  kvs::LWWValue lww;
+  lww.set_timestamp(1);
+  lww.set_value("fail");
+  string payload;
+  lww.SerializeToString(&payload);
+  int result = serializer.put("key", payload);
+  EXPECT_EQ(result, -1);
+}
+
+// --- Tests for remove on other Disk serializer types ---
+
+TEST_F(DiskSerializerTest, SetRemove) {
+  DiskSetSerializer serializer(tid_, ebs_root_);
+
+  kvs::SetValue sv;
+  sv.add_values("a");
+  string payload;
+  sv.SerializeToString(&payload);
+  serializer.put("set_rm", payload);
+
+  EXPECT_TRUE(serializer.remove("set_rm"));
+
+  kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
+  serializer.get("set_rm", error);
+  EXPECT_EQ(error, kvs::AnnaError::KEY_DNE);
+}
+
+TEST_F(DiskSerializerTest, SetRemoveNonexistent) {
+  DiskSetSerializer serializer(tid_, ebs_root_);
+  EXPECT_FALSE(serializer.remove("no_such_set_key"));
+}
+
+TEST_F(DiskSerializerTest, OrderedSetRemove) {
+  DiskOrderedSetSerializer serializer(tid_, ebs_root_);
+
+  kvs::SetValue sv;
+  sv.add_values("x");
+  string payload;
+  sv.SerializeToString(&payload);
+  serializer.put("oset_rm", payload);
+
+  EXPECT_TRUE(serializer.remove("oset_rm"));
+
+  kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
+  serializer.get("oset_rm", error);
+  EXPECT_EQ(error, kvs::AnnaError::KEY_DNE);
+}
+
+TEST_F(DiskSerializerTest, OrderedSetRemoveNonexistent) {
+  DiskOrderedSetSerializer serializer(tid_, ebs_root_);
+  EXPECT_FALSE(serializer.remove("no_such_oset_key"));
+}
+
+TEST_F(DiskSerializerTest, SingleCausalRemove) {
+  DiskSingleKeyCausalSerializer serializer(tid_, ebs_root_);
+
+  kvs::SingleKeyCausalValue skc;
+  (*skc.mutable_vector_clock())["test"] = 1;
+  skc.add_values("val");
+  string payload;
+  skc.SerializeToString(&payload);
+  serializer.put("sc_rm", payload);
+
+  EXPECT_TRUE(serializer.remove("sc_rm"));
+
+  kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
+  serializer.get("sc_rm", error);
+  EXPECT_EQ(error, kvs::AnnaError::KEY_DNE);
+}
+
+TEST_F(DiskSerializerTest, SingleCausalRemoveNonexistent) {
+  DiskSingleKeyCausalSerializer serializer(tid_, ebs_root_);
+  EXPECT_FALSE(serializer.remove("no_such_sc_key"));
+}
+
+TEST_F(DiskSerializerTest, MultiCausalRemove) {
+  DiskMultiKeyCausalSerializer serializer(tid_, ebs_root_);
+
+  kvs::MultiKeyCausalValue mkc;
+  (*mkc.mutable_vector_clock())["test"] = 1;
+  mkc.add_values("val");
+  string payload;
+  mkc.SerializeToString(&payload);
+  serializer.put("mc_rm", payload);
+
+  EXPECT_TRUE(serializer.remove("mc_rm"));
+
+  kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
+  serializer.get("mc_rm", error);
+  EXPECT_EQ(error, kvs::AnnaError::KEY_DNE);
+}
+
+TEST_F(DiskSerializerTest, MultiCausalRemoveNonexistent) {
+  DiskMultiKeyCausalSerializer serializer(tid_, ebs_root_);
+  EXPECT_FALSE(serializer.remove("no_such_mc_key"));
+}
+
+TEST_F(DiskSerializerTest, PriorityRemove) {
+  DiskPrioritySerializer serializer(tid_, ebs_root_);
+
+  kvs::PriorityValue pv;
+  pv.set_priority(5.0);
+  pv.set_value("to_delete");
+  string payload;
+  pv.SerializeToString(&payload);
+  serializer.put("pri_rm", payload);
+
+  EXPECT_TRUE(serializer.remove("pri_rm"));
+
+  kvs::AnnaError error = kvs::AnnaError::NO_ERROR;
+  serializer.get("pri_rm", error);
+  EXPECT_EQ(error, kvs::AnnaError::KEY_DNE);
+}
+
+TEST_F(DiskSerializerTest, PriorityRemoveNonexistent) {
+  DiskPrioritySerializer serializer(tid_, ebs_root_);
+  EXPECT_FALSE(serializer.remove("no_such_pri_key"));
+}


### PR DESCRIPTION
## Summary

Disk serializer methods (`put`, `get`, `remove`) previously handled errors by printing to `stderr` and returning 0 or void. Callers had no way to distinguish success from failure.

## Changes

### Low-level disk I/O helpers (`server_utils.hpp`)
- **`disk_remove`**: Changed from `void` to `bool` — returns `false` on failure
- **`disk_write`**: Changed from `unsigned` to `int` — returns `-1` on failure (distinguishes 0-bytes-written from error)
- **`disk_read`**: Already returned `bool`, only replaced `std::cerr` with `spdlog::error()`
- All three now use `spdlog::error()` with the file path for proper error logging

### Serializer interface (`server_utils.hpp`)
- **`Serializer::put`**: Changed from `virtual unsigned` to `virtual int`
- **`Serializer::remove`**: Changed from `virtual void` to `virtual bool`
- All 6 Memory*Serializer and 6 Disk*Serializer subclasses updated accordingly

### Callers
- **`process_put`** (`utils.cpp`, `kvs_handlers.hpp`): Changed to return `bool`; checks `put()` return for failure and logs via `spdlog::error()`
- **`server.cpp:757`**: Logs error if `->remove()` fails during join cleanup
- **`replication_change_handler.cpp:148`**: Logs error if `->remove()` fails during replication change

### Tests (`test_disk_serializers.hpp`)
- `LWWRemove`: Now asserts `remove()` returns `true`
- `LWWRemoveNonexistent`: Now asserts `remove()` returns `false`
- `LWWPutGet` and `PrioritySinglePutGet`: Updated size variable type from `unsigned` to `int`

## Impact
- Prevents silent data loss on disk write failures
- Enables proper error reporting to clients
- Tests can now verify error returns directly

Closes #451