### PR TITLE
Add DELETE to C++ and Python CLI HELP text

### DIFF
--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -70,8 +70,8 @@ void print_priority_value(const annalib::PriorityResult& result) {
 string cli_usage() {
   return "Valid commands are GET, GET_SET, GET_ORDERED_SET, GET_CAUSAL, "
          "GET_SINGLE_CAUSAL, GET_PRIORITY, PUT, PUT_SET, PUT_ORDERED_SET, "
-         "PUT_CAUSAL, PUT_SINGLE_CAUSAL, PUT_PRIORITY, START, STOP, STATUS, "
-         "HELP and EXIT";
+         "PUT_CAUSAL, PUT_SINGLE_CAUSAL, PUT_PRIORITY, DELETE, START, STOP, "
+         "STATUS, HELP and EXIT";
 }
 
 void execute_cli_command(KvsClientInterface* client, const string& config_file,

--- a/clients/python/anna/cli.py
+++ b/clients/python/anna/cli.py
@@ -7,7 +7,7 @@ from .process_mgmt import start, stop, status, PROCESS_LIST
 def cli_usage():
     return ("Valid commands are GET, GET_SET, GET_ORDERED_SET, GET_CAUSAL, "
             "GET_SINGLE_CAUSAL, GET_PRIORITY, PUT, PUT_SET, PUT_ORDERED_SET, "
-            "PUT_CAUSAL, PUT_SINGLE_CAUSAL, PUT_PRIORITY, "
+            "PUT_CAUSAL, PUT_SINGLE_CAUSAL, PUT_PRIORITY, DELETE, "
             "START, STOP, STATUS, HELP and EXIT")
 
 


### PR DESCRIPTION
The `cli_usage()` functions in both the C++ and Python CLIs listed all available commands except DELETE. The DELETE command was already handled correctly in both CLIs, but users typing HELP would not see it listed.

## Changes

- `clients/cpp/src/cli.cpp`: Added `DELETE` to the `cli_usage()` string, placed after the PUT variants and before START (consistent with Go/Rust CLIs)
- `clients/python/anna/cli.py`: Same change to the Python `cli_usage()` function

Closes #460