### PR TITLE
Wrap protobuf types behind library API, simplify ClientConfig

### DIFF
--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -91,18 +91,15 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
   } else if (command == "GET_CAUSAL") {
     print_causal_value(annalib::get_causal(client, v[1]));
   } else if (command == "DELETE") {
-    kvs::KeyResponse response = annalib::del(client, v[1]);
-    if (response.error() != kvs::AnnaError::NO_ERROR) {
+    if (!annalib::del(client, v[1]).succeeded()) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "PUT") {
-    kvs::KeyResponse response = annalib::put(client, v[1], v[2]);
-    if (response.error() != kvs::AnnaError::NO_ERROR) {
+    if (!annalib::put(client, v[1], v[2]).succeeded()) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "PUT_CAUSAL") {
-    kvs::KeyResponse response = annalib::put_causal(client, v[1], v[2]);
-    if (response.error() != kvs::AnnaError::NO_ERROR) {
+    if (!annalib::put_causal(client, v[1], v[2]).succeeded()) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "PUT_SET") {
@@ -110,8 +107,7 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
     for (size_t i = 2; i < v.size(); i++) {
       values.insert(v[i]);
     }
-    kvs::KeyResponse response = annalib::put_set(client, v[1], values);
-    if (response.error() != kvs::AnnaError::NO_ERROR) {
+    if (!annalib::put_set(client, v[1], values).succeeded()) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "GET_SET") {
@@ -121,9 +117,7 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
     for (size_t i = 2; i < v.size(); i++) {
       values.insert(v[i]);
     }
-    kvs::KeyResponse response =
-        annalib::put_ordered_set(client, v[1], values);
-    if (response.error() != kvs::AnnaError::NO_ERROR) {
+    if (!annalib::put_ordered_set(client, v[1], values).succeeded()) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "GET_ORDERED_SET") {
@@ -134,18 +128,14 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
     }
     std::cout << "]" << std::endl;
   } else if (command == "PUT_SINGLE_CAUSAL") {
-    kvs::KeyResponse response =
-        annalib::put_single_causal(client, v[1], v[2]);
-    if (response.error() != kvs::AnnaError::NO_ERROR) {
+    if (!annalib::put_single_causal(client, v[1], v[2]).succeeded()) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "GET_SINGLE_CAUSAL") {
     print_single_causal_value(annalib::get_single_causal(client, v[1]));
   } else if (command == "PUT_PRIORITY") {
     double priority = std::stod(v[2]);
-    kvs::KeyResponse response =
-        annalib::put_priority(client, v[1], priority, v[3]);
-    if (response.error() != kvs::AnnaError::NO_ERROR) {
+    if (!annalib::put_priority(client, v[1], priority, v[3]).succeeded()) {
       std::cout << "Failure!" << std::endl;
     }
   } else if (command == "GET_PRIORITY") {
@@ -252,17 +242,11 @@ int main(int argc, char* argv[]) {
   // Build ClientConfig from command-line arguments
   annalib::ClientConfig config;
   config.ip = client_ip;
+  config.routing_thread_count = thread_count;
 
   if (!routing_arg.empty()) {
     // Split comma-separated routing IPs
-    vector<string> routing_ips;
-    split(routing_arg, ',', routing_ips);
-
-    for (const string& ip : routing_ips) {
-      for (unsigned t = 0; t < thread_count; t++) {
-        config.routing_threads.push_back(UserRoutingThread(ip, t));
-      }
-    }
+    split(routing_arg, ',', config.routing_ips);
   }
 
   if (command == "CLI") {

--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -37,12 +37,35 @@ const vector<string> kProcessList = {"anna-monitor", "anna-route",
 
 std::unique_ptr<KvsClient> make_client(const ClientConfig& config,
                                         unsigned tid, unsigned timeout) {
-  return std::make_unique<KvsClient>(config.routing_threads, config.ip, tid,
-                                      timeout);
+  vector<UserRoutingThread> routing_threads;
+  for (const auto& ip : config.routing_ips) {
+    for (unsigned t = 0; t < config.routing_thread_count; t++) {
+      routing_threads.push_back(UserRoutingThread(ip, t));
+    }
+  }
+  return std::make_unique<KvsClient>(routing_threads, config.ip, tid, timeout);
 }
 
+namespace {
 
-kvs::KeyResponse del(KvsClientInterface* client, const string& key) {
+// Convert a kvs::KeyResponse into a PutResult for the public API.
+PutResult to_put_result(const kvs::KeyResponse& response,
+                        const string& expected_rid) {
+  PutResult result;
+  result.error = (response.error() != kvs::AnnaError::NO_ERROR);
+  result.response_id = response.response_id();
+
+  if (result.response_id != expected_rid) {
+    std::cerr << "Invalid response: ID did not match request ID!" << std::endl;
+    result.error = true;
+  }
+
+  return result;
+}
+
+}  // namespace
+
+PutResult del(KvsClientInterface* client, const string& key) {
   return put(client, key, "");
 }
 
@@ -115,8 +138,8 @@ CausalValue get_causal(KvsClientInterface* client, const string& key) {
   return result;
 }
 
-kvs::KeyResponse put(KvsClientInterface* client, const string& key,
-                     const string& value) {
+PutResult put(KvsClientInterface* client, const string& key,
+              const string& value) {
   LWWPairLattice<string> val(
       TimestampValuePair<string>(generate_timestamp(0), value));
 
@@ -128,19 +151,11 @@ kvs::KeyResponse put(KvsClientInterface* client, const string& key,
     responses = client->receive_async();
   }
 
-  kvs::KeyResponse response = responses[0];
-
-  // TODO encode this error into the response
-  if (response.response_id() != rid) {
-    std::cerr << "Invalid response: ID did not match request ID!"
-              << std::endl;
-  }
-
-  return response;
+  return to_put_result(responses[0], rid);
 }
 
-kvs::KeyResponse put_causal(KvsClientInterface* client, const string& key,
-                            const string& value) {
+PutResult put_causal(KvsClientInterface* client, const string& key,
+                     const string& value) {
   MultiKeyCausalPayload<SetLattice<string>> mkcp;
   // construct a test client id - version pair
   mkcp.vector_clock.insert("test", 1);
@@ -162,19 +177,11 @@ kvs::KeyResponse put_causal(KvsClientInterface* client, const string& key,
     responses = client->receive_async();
   }
 
-  kvs::KeyResponse response = responses[0];
-
-  // TODO encode this error into the response
-  if (response.response_id() != rid) {
-    std::cerr << "Invalid response: ID did not match request ID!"
-              << std::endl;
-  }
-
-  return response;
+  return to_put_result(responses[0], rid);
 }
 
-kvs::KeyResponse put_set(KvsClientInterface* client, const string& key,
-                         const set<string>& values) {
+PutResult put_set(KvsClientInterface* client, const string& key,
+                  const set<string>& values) {
   string rid = client->put_async(key, serialize(SetLattice<string>(values)),
                                  kvs::LatticeType::SET);
 
@@ -183,15 +190,7 @@ kvs::KeyResponse put_set(KvsClientInterface* client, const string& key,
     responses = client->receive_async();
   }
 
-  kvs::KeyResponse response = responses[0];
-
-  // TODO encode this error into the response
-  if (response.response_id() != rid) {
-    std::cerr << "Invalid response: ID did not match request ID!"
-              << std::endl;
-  }
-
-  return response;
+  return to_put_result(responses[0], rid);
 }
 
 set<string> get_set(KvsClientInterface* client, const string& key) {
@@ -213,8 +212,8 @@ set<string> get_set(KvsClientInterface* client, const string& key) {
   return latt.reveal();
 }
 
-kvs::KeyResponse put_ordered_set(KvsClientInterface* client, const string& key,
-                                 const set<string>& values) {
+PutResult put_ordered_set(KvsClientInterface* client, const string& key,
+                          const set<string>& values) {
   // Same serialization as SET, but use ORDERED_SET lattice type so the
   // server stores as OrderedSetLattice.
   string rid = client->put_async(key, serialize(SetLattice<string>(values)),
@@ -225,14 +224,7 @@ kvs::KeyResponse put_ordered_set(KvsClientInterface* client, const string& key,
     responses = client->receive_async();
   }
 
-  kvs::KeyResponse response = responses[0];
-
-  if (response.response_id() != rid) {
-    std::cerr << "Invalid response: ID did not match request ID!"
-              << std::endl;
-  }
-
-  return response;
+  return to_put_result(responses[0], rid);
 }
 
 vector<string> get_ordered_set(KvsClientInterface* client, const string& key) {
@@ -259,8 +251,8 @@ vector<string> get_ordered_set(KvsClientInterface* client, const string& key) {
   return result;
 }
 
-kvs::KeyResponse put_single_causal(KvsClientInterface* client,
-                                   const string& key, const string& value) {
+PutResult put_single_causal(KvsClientInterface* client,
+                            const string& key, const string& value) {
   VectorClockValuePair<SetLattice<string>> p;
   // construct a test client id - version pair
   p.vector_clock.insert("test", 1);
@@ -277,14 +269,7 @@ kvs::KeyResponse put_single_causal(KvsClientInterface* client,
     responses = client->receive_async();
   }
 
-  kvs::KeyResponse response = responses[0];
-
-  if (response.response_id() != rid) {
-    std::cerr << "Invalid response: ID did not match request ID!"
-              << std::endl;
-  }
-
-  return response;
+  return to_put_result(responses[0], rid);
 }
 
 SingleCausalValue get_single_causal(KvsClientInterface* client,
@@ -319,8 +304,8 @@ SingleCausalValue get_single_causal(KvsClientInterface* client,
   return result;
 }
 
-kvs::KeyResponse put_priority(KvsClientInterface* client, const string& key,
-                              double priority, const string& value) {
+PutResult put_priority(KvsClientInterface* client, const string& key,
+                       double priority, const string& value) {
   PriorityLattice<double, string> pl(
       PriorityValuePair<double, string>(priority, value));
 
@@ -332,14 +317,7 @@ kvs::KeyResponse put_priority(KvsClientInterface* client, const string& key,
     responses = client->receive_async();
   }
 
-  kvs::KeyResponse response = responses[0];
-
-  if (response.response_id() != rid) {
-    std::cerr << "Invalid response: ID did not match request ID!"
-              << std::endl;
-  }
-
-  return response;
+  return to_put_result(responses[0], rid);
 }
 
 PriorityResult get_priority(KvsClientInterface* client, const string& key) {

--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -18,6 +18,7 @@
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <stdexcept>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/wait.h>
@@ -37,6 +38,11 @@ const vector<string> kProcessList = {"anna-monitor", "anna-route",
 
 std::unique_ptr<KvsClient> make_client(const ClientConfig& config,
                                         unsigned tid, unsigned timeout) {
+  if (config.routing_ips.empty() || config.routing_thread_count == 0) {
+    throw std::invalid_argument(
+        "ClientConfig requires at least one routing IP and a non-zero "
+        "routing_thread_count");
+  }
   vector<UserRoutingThread> routing_threads;
   for (const auto& ip : config.routing_ips) {
     for (unsigned t = 0; t < config.routing_thread_count; t++) {

--- a/clients/cpp/src/client_lib.hpp
+++ b/clients/cpp/src/client_lib.hpp
@@ -16,6 +16,8 @@
 #define INCLUDE_CLIENT_LIB_HPP_
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "kvs_client.hpp"
 #include "metadata.pb.h"
@@ -29,10 +31,20 @@
 namespace annalib {
 
 // The set of configuration needed to construct a KvsClient: this client's
-// own IP address, and the set of routing threads it should talk to.
+// own IP address, the routing tier IP addresses, and the number of routing
+// threads per IP.
 struct ClientConfig {
-  vector<UserRoutingThread> routing_threads;
-  Address ip;
+  std::vector<std::string> routing_ips;
+  unsigned routing_thread_count = 1;
+  std::string ip;
+};
+
+// The result of a PUT or DELETE operation. Callers should check succeeded()
+// rather than inspecting protobuf types directly.
+struct PutResult {
+  bool succeeded() const { return !error; }
+  bool error = false;
+  std::string response_id;
 };
 
 // Construct a KvsClient connected to the routing tier described by `config`.
@@ -74,55 +86,46 @@ struct PriorityResult {
 CausalValue get_causal(KvsClientInterface* client, const string& key);
 
 // Delete a key by writing an empty LWW value with a dominating timestamp.
-kvs::KeyResponse del(KvsClientInterface* client, const string& key);
+PutResult del(KvsClientInterface* client, const string& key);
 
 // Issue a blocking PUT of `value` for `key` under the default (LWW) lattice
 // type.
-kvs::KeyResponse put(KvsClientInterface* client, const string& key,
-                     const string& value);
-
-// Delete a key by writing an empty LWW value with a dominating timestamp.
-kvs::KeyResponse del(KvsClientInterface* client, const string& key);
+PutResult put(KvsClientInterface* client, const string& key,
+              const string& value);
 
 // Issue a blocking PUT of `value` for `key` under the multi-key-causal
 // lattice type.
-kvs::KeyResponse put_causal(KvsClientInterface* client, const string& key,
-                            const string& value);
+PutResult put_causal(KvsClientInterface* client, const string& key,
+                     const string& value);
 
 // Issue a blocking PUT of `values` for `key` under the set lattice type.
-kvs::KeyResponse put_set(KvsClientInterface* client, const string& key,
-                         const set<string>& values);
+PutResult put_set(KvsClientInterface* client, const string& key,
+                  const set<string>& values);
 
 // Issue a blocking GET for `key` under the set lattice type.
 set<string> get_set(KvsClientInterface* client, const string& key);
 
 // Issue a blocking PUT of `values` for `key` under the ordered-set lattice
 // type. Same serialization as SET, but the server preserves insertion order.
-kvs::KeyResponse put_ordered_set(KvsClientInterface* client, const string& key,
-                                 const set<string>& values);
+PutResult put_ordered_set(KvsClientInterface* client, const string& key,
+                          const set<string>& values);
 
 // Issue a blocking GET for `key` under the ordered-set lattice type.
 vector<string> get_ordered_set(KvsClientInterface* client, const string& key);
 
-// Delete a key by writing an empty LWW value with a dominating timestamp.
-kvs::KeyResponse del(KvsClientInterface* client, const string& key);
-
 // Issue a blocking PUT of `value` for `key` under the single-key-causal
 // lattice type.
-kvs::KeyResponse put_single_causal(KvsClientInterface* client,
-                                   const string& key, const string& value);
+PutResult put_single_causal(KvsClientInterface* client,
+                            const string& key, const string& value);
 
 // Issue a blocking GET for `key` under the single-key-causal lattice type.
 SingleCausalValue get_single_causal(KvsClientInterface* client,
                                     const string& key);
 
-// Delete a key by writing an empty LWW value with a dominating timestamp.
-kvs::KeyResponse del(KvsClientInterface* client, const string& key);
-
 // Issue a blocking PUT of `value` with `priority` for `key` under the
 // priority lattice type (lower priority value wins).
-kvs::KeyResponse put_priority(KvsClientInterface* client, const string& key,
-                              double priority, const string& value);
+PutResult put_priority(KvsClientInterface* client, const string& key,
+                       double priority, const string& value);
 
 // Issue a blocking GET for `key` under the priority lattice type.
 PriorityResult get_priority(KvsClientInterface* client, const string& key);

--- a/clients/cpp/tests/system/test_system.cpp
+++ b/clients/cpp/tests/system/test_system.cpp
@@ -15,9 +15,8 @@ protected:
 
     const char* routing_ip = std::getenv("ANNA_ROUTING_IP");
     config.ip = "127.0.0.1";
-
-    std::string rip = routing_ip ? routing_ip : "127.0.0.1";
-    config.routing_threads.push_back(UserRoutingThread(rip, 0));
+    config.routing_ips.push_back(routing_ip ? routing_ip : "127.0.0.1");
+    config.routing_thread_count = 1;
 
     return config;
   }
@@ -33,8 +32,7 @@ TEST_F(SystemTest, BasicPutGet) {
   string val = "test_value";
 
   // 1. Put
-  kvs::KeyResponse resp = annalib::put(client.get(), key, val);
-  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+  ASSERT_TRUE(annalib::put(client.get(), key, val).succeeded());
 
   // 2. Get
   string result = annalib::get(client.get(), key);
@@ -51,8 +49,7 @@ TEST_F(SystemTest, PutSetGetSet) {
   set<string> values = {"a", "b", "c"};
 
   // 1. Put set
-  kvs::KeyResponse resp = annalib::put_set(client.get(), key, values);
-  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+  ASSERT_TRUE(annalib::put_set(client.get(), key, values).succeeded());
 
   // 2. Get set
   set<string> result = annalib::get_set(client.get(), key);
@@ -69,8 +66,7 @@ TEST_F(SystemTest, OrderedSetPutGet) {
   set<string> values = {"alpha", "beta", "gamma"};
 
   // 1. Put ordered set
-  kvs::KeyResponse resp = annalib::put_ordered_set(client.get(), key, values);
-  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+  ASSERT_TRUE(annalib::put_ordered_set(client.get(), key, values).succeeded());
 
   // 2. Get ordered set
   vector<string> result = annalib::get_ordered_set(client.get(), key);
@@ -87,9 +83,7 @@ TEST_F(SystemTest, SingleCausalPutGet) {
   string val = "sc_hello";
 
   // 1. Put single causal
-  kvs::KeyResponse resp =
-      annalib::put_single_causal(client.get(), key, val);
-  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+  ASSERT_TRUE(annalib::put_single_causal(client.get(), key, val).succeeded());
 
   // 2. Get single causal
   annalib::SingleCausalValue result =
@@ -116,8 +110,7 @@ TEST_F(SystemTest, MultiCausalPutGet) {
   string val = "mc_hello";
 
   // 1. Put causal
-  kvs::KeyResponse resp = annalib::put_causal(client.get(), key, val);
-  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+  ASSERT_TRUE(annalib::put_causal(client.get(), key, val).succeeded());
 
   // 2. Get causal
   annalib::CausalValue result = annalib::get_causal(client.get(), key);
@@ -135,9 +128,7 @@ TEST_F(SystemTest, PriorityPutGet) {
   string val = "important";
 
   // 1. Put priority
-  kvs::KeyResponse resp =
-      annalib::put_priority(client.get(), key, priority, val);
-  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+  ASSERT_TRUE(annalib::put_priority(client.get(), key, priority, val).succeeded());
 
   // 2. Get priority
   annalib::PriorityResult result = annalib::get_priority(client.get(), key);
@@ -155,16 +146,14 @@ TEST_F(SystemTest, DeleteKey) {
   string val = "to_delete";
 
   // 1. Put
-  kvs::KeyResponse resp = annalib::put(client.get(), key, val);
-  ASSERT_EQ(resp.error(), kvs::AnnaError::NO_ERROR);
+  ASSERT_TRUE(annalib::put(client.get(), key, val).succeeded());
 
   // 2. Get - verify value exists
   string result = annalib::get(client.get(), key);
   EXPECT_EQ(result, val);
 
   // 3. Delete
-  kvs::KeyResponse del_resp = annalib::del(client.get(), key);
-  ASSERT_EQ(del_resp.error(), kvs::AnnaError::NO_ERROR);
+  ASSERT_TRUE(annalib::del(client.get(), key).succeeded());
 }
 
 int main(int argc, char **argv) {

--- a/clients/cpp/tests/unit/test_client_lib.cpp
+++ b/clients/cpp/tests/unit/test_client_lib.cpp
@@ -123,11 +123,12 @@ TEST(ClientLibTest, PutSendsSerializedLwwValue) {
   // starts at 0, pre-increments to 1).
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response = annalib::put(&client, "my_key", "my_value");
+  annalib::PutResult result = annalib::put(&client, "my_key", "my_value");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_key");
-  EXPECT_EQ(response.response_id(), "1");
+  EXPECT_TRUE(result.succeeded());
+  EXPECT_EQ(result.response_id, "1");
 }
 
 TEST(ClientLibTest, GetSetReturnsAllValues) {
@@ -146,12 +147,13 @@ TEST(ClientLibTest, PutSetSendsAllValues) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_set(&client, "my_set_key", {"a", "b"});
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_set_key");
-  EXPECT_EQ(response.response_id(), "1");
+  EXPECT_TRUE(result.succeeded());
+  EXPECT_EQ(result.response_id, "1");
 }
 
 TEST(ClientLibTest, GetCausalReturnsValueVectorClockAndDependencies) {
@@ -177,12 +179,13 @@ TEST(ClientLibTest, PutCausalSendsRequest) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_causal(&client, "my_causal_key", "some_value");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_causal_key");
-  EXPECT_EQ(response.response_id(), "1");
+  EXPECT_TRUE(result.succeeded());
+  EXPECT_EQ(result.response_id, "1");
 }
 
 
@@ -190,24 +193,25 @@ TEST(ClientLibTest, DeleteSendsEmptyPut) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response = annalib::del(&client, "my_key");
+  annalib::PutResult result = annalib::del(&client, "my_key");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_key");
+  EXPECT_TRUE(result.succeeded());
 }
 TEST(ClientLibTest, MultipleKvsClientsShareLogger) {
   spdlog::drop("client_log");
 
-  vector<UserRoutingThread> routing_threads;
-  routing_threads.push_back(UserRoutingThread("127.0.0.1", 0));
+  annalib::ClientConfig config;
+  config.routing_ips = {"127.0.0.1"};
+  config.routing_thread_count = 1;
+  config.ip = "127.0.0.1";
 
   {
-    auto client1 = annalib::make_client(
-        annalib::ClientConfig{routing_threads, "127.0.0.1"}, 10, 1000);
+    auto client1 = annalib::make_client(config, 10, 1000);
     ASSERT_NE(client1, nullptr);
 
-    auto client2 = annalib::make_client(
-        annalib::ClientConfig{routing_threads, "127.0.0.1"}, 11, 1000);
+    auto client2 = annalib::make_client(config, 11, 1000);
     ASSERT_NE(client2, nullptr);
   }
 
@@ -230,12 +234,12 @@ TEST(ClientLibTest, PutOrderedSetSendsRequest) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_ordered_set(&client, "my_ordered_key", {"x", "y"});
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_ordered_key");
-  EXPECT_EQ(response.response_id(), "1");
+  EXPECT_EQ(result.response_id, "1");
 }
 
 TEST(ClientLibTest, GetSingleCausalReturnsValueAndVectorClock) {
@@ -257,12 +261,12 @@ TEST(ClientLibTest, PutSingleCausalSendsRequest) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_single_causal(&client, "my_sc_key", "some_value");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_sc_key");
-  EXPECT_EQ(response.response_id(), "1");
+  EXPECT_EQ(result.response_id, "1");
 }
 
 TEST(ClientLibTest, GetPriorityReturnsValueAndPriority) {
@@ -283,12 +287,12 @@ TEST(ClientLibTest, PutPrioritySendsRequest) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_priority(&client, "my_priority_key", 1.5, "pval");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_priority_key");
-  EXPECT_EQ(response.response_id(), "1");
+  EXPECT_EQ(result.response_id, "1");
 }
 
 // --- Metadata / stats helper tests ---
@@ -572,7 +576,7 @@ TEST(ClientLibTest, PutSetWithEmptySet) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_set(&client, "empty_set_key", set<string>());
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
@@ -583,7 +587,7 @@ TEST(ClientLibTest, PutOrderedSetWithEmptySet) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_ordered_set(&client, "empty_os_key", set<string>());
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
@@ -671,7 +675,7 @@ TEST(ClientLibTest, PutPriorityWithZeroPriority) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_priority(&client, "zero_key", 0.0, "zero_val");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
@@ -682,7 +686,7 @@ TEST(ClientLibTest, PutPriorityWithNegativePriority) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_priority(&client, "neg_key", -5.0, "neg_val");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
@@ -705,7 +709,7 @@ TEST(ClientLibTest, PutRetriesUntilResponse) {
   DelayedMockKvsClient client(2);
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response = annalib::put(&client, "retry_key", "val");
+  annalib::PutResult result = annalib::put(&client, "retry_key", "val");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
 }
@@ -724,7 +728,7 @@ TEST(ClientLibTest, PutSetRetriesUntilResponse) {
   DelayedMockKvsClient client(1);
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_set(&client, "retry_set", {"x"});
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
@@ -743,7 +747,7 @@ TEST(ClientLibTest, PutOrderedSetRetriesUntilResponse) {
   DelayedMockKvsClient client(1);
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_ordered_set(&client, "retry_os", {"x"});
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
@@ -762,7 +766,7 @@ TEST(ClientLibTest, PutCausalRetriesUntilResponse) {
   DelayedMockKvsClient client(1);
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_causal(&client, "retry_causal", "val");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
@@ -783,7 +787,7 @@ TEST(ClientLibTest, PutSingleCausalRetriesUntilResponse) {
   DelayedMockKvsClient client(1);
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_single_causal(&client, "retry_sc", "val");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
@@ -804,7 +808,7 @@ TEST(ClientLibTest, PutPriorityRetriesUntilResponse) {
   DelayedMockKvsClient client(1);
   client.responses_.push_back(make_lww_response("1", "unused"));
 
-  kvs::KeyResponse response =
+  annalib::PutResult result =
       annalib::put_priority(&client, "retry_priority", 1.0, "val");
 
   ASSERT_EQ(client.keys_put_.size(), 1u);

--- a/clients/cpp/tests/unit/test_client_lib.cpp
+++ b/clients/cpp/tests/unit/test_client_lib.cpp
@@ -239,6 +239,7 @@ TEST(ClientLibTest, PutOrderedSetSendsRequest) {
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_ordered_key");
+  EXPECT_TRUE(result.succeeded());
   EXPECT_EQ(result.response_id, "1");
 }
 
@@ -266,6 +267,7 @@ TEST(ClientLibTest, PutSingleCausalSendsRequest) {
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_sc_key");
+  EXPECT_TRUE(result.succeeded());
   EXPECT_EQ(result.response_id, "1");
 }
 
@@ -292,6 +294,7 @@ TEST(ClientLibTest, PutPrioritySendsRequest) {
 
   ASSERT_EQ(client.keys_put_.size(), 1u);
   EXPECT_EQ(client.keys_put_[0], "my_priority_key");
+  EXPECT_TRUE(result.succeeded());
   EXPECT_EQ(result.response_id, "1");
 }
 


### PR DESCRIPTION
## Summary

Ensures CLI and tests use the client library's public API rather than inspecting protobuf types directly. Addresses #436.

## Changes

### New `PutResult` type (`client_lib.hpp`)
All `put*` and `del` functions now return `annalib::PutResult` instead of `kvs::KeyResponse`:
```cpp
struct PutResult {
  bool succeeded() const { return !error; }
  bool error = false;
  std::string response_id;
};
```
Callers use `result.succeeded()` instead of `response.error() != kvs::AnnaError::NO_ERROR`.

### Simplified `ClientConfig` (`client_lib.hpp`)
Replaced `vector<UserRoutingThread> routing_threads` with:
```cpp
struct ClientConfig {
  std::vector<std::string> routing_ips;
  unsigned routing_thread_count = 1;
  std::string ip;
};
```
`make_client()` now constructs `UserRoutingThread` objects internally. CLI and tests no longer need to know about `UserRoutingThread`.

### Other cleanups
- Removed 3 duplicate `del()` declarations (was declared 4 times)
- Added `to_put_result()` helper in `client_lib.cpp` to centralize response conversion and request ID validation
- Benchmark encapsulation work documented in #418 for separate PR

### Files changed
| File | Change |
|---|---|
| `client_lib.hpp` | `PutResult` struct, new `ClientConfig`, updated function signatures |
| `client_lib.cpp` | All `put*`/`del` return `PutResult` via `to_put_result()` |
| `cli.cpp` | Uses `PutResult.succeeded()`, simplified `ClientConfig` construction |
| `test_system.cpp` | Uses `PutResult.succeeded()`, simplified `ClientConfig` |
| `test_client_lib.cpp` | All put/del assertions use `PutResult` fields |

Addresses #436