### PR TITLE
Fix C++ client coverage report to only include client source files

### DIFF
--- a/clients/cpp/tests/CodeCoverage.cmake
+++ b/clients/cpp/tests/CodeCoverage.cmake
@@ -144,6 +144,8 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
     # Capturing lcov counters and generating report
     COMMAND ${LCOV_PATH} --directory . --base-directory . --capture --output-file ${coverage_info} --gcov-tool="${CMAKE_SOURCE_DIR}/tests/llvm-gcov.sh" --ignore-errors inconsistent,format || true
     COMMAND ${LCOV_PATH} --remove ${coverage_info} '/Applications/*' '/usr*' '*/build/*' '*/test/*' '*tests/*' '*/ext/*' '*/cpp/hash_ring/*' '*/cpp/zmq/*' '*/protobuf/*' -o ${coverage_info} --ignore-errors inconsistent,format,unused || true
+    # Keep only client source files — strip server headers, system headers, etc.
+    COMMAND ${LCOV_PATH} --extract ${coverage_info} '*/clients/cpp/src/*' -o ${coverage_info} --ignore-errors inconsistent,format,unused || true
 
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."


### PR DESCRIPTION
## Problem

Codecov was reporting ~68% coverage for the C++ client component, while the actual client source code coverage is 83.7%. The discrepancy was caused by server headers, system headers (absl, fmt, gtest, spdlog, zmq.hpp), and lattice implementations leaking into `client.info` through transitive includes from `kvs_client.hpp`.

The lcov `--remove` step stripped test files, build artifacts, and some known paths, but did not strip:
- `server/cpp/src/` headers (common.hpp, threads.hpp, lattices/*.hpp, requests.hpp)  
- `/opt/homebrew/include/` system headers (absl, fmt, gtest, spdlog, zmq)

These extra files added ~1127 lines to the denominator (1963 total vs 836 actual client lines), dragging reported coverage down.

## Fix

Added an `lcov --extract` step after the existing `--remove` filtering to keep only files matching `*/clients/cpp/src/*`. This ensures the uploaded `client.info` contains exactly the 6 client source files.

**Before:** 48 source files, 1509/1963 lines = 76.9%  
**After:** 6 source files, 700/836 lines = 83.7%

Addresses #404