### PR TITLE
Fix docs CI build and catch docs issues earlier

### DIFF
--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   check-docs:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -15,6 +15,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq protobuf-compiler
+        cargo install cargo-binstall || true
+        cargo binstall -y mdbook lychee
+
+    - name: Build and check docs
+      run: make docs
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Install dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ coverage: test
 	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info || true
 
 .PHONY: test
-test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage
+test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage docs
 
 .PHONY: server-system-coverage
 server-system-coverage:
@@ -205,8 +205,16 @@ workspace-rust-tests:
 	@$(CARGO_ENV) cargo llvm-cov test --lcov --output-path rust_workspace.info
 	@lcov --remove rust_workspace.info '/Applications/*' '/usr*' '*/build/*' '**/build.rs' '*/cpp/hash_ring/*' '*/cpp/zmq/*' '**/errors.rs' '**/*.pb.*' '*tests/*' '*/protobuf/*' '*/incremental/*' -o rust_workspace.info --ignore-errors inconsistent,format,unused
 
+MDBOOK := $(shell command -v mdbook 2> /dev/null)
+LYCHEE := $(shell command -v lychee 2> /dev/null)
+
 .PHONY: docs
 docs:
+ifeq ($(MDBOOK),)
+	@echo "Skipping docs: mdbook not found (install with 'cargo binstall mdbook')"
+else ifeq ($(LYCHEE),)
+	@echo "Skipping docs: lychee not found (install with 'cargo binstall lychee')"
+else
 	@echo "Generating docs with cargo doc"
 	@cargo doc --quiet --no-deps --target-dir=target/html/code 2>&1 > /dev/null
 	@echo "Generating book with mdbook"
@@ -221,6 +229,7 @@ docs:
 	@echo "Checking links"
 	@lychee --offline --root-dir target/html 'target/html/**/*.html' 2>&1
 	@echo "Cleaned up extra files in docs folder"
+endif
 
 .PHONY: cleanup
 cleanup: test-cleanup coverage-cleanup

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Lattices and Consistency](docs/lattices.md)
 - [Autoscaling and Policy Engine](docs/autoscaling.md)
 - [Feature List](docs/feature-list.md)
+  - [Client Feature List](docs/client-feature-list.md)
 
 # Building and Running
 - [Building anna](docs/building-anna.md)


### PR DESCRIPTION
## Problem

The Deploy Docs workflow has been failing on master for the last 5+ runs. The `make docs` step fails because `docs/feature-list.md` links to `client-feature-list.md`, but that page is not listed in `SUMMARY.md`. Since `book.toml` has `create-missing = false`, mdbook doesn't build it, and lychee reports 4 broken link errors.

## Changes

1. **`SUMMARY.md`** - Add `client-feature-list.md` as a sub-item under Feature List (fixes the broken link)

2. **`Makefile`** - Add `docs` to the `make test` target so docs issues are caught locally. The target skips gracefully with a message when `mdbook` or `lychee` are not installed.

3. **`.github/workflows/build_and_test_all.yml`** - Add a `check-docs` job that runs `make docs` on PRs (without deploying), so broken docs are caught before merge to master.

## Verification

- `make docs` now passes locally with 0 errors (was 4 errors before the SUMMARY.md fix)
- `make clippy` and `make fmt` pass