### PR TITLE
Remove v0/v1 references from autoscaling docs

### DIFF
--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -1,8 +1,8 @@
 # Autoscaling and Policy Engine
 
-The second Anna paper (VLDB 2019) extended the system with autoscaling
-capabilities to adapt to changing workloads. Anna automatically adjusts
-its deployment to balance cost, latency, and fault tolerance.
+Anna includes autoscaling capabilities to adapt to changing workloads,
+automatically adjusting its deployment to balance cost, latency, and
+fault tolerance.
 
 ## Workload Challenges
 
@@ -31,8 +31,8 @@ Anna scales each storage tier independently by adding or removing nodes:
 
 ### 2. Multi-Master Selective Replication
 
-Unlike Anna v0 which replicated all keys uniformly, the extended Anna
-selectively replicates hot keys:
+When `policy.selective-rep` is enabled, Anna selectively replicates hot
+keys rather than replicating all keys uniformly:
 
 - The policy engine classifies keys as "hot" if their access frequency
   exceeds H standard deviations above the mean
@@ -207,7 +207,7 @@ to implement infrastructure provisioning in response to these messages.
 
 ## Performance Results
 
-From the VLDB 2019 evaluation:
+From the [VLDB 2019 paper](http://www.vikrams.io/papers/anna-vldb19.pdf) evaluation:
 
 - Anna outperforms AWS ElastiCache and Masstree by up to 10x in
   cost-effectiveness under various contention levels


### PR DESCRIPTION
## Summary

Removes the "v0 vs extended Anna" paper versioning language from `docs/autoscaling.md` and describes the current system as-is.

## Changes

- **Line 3**: Removed "The second Anna paper (VLDB 2019) extended the system..." framing. Now simply states what the system does.
- **Line 34**: Replaced "Unlike Anna v0 which replicated all keys uniformly, the extended Anna selectively replicates hot keys" with a description referencing the `policy.selective-rep` config flag.
- **Line 210**: Added a hyperlink to the VLDB 2019 paper for the performance results citation.

## Context

The "v0" terminology refers to two research papers (SOSP 2018 vs VLDB 2019), not to actual code versions. The codebase has a single implementation that includes all VLDB 2019 features, controlled by config flags. The upstream `hydro-project/anna` is abandoned (last commit June 2020) with no version numbering.

## Pre-commit checks

- `make clippy` - pass
- `make fmt` - pass
- `make test` - 2 pre-existing test failures on master (`management_node_integration`, `elasticity_storage_policy`) confirmed unrelated to this change

Closes #471