### PR TITLE
Split codecov client flag into per-language flags

### DIFF
--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -82,12 +82,39 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: cargo test
 
-    - name: Upload client coverage
+    - name: Upload Rust client coverage
       if: matrix.os == 'macos-latest'
       uses: codecov/codecov-action@v6
       with:
-        files: rust_workspace.info,clients/cpp/build/client.info,clients/python/coverage.xml,clients/go/annalib/coverage.out
-        flags: clients
+        files: rust_workspace.info
+        flags: rust-client
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+
+    - name: Upload C++ client coverage
+      if: matrix.os == 'macos-latest'
+      uses: codecov/codecov-action@v6
+      with:
+        files: clients/cpp/build/client.info
+        flags: cpp-client
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+
+    - name: Upload Python client coverage
+      if: matrix.os == 'macos-latest'
+      uses: codecov/codecov-action@v6
+      with:
+        files: clients/python/coverage.xml
+        flags: python-client
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+
+    - name: Upload Go client coverage
+      if: matrix.os == 'macos-latest'
+      uses: codecov/codecov-action@v6
+      with:
+        files: clients/go/annalib/coverage.out
+        flags: go-client
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -43,9 +43,21 @@ component_management:
         - clients/go/
 
 flags:
-  clients:
+  rust-client:
     paths:
-      - clients/
+      - clients/rust/
+    carryforward: true
+  cpp-client:
+    paths:
+      - clients/cpp/
+    carryforward: true
+  python-client:
+    paths:
+      - clients/python/
+    carryforward: true
+  go-client:
+    paths:
+      - clients/go/
     carryforward: true
   server-system-tests:
     paths:


### PR DESCRIPTION
## Problem

The single `clients` flag uploaded all four languages' coverage (Rust, C++, Python, Go) in one bundle. Codecov then reported misleading per-language numbers because the flag's path filter (`clients/`) included all languages, diluting each language's actual coverage.

For example, the Go flag showed 37.44% while the Go Client component showed 74.65% — because the flag counted Go hits against ALL client source files.

## Fix

Split the single `clients` flag into four per-language flags:

| Old | New |
|-----|-----|
| `clients` (all 4 languages in 1 upload) | `rust-client`, `cpp-client`, `python-client`, `go-client` |

Each flag has a matching `paths:` filter (`clients/rust/`, `clients/cpp/`, etc.) and gets its own codecov upload in CI.

The components are unchanged — they already had correct per-language paths.

## Files changed

- `codecov.yml` — replace `clients` flag with 4 per-language flags
- `.github/workflows/build_and_test_all.yml` — split single upload into 4 uploads

Addresses #467