### PR TITLE
Move server logs from files to stdout

### DIFF
--- a/clients/cpp/src/kvs_client.hpp
+++ b/clients/cpp/src/kvs_client.hpp
@@ -57,7 +57,7 @@ class KvsClient : public KvsClientInterface {
       response_puller_(zmq::socket_t(context_, ZMQ_PULL)),
       log_(spdlog::get("client_log")
                ? spdlog::get("client_log")
-               : spdlog::stdout_color_mt("client_log")),
+               : spdlog::stderr_color_mt("client_log")),
       timeout_(timeout) {
     // initialize logger
     log_->flush_on(spdlog::level::info);

--- a/clients/cpp/src/kvs_client.hpp
+++ b/clients/cpp/src/kvs_client.hpp
@@ -57,7 +57,7 @@ class KvsClient : public KvsClientInterface {
       response_puller_(zmq::socket_t(context_, ZMQ_PULL)),
       log_(spdlog::get("client_log")
                ? spdlog::get("client_log")
-               : spdlog::basic_logger_mt("client_log", "client_log.txt", true)),
+               : spdlog::stdout_color_mt("client_log")),
       timeout_(timeout) {
     // initialize logger
     log_->flush_on(spdlog::level::info);

--- a/clients/cpp/tests/benchmark/benchmark.cpp
+++ b/clients/cpp/tests/benchmark/benchmark.cpp
@@ -88,9 +88,8 @@ void run(const unsigned &thread_id,
          const vector<MonitoringThread> &monitoring_threads,
          const Address &ip) {
   KvsClient client(routing_threads, ip, thread_id, 10000);
-  string log_file = "log_" + std::to_string(thread_id) + ".txt";
   string logger_name = "benchmark_log_" + std::to_string(thread_id);
-  auto log = spdlog::basic_logger_mt(logger_name, log_file, true);
+  auto log = spdlog::stdout_color_mt(logger_name);
   log->flush_on(spdlog::level::info);
 
   client.set_logger(log);

--- a/clients/cpp/tests/unit/test_client_lib.cpp
+++ b/clients/cpp/tests/unit/test_client_lib.cpp
@@ -12,9 +12,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include <fstream>
+#include <sstream>
 
 #include "gtest/gtest.h"
+#include "spdlog/sinks/ostream_sink.h"
 
 #include "client_lib.hpp"
 #include "mock_kvs_client.hpp"
@@ -997,37 +998,29 @@ TEST(ClientLibTest, KvsClientGetSeed) {
 
 TEST(ClientLibTest, KvsClientSetLogger) {
   const string log_name = "test_custom_log_94";
-  const string log_file = "test_custom_log_94.txt";
 
   vector<UserRoutingThread> threads;
   threads.push_back(UserRoutingThread("127.0.0.1", 0));
 
+  // Use an ostream sink to capture log output in memory (no file I/O).
+  auto oss = std::make_shared<std::ostringstream>();
+  auto ostream_sink =
+      std::make_shared<spdlog::sinks::ostream_sink_mt>(*oss);
+  auto custom_log =
+      std::make_shared<spdlog::logger>(log_name, ostream_sink);
+
   {
     KvsClient kvs_client(threads, "127.0.0.1", 94, 10000);
-
-    auto custom_log = spdlog::basic_logger_mt(log_name, log_file, true);
     kvs_client.set_logger(custom_log);
 
-    // Use set_timeout to trigger a log write through the custom logger.
-    // The KvsClient constructor logs "Random seed is ..." via its logger,
-    // but that happened before we swapped it. Force a flush so any buffered
-    // messages from the new logger reach disk.
     custom_log->info("set_logger_test_marker");
     custom_log->flush();
   }
-  // KvsClient is destroyed here, releasing its shared_ptr to the logger.
 
-  // Drop the registry entry so spdlog closes the file.
   spdlog::drop(log_name);
 
-  // Verify the log file contains our marker.
-  std::ifstream in(log_file);
-  std::string contents((std::istreambuf_iterator<char>(in)),
-                        std::istreambuf_iterator<char>());
-  in.close();
-  EXPECT_NE(contents.find("set_logger_test_marker"), std::string::npos);
-
-  std::remove(log_file.c_str());
+  // Verify the in-memory log contains our marker.
+  EXPECT_NE(oss->str().find("set_logger_test_marker"), std::string::npos);
 }
 
 TEST(ClientLibTest, KvsClientDefaultTimeout) {

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -45,9 +45,8 @@ HashRingUtilInterface *kHashRingUtil = &hash_ring_util;
 void run(unsigned thread_id, string ebs_root, Address public_ip, Address private_ip,
          Address seed_ip, vector<Address> routing_ips,
          vector<Address> monitoring_ips, Address management_ip) {
-  string log_file = "log_" + std::to_string(thread_id) + ".txt";
   string log_name = "server_log_" + std::to_string(thread_id);
-  auto log = spdlog::basic_logger_mt(log_name, log_file, true);
+  auto log = spdlog::stdout_color_mt(log_name);
   log->flush_on(spdlog::level::info);
 
   // each thread has a handle to itself

--- a/server/cpp/src/monitor/monitoring.cpp
+++ b/server/cpp/src/monitor/monitoring.cpp
@@ -43,7 +43,7 @@ HashRingUtil hash_ring_util;
 HashRingUtilInterface *kHashRingUtil = &hash_ring_util;
 
 int main(int argc, char *argv[]) {
-  auto log = spdlog::basic_logger_mt("monitoring_log", "log.txt", true);
+  auto log = spdlog::stdout_color_mt("monitoring_log");
   log->flush_on(spdlog::level::info);
 
   install_shutdown_handler();

--- a/server/cpp/src/route/routing.cpp
+++ b/server/cpp/src/route/routing.cpp
@@ -30,9 +30,8 @@ HashRingUtil hash_ring_util;
 HashRingUtilInterface *kHashRingUtil = &hash_ring_util;
 
 void run(unsigned thread_id, Address ip, vector<Address> monitoring_ips) {
-  string log_file = "log_" + std::to_string(thread_id) + ".txt";
   string log_name = "routing_log_" + std::to_string(thread_id);
-  auto log = spdlog::basic_logger_mt(log_name, log_file, true);
+  auto log = spdlog::stdout_color_mt(log_name);
   log->flush_on(spdlog::level::info);
 
   RoutingThread rt = RoutingThread(ip, thread_id);

--- a/server/cpp/src/types.hpp
+++ b/server/cpp/src/types.hpp
@@ -21,7 +21,7 @@
 #include <unordered_set>
 #include <vector>
 #include "spdlog/spdlog.h"
-#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
 
 using string = std::string;
 

--- a/server/cpp/tests/kvs/server_handler_base.hpp
+++ b/server/cpp/tests/kvs/server_handler_base.hpp
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
 #include "mock/mock_hash_utils.hpp"
 #include "mock/mock_zmq_utils.hpp"
@@ -23,7 +23,7 @@ ZmqUtilInterface *kZmqUtil = &mock_zmq_util;
 MockHashRingUtil mock_hash_ring_util;
 HashRingUtilInterface *kHashRingUtil = &mock_hash_ring_util;
 
-logger log_ = spdlog::basic_logger_mt("mock_log", "mock_log.txt", true);
+logger log_ = spdlog::stdout_color_mt("mock_log");
 
 string kRequestId = "0";
 

--- a/server/cpp/tests/route/routing_handler_base.hpp
+++ b/server/cpp/tests/route/routing_handler_base.hpp
@@ -21,8 +21,7 @@ ZmqUtilInterface *kZmqUtil = &mock_zmq_util;
 MockHashRingUtil mock_hash_ring_util;
 HashRingUtilInterface *kHashRingUtil = &mock_hash_ring_util;
 
-std::shared_ptr<spdlog::logger> log_ =
-    spdlog::basic_logger_mt("mock_log", "mock_log.txt", true);
+std::shared_ptr<spdlog::logger> log_ = spdlog::stdout_color_mt("mock_log");
 
 class RoutingHandlerTest : public ::testing::Test {
 protected:

--- a/tests/shared/cli/run_smoke_test.py
+++ b/tests/shared/cli/run_smoke_test.py
@@ -208,7 +208,7 @@ def run_smoke_test(cli_cmd):
 
     finally:
         stop_servers(procs)
-        for f in ["test_config.yml", "client_log.txt", "log.txt", "log_0.txt"]:
+        for f in ["test_config.yml"]:
             if os.path.exists(f):
                 os.remove(f)
         if os.path.exists("test_data"):


### PR DESCRIPTION
## Summary

Replace file-based logging with stdout logging in all three C++ server binaries, following the standard practice for containerized applications.

## Problem

The servers used `spdlog::basic_logger_mt()` which writes to files:
- `anna-kvs`: `log_0.txt`, `log_1.txt`, ... (per thread)
- `anna-route`: `log_0.txt`, `log_1.txt`, ... (same names, clobbered anna-kvs logs)
- `anna-monitor`: `log.txt`

These file paths were hardcoded (not configurable), relative to the working directory, and anna-kvs/anna-route used the same filenames causing log clobbering when run from the same directory.

## Fix

Switch to `spdlog::stdout_color_mt()` which writes to stdout with colored level indicators. This:
- Aligns with Kubernetes best practices (stdout/stderr captured automatically)
- Eliminates log file clobbering between anna-kvs and anna-route
- Removes stray log files from the working directory
- Works with any log collection agent (Fluentd, Fluent Bit, Promtail)

## Changes

| File | Change |
|------|--------|
| `server/cpp/src/types.hpp` | `basic_file_sink.h` -> `stdout_color_sinks.h` |
| `server/cpp/src/kvs/server.cpp` | `basic_logger_mt` -> `stdout_color_mt`, remove log file var |
| `server/cpp/src/route/routing.cpp` | Same |
| `server/cpp/src/monitor/monitoring.cpp` | Same |
| `server/cpp/tests/kvs/server_handler_base.hpp` | Same for test mock |
| `server/cpp/tests/route/routing_handler_base.hpp` | Same for test mock |

The Rust test infrastructure already redirects server stdout/stderr to `Stdio::null()`, so no test changes are needed.

## Pre-commit checks
- `make clippy` - pass
- `make fmt` - pass
- `make test` - all tests pass

Closes #2