### PR TITLE
Add tombstone garbage collection for deleted keys

### DIFF
--- a/clients/rust/tests/common/mod.rs
+++ b/clients/rust/tests/common/mod.rs
@@ -97,6 +97,7 @@ timings:
   monitoring_timeout: 30
   gossip_epoch: 10
   data_redistribute_batch: 50
+  tombstone_gc_multiplier: 30
   grace_period: 120
   monitoring_response_timeout_ms: 10000
 "#,

--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -114,6 +114,7 @@ timings:
   monitoring_timeout: 8
   monitoring_response_timeout_ms: 1000
   data_redistribute_batch: 50
+  tombstone_gc_multiplier: 30
   grace_period: 5
 replication:
   memory: {replication_memory}

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -123,6 +123,7 @@ timings:
   monitoring_timeout: {monitoring_timeout}
   monitoring_response_timeout_ms: 1000
   data_redistribute_batch: 50
+  tombstone_gc_multiplier: 30
   grace_period: {grace_period}
 replication:
   memory: {replication_memory}

--- a/server/conf/anna-base.yml
+++ b/server/conf/anna-base.yml
@@ -15,6 +15,7 @@ timings:
   monitoring_timeout: 30
   gossip_epoch: 10
   data_redistribute_batch: 50
+  tombstone_gc_multiplier: 30
   grace_period: 120
 replication:
   memory: 1

--- a/server/conf/anna-config.yml
+++ b/server/conf/anna-config.yml
@@ -41,6 +41,7 @@ timings:
   monitoring_timeout: 30
   gossip_epoch: 10
   data_redistribute_batch: 50
+  tombstone_gc_multiplier: 30
   grace_period: 120
 replication:
   memory: 1

--- a/server/conf/anna-local.yml
+++ b/server/conf/anna-local.yml
@@ -41,6 +41,7 @@ timings:
   monitoring_timeout: 30
   gossip_epoch: 10
   data_redistribute_batch: 50
+  tombstone_gc_multiplier: 30
   grace_period: 120
 replication:
   memory: 1

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -296,6 +296,7 @@ void run(unsigned thread_id, string ebs_root, Address public_ip, Address private
   auto gossip_end = std::chrono::system_clock::now();
   auto report_start = std::chrono::system_clock::now();
   auto report_end = std::chrono::system_clock::now();
+  auto gc_start = std::chrono::system_clock::now();
 
   unsigned long long working_time = 0;
   unsigned long long working_time_map[11] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -521,6 +522,38 @@ void run(unsigned thread_id, string ebs_root, Address public_ip, Address private
 
       working_time += time_elapsed;
       working_time_map[10] += time_elapsed;
+    }
+
+    // Tombstone GC: reap deleted keys whose tombstone has expired.
+    // Runs on the same cadence as gossip to avoid continuous scanning.
+    if (kTombstoneGcMultiplier > 0 &&
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now() - gc_start)
+                .count() >= kGossipPeriod) {
+      auto gc_threshold =
+          std::chrono::microseconds(kGossipPeriod) * kTombstoneGcMultiplier;
+      auto now = std::chrono::system_clock::now();
+
+      vector<Key> keys_to_reap;
+      for (const auto &kv : stored_key_map) {
+        if (kv.second.size_ == 0 && !is_metadata(kv.first) &&
+            kv.second.tombstone_time_.time_since_epoch().count() > 0 &&
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                now - kv.second.tombstone_time_) > gc_threshold) {
+          keys_to_reap.push_back(kv.first);
+        }
+      }
+
+      for (const Key &key : keys_to_reap) {
+        if (serializers[stored_key_map[key].type_]->remove(key)) {
+          stored_key_map.erase(key);
+          log->info("Tombstone GC: reaped key {}", key);
+        } else {
+          log->error("Tombstone GC: failed to remove key {}", key);
+        }
+      }
+
+      gc_start = std::chrono::system_clock::now();
     }
 
     // Collect and store internal statistics,
@@ -814,6 +847,8 @@ int main(int argc, char *argv[]) {
       kGossipPeriod = timings["gossip_epoch"].as<unsigned>() * 1000000;
     if (timings["data_redistribute_batch"])
       kDataRedistributeThreshold = timings["data_redistribute_batch"].as<unsigned>();
+    if (timings["tombstone_gc_multiplier"])
+      kTombstoneGcMultiplier = timings["tombstone_gc_multiplier"].as<unsigned>();
   }
 
   YAML::Node threads = conf["threads"];

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -29,6 +29,13 @@
 // Gossip period in microseconds (default 10 seconds)
 inline unsigned kGossipPeriod = 10000000;
 
+// Tombstone GC: multiplier of the gossip period. Tombstoned keys (size_ == 0)
+// are reaped after gossip_epoch * tombstone_gc_multiplier seconds. This must
+// be long enough for all replicas to receive the tombstone via gossip.
+// Default 30 means 30 * 10s = 5 minutes with the default gossip epoch.
+// Set to 0 to disable tombstone GC.
+inline unsigned kTombstoneGcMultiplier = 30;
+
 // Max keys redistributed per gossip batch
 inline unsigned kDataRedistributeThreshold = 50;
 

--- a/server/cpp/src/kvs/utils.cpp
+++ b/server/cpp/src/kvs/utils.cpp
@@ -67,6 +67,22 @@ bool process_put(const Key &key, kvs::LatticeType lattice_type,
   }
   stored_key_map[key].size_ = static_cast<unsigned>(result);
   stored_key_map[key].type_ = std::move(lattice_type);
+
+  // Track when a key becomes a tombstone (empty value after a delete).
+  // Set the timestamp whenever the result is zero-length, so both new
+  // tombstones and transitions from non-zero get a correct timestamp.
+  if (result == 0) {
+    // Only update the timestamp if it hasn't been set yet (epoch value),
+    // or if this is a fresh transition to empty. This avoids resetting
+    // the clock when a tombstone is re-gossiped.
+    if (stored_key_map[key].tombstone_time_.time_since_epoch().count() == 0) {
+      stored_key_map[key].tombstone_time_ = std::chrono::system_clock::now();
+    }
+  } else {
+    // Key has a non-empty value — clear any tombstone timestamp.
+    stored_key_map[key].tombstone_time_ = {};
+  }
+
   return true;
 }
 

--- a/server/cpp/src/metadata.hpp
+++ b/server/cpp/src/metadata.hpp
@@ -34,6 +34,9 @@ struct KeyReplication {
 struct KeyProperty {
   unsigned size_;
   kvs::LatticeType type_;
+  // When the key became a tombstone (size_ == 0). Only meaningful when
+  // size_ == 0; used by tombstone GC to decide when to reap the key.
+  std::chrono::time_point<std::chrono::system_clock> tombstone_time_;
 };
 
 inline bool operator==(const KeyReplication &lhs, const KeyReplication &rhs) {

--- a/tests/shared/cli/run_smoke_test.py
+++ b/tests/shared/cli/run_smoke_test.py
@@ -100,6 +100,7 @@ timings:
   monitoring_timeout: 30
   gossip_epoch: 10
   data_redistribute_batch: 50
+  tombstone_gc_multiplier: 30
   grace_period: 120
 replication:
   memory: 1


### PR DESCRIPTION
## Summary

Deleted keys (tombstones) are now automatically reaped after a configurable grace period, reclaiming memory and disk storage. The TTL is a multiple of the gossip period so both timings stay in sync.

## Problem

Anna implements DELETE as a PUT with an empty value. The key remains in `stored_key_map` forever, wasting memory/disk and continuing to participate in gossip and stats. Over time, deleted keys accumulate without bound.

## Design

- **Tombstone TTL** = `gossip_epoch * tombstone_gc_multiplier`
- **Default**: 10s * 30 = **5 minutes** — long enough for gossip to propagate the tombstone to all replicas
- **Configurable**: `timings.tombstone_gc_multiplier` in YAML config (set to 0 to disable)
- **Scales with gossip**: if you shorten `gossip_epoch` for testing, the GC period shortens proportionally

## Implementation

| Change | File |
|--------|------|
| Add `tombstone_time_` field to `KeyProperty` | `metadata.hpp` |
| Record tombstone time when key transitions to empty | `utils.cpp` (`process_put`) |
| Add `kTombstoneGcMultiplier` config variable | `server_utils.hpp` |
| Parse config from YAML | `server.cpp` |
| GC sweep in server event loop | `server.cpp` (after gossip section) |
| Add config to all YAML files | `anna-config.yml`, `anna-local.yml`, `anna-base.yml` |
| Add config to test configs | `common/mod.rs`, `monitor.rs`, `multi_node.rs`, `run_smoke_test.py` |

The GC sweep runs each event loop iteration and reaps tombstoned keys (size == 0, not metadata) whose `tombstone_time_` exceeds the TTL. It uses `serializer->remove()` and `stored_key_map.erase()` — the same pattern already used by node-join cleanup and replication changes.

## Safety

The tombstone must survive long enough for all replicas to receive it via gossip. If a node is partitioned longer than the TTL and rejoins, it could gossip stale values that resurrect deleted keys. This is the same caveat as Cassandra's `gc_grace_seconds` — the multiplier should be set conservatively for environments with prolonged partitions.

## Pre-commit checks
- `make clippy` - pass
- `make fmt` - pass
- `make test` - all tests pass

Closes #405