### PR TITLE
Implement monotonic reads across all client libraries

### DIFF
--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -116,8 +116,28 @@ string make_lww_payload(const string& value) {
   return payload;
 }
 
-// Decode an LWW protobuf payload and return the value string.
-string decode_lww_value(const string& payload) {
+// Monotonic read cache: per-key high-water mark of LWW timestamps and
+// the corresponding value. When a GET returns a stale timestamp, the
+// cached value is returned instead, guaranteeing monotonic reads.
+map<string, pair<uint64_t, string>> lww_read_cache;
+
+// Decode an LWW protobuf payload and return the value string,
+// enforcing monotonic reads via the lww_read_cache.
+string decode_lww_value(const string& key, const string& payload) {
+  kvs::LWWValue lww;
+  lww.ParseFromString(payload);
+
+  auto it = lww_read_cache.find(key);
+  if (it != lww_read_cache.end() && lww.timestamp() < it->second.first) {
+    return it->second.second;
+  }
+
+  lww_read_cache[key] = {lww.timestamp(), lww.value()};
+  return lww.value();
+}
+
+// Decode without monotonic read enforcement (for internal/metadata use).
+string decode_lww_value_raw(const string& payload) {
   kvs::LWWValue lww;
   lww.ParseFromString(payload);
   return lww.value();
@@ -156,7 +176,7 @@ string get(KvsClientInterface* client, const string& key) {
   client->get_async(key);
   auto responses = receive_with_deadline(client);
   check_response_error(responses[0]);
-  return decode_lww_value(responses[0].tuples(0).payload());
+  return decode_lww_value(key, responses[0].tuples(0).payload());
 }
 
 CausalValue get_causal(KvsClientInterface* client, const string& key) {

--- a/clients/go/annalib/client.go
+++ b/clients/go/annalib/client.go
@@ -25,6 +25,11 @@ type transport interface {
 }
 
 // KVSClient communicates with the Anna KVS via ZeroMQ.
+type lwwCacheEntry struct {
+	timestamp uint64
+	value     string
+}
+
 type KVSClient struct {
 	routingThreads  []*UserRoutingThread
 	rid             int
@@ -32,6 +37,8 @@ type KVSClient struct {
 	rng             *rand.Rand
 	keyAddressCache map[string][]string
 	tp              transport
+	// Monotonic read cache: per-key high-water mark of LWW timestamps.
+	lwwReadCache map[string]lwwCacheEntry
 }
 
 type zmqTransport struct {
@@ -92,6 +99,7 @@ func NewKVSClient(config *ClientConfig, tid int) (*KVSClient, error) {
 		rng:             rng,
 		keyAddressCache: make(map[string][]string),
 		tp:              tp,
+		lwwReadCache:    make(map[string]lwwCacheEntry),
 	}, nil
 }
 
@@ -304,12 +312,12 @@ func buildLWWPayload(value string) ([]byte, error) {
 	return proto.Marshal(lww)
 }
 
-func parseLWWPayload(payload []byte) (string, error) {
+func parseLWWPayload(payload []byte) (string, uint64, error) {
 	var lww kvspb.LWWValue
 	if err := proto.Unmarshal(payload, &lww); err != nil {
-		return "", fmt.Errorf("failed to decode LWW value: %w", err)
+		return "", 0, fmt.Errorf("failed to decode LWW value: %w", err)
 	}
-	return string(lww.Value), nil
+	return string(lww.Value), lww.Timestamp, nil
 }
 
 func buildSetPayload(values []string) ([]byte, error) {
@@ -436,7 +444,19 @@ func (c *KVSClient) Get(key string) (string, error) {
 		return "", err
 	}
 
-	return parseLWWPayload(tuple.Payload)
+	value, timestamp, err := parseLWWPayload(tuple.Payload)
+	if err != nil {
+		return "", err
+	}
+
+	// Monotonic read enforcement: if we've seen a higher timestamp for
+	// this key, return the cached value instead of the stale one.
+	if cached, ok := c.lwwReadCache[key]; ok && timestamp < cached.timestamp {
+		return cached.value, nil
+	}
+
+	c.lwwReadCache[key] = lwwCacheEntry{timestamp: timestamp, value: value}
+	return value, nil
 }
 
 // Put stores a key-value pair (LWW lattice).

--- a/clients/go/annalib/client_test.go
+++ b/clients/go/annalib/client_test.go
@@ -373,7 +373,7 @@ func TestBuildAndParseLWWPayload(t *testing.T) {
 		t.Fatalf("buildLWWPayload failed: %v", err)
 	}
 
-	val, err := parseLWWPayload(payload)
+	val, _, err := parseLWWPayload(payload)
 	if err != nil {
 		t.Fatalf("parseLWWPayload failed: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestBuildAndParseLWWPayload(t *testing.T) {
 }
 
 func TestParseLWWPayloadInvalid(t *testing.T) {
-	_, err := parseLWWPayload([]byte{0xff, 0xff})
+	_, _, err := parseLWWPayload([]byte{0xff, 0xff})
 	if err == nil {
 		t.Error("expected error for invalid LWW payload")
 	}
@@ -449,6 +449,7 @@ func newTestClient(tp transport) *KVSClient {
 		rng:             rand.New(rand.NewSource(42)),
 		keyAddressCache: make(map[string][]string),
 		tp:              tp,
+		lwwReadCache:    make(map[string]lwwCacheEntry),
 	}
 }
 
@@ -2565,5 +2566,120 @@ func TestQueryRoutingResponseError(t *testing.T) {
 	addrs := client.queryRouting("key")
 	if addrs != nil {
 		t.Errorf("expected nil addresses on routing error, got %v", addrs)
+	}
+}
+
+// sequenceMockTransport returns responses in order: first routing, then
+// data responses from a queue. This allows testing multiple GETs with
+// different server responses.
+type sequenceMockTransport struct {
+	routingResp []byte
+	dataResps   [][]byte
+	dataIdx     int
+	sentMsgs    []sentMsg
+}
+
+func (m *sequenceMockTransport) sendRequest(msg []byte, addr string) error {
+	m.sentMsgs = append(m.sentMsgs, sentMsg{data: msg, addr: addr})
+	return nil
+}
+
+func (m *sequenceMockTransport) recvResponse(useKeyAddress bool) ([]byte, error) {
+	if useKeyAddress {
+		return m.routingResp, nil
+	}
+	if m.dataIdx < len(m.dataResps) {
+		resp := m.dataResps[m.dataIdx]
+		m.dataIdx++
+		return resp, nil
+	}
+	return nil, fmt.Errorf("no more mock responses")
+}
+
+func (m *sequenceMockTransport) close() error { return nil }
+
+func makeLWWResponse(key string, value string, timestamp uint64) []byte {
+	lww := &kvspb.LWWValue{Timestamp: timestamp, Value: []byte(value)}
+	lwwBytes, _ := proto.Marshal(lww)
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: key, Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBytes}},
+	}
+	respBytes, _ := proto.Marshal(response)
+	return respBytes
+}
+
+func TestMonotonicReadReturnsCachedOnStale(t *testing.T) {
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "k", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	tp := &sequenceMockTransport{
+		routingResp: routingBytes,
+		dataResps: [][]byte{
+			makeLWWResponse("k", "new", 100),
+			makeLWWResponse("k", "old", 50), // stale
+		},
+	}
+	client := &KVSClient{
+		routingThreads:  []*UserRoutingThread{NewUserRoutingThread("127.0.0.1", 0)},
+		rid:             0,
+		ut:              NewUserThread("127.0.0.1", 0),
+		rng:             rand.New(rand.NewSource(42)),
+		keyAddressCache: make(map[string][]string),
+		tp:              tp,
+		lwwReadCache:    make(map[string]lwwCacheEntry),
+	}
+
+	val1, err := client.Get("k")
+	if err != nil {
+		t.Fatalf("first Get failed: %v", err)
+	}
+	if val1 != "new" {
+		t.Errorf("first Get = %q, want %q", val1, "new")
+	}
+
+	val2, err := client.Get("k")
+	if err != nil {
+		t.Fatalf("second Get failed: %v", err)
+	}
+	if val2 != "new" {
+		t.Errorf("stale Get should return cached value %q, got %q", "new", val2)
+	}
+}
+
+func TestMonotonicReadUpdatesOnNewer(t *testing.T) {
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "k", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	tp := &sequenceMockTransport{
+		routingResp: routingBytes,
+		dataResps: [][]byte{
+			makeLWWResponse("k", "first", 100),
+			makeLWWResponse("k", "second", 200), // newer
+		},
+	}
+	client := &KVSClient{
+		routingThreads:  []*UserRoutingThread{NewUserRoutingThread("127.0.0.1", 0)},
+		rid:             0,
+		ut:              NewUserThread("127.0.0.1", 0),
+		rng:             rand.New(rand.NewSource(42)),
+		keyAddressCache: make(map[string][]string),
+		tp:              tp,
+		lwwReadCache:    make(map[string]lwwCacheEntry),
+	}
+
+	val1, _ := client.Get("k")
+	if val1 != "first" {
+		t.Errorf("first Get = %q, want %q", val1, "first")
+	}
+
+	val2, _ := client.Get("k")
+	if val2 != "second" {
+		t.Errorf("newer Get = %q, want %q", val2, "second")
 	}
 }

--- a/clients/python/anna/client.py
+++ b/clients/python/anna/client.py
@@ -104,6 +104,11 @@ class AnnaTcpClient(BaseAnnaClient):
         self._max_retries = 5
         self._timeout_ms = 10000
 
+        # Monotonic read cache: per-key high-water mark of LWW timestamps
+        # and the corresponding deserialized value. When a GET returns a
+        # stale timestamp, the cached value is returned instead.
+        self._lww_read_cache = {}
+
     def set_timeout(self, timeout_ms):
         """Set the request timeout in milliseconds."""
         self._timeout_ms = timeout_ms
@@ -160,7 +165,15 @@ class AnnaTcpClient(BaseAnnaClient):
                             self._invalidate_cache(tup.key)
                         retry_keys.append(tup.key)
                     elif tup.error == NO_ERROR:
-                        kv_pairs[tup.key] = self._deserialize(tup)
+                        value = self._deserialize(tup)
+                        # Monotonic read enforcement for LWW values.
+                        if hasattr(value, 'ts'):
+                            cached = self._lww_read_cache.get(tup.key)
+                            if cached is not None and value.ts < cached.ts:
+                                value = cached
+                            else:
+                                self._lww_read_cache[tup.key] = value
+                        kv_pairs[tup.key] = value
 
             pending = retry_keys
 

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -784,6 +784,55 @@ class TestConfigurableTimeout:
         assert client.get_timeout() == 5000
 
 
+class TestMonotonicReads:
+    def _get_with_timestamp(self, client, key, value, timestamp):
+        """Helper: mock a GET that returns an LWW value with a specific timestamp."""
+        lww_val = LWWValue()
+        lww_val.timestamp = timestamp
+        lww_val.value = value.encode()
+
+        response = KeyResponse()
+        response.response_id = "placeholder"
+        tup = response.tuples.add()
+        tup.key = key
+        tup.lattice_type = LWW
+        tup.payload = lww_val.SerializeToString()
+        tup.error = NO_ERROR
+
+        client.address_cache[key] = ["tcp://127.0.0.1:6200"]
+        mock_send_sock = MagicMock()
+        client.pusher_cache = MagicMock()
+        client.pusher_cache.get.return_value = mock_send_sock
+
+        with patch("anna.client.send_request"), \
+             patch("anna.client.recv_response") as mock_recv:
+            def recv_side_effect(req_ids, sock, cls, timeout=10000):
+                response.response_id = req_ids[0]
+                return [response]
+            mock_recv.side_effect = recv_side_effect
+            return client.get(key)
+
+    def test_monotonic_read_returns_cached_on_stale(self):
+        client = make_client()
+
+        # First read: timestamp 100
+        result1 = self._get_with_timestamp(client, "k", "new", 100)
+        assert result1["k"].reveal() == b"new"
+
+        # Second read: stale timestamp 50 — should return cached "new"
+        result2 = self._get_with_timestamp(client, "k", "old", 50)
+        assert result2["k"].reveal() == b"new"
+
+    def test_monotonic_read_updates_on_newer(self):
+        client = make_client()
+
+        result1 = self._get_with_timestamp(client, "k", "first", 100)
+        assert result1["k"].reveal() == b"first"
+
+        result2 = self._get_with_timestamp(client, "k", "second", 200)
+        assert result2["k"].reveal() == b"second"
+
+
 class TestResponseAddress:
     def test_returns_connect_address(self):
         client = make_client()

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -58,6 +58,11 @@ pub struct KVSClient {
     key_address_cache: HashMap<Key, HashSet<Address>>,
     timeout: Duration,
     transport: Transport,
+    /// Monotonic read tracking: per-key high-water mark of LWW timestamps
+    /// and the corresponding value. When a GET returns a stale timestamp
+    /// (lower than the tracked max), the cached value is returned instead,
+    /// guaranteeing monotonic reads.
+    lww_read_cache: HashMap<Key, (u64, Vec<u8>)>,
 }
 
 impl KVSClient {
@@ -118,6 +123,7 @@ impl KVSClient {
                 key_address_puller,
                 response_puller,
             },
+            lww_read_cache: HashMap::new(),
         }
     }
 
@@ -135,6 +141,7 @@ impl KVSClient {
             transport: Transport::Mock {
                 responses: std::collections::VecDeque::new(),
             },
+            lww_read_cache: HashMap::new(),
         }
     }
 
@@ -437,8 +444,9 @@ impl KVSClient {
     /// metadata keys that contain serialized protobuf payloads.
     pub async fn get_bytes<K: AsRef<str> + Display>(&mut self, key: K) -> Result<Vec<u8>> {
         debug!("GET_BYTES: {}", key);
+        let key_str = key.as_ref().to_string();
         let response = self
-            .send_data_request(key.as_ref(), RequestType::Get as i32, None, None)
+            .send_data_request(&key_str, RequestType::Get as i32, None, None)
             .await
             .ok_or_else(|| Error::Kvs("GET_BYTES: request failed or timed out".into()))?;
 
@@ -446,6 +454,18 @@ impl KVSClient {
 
         let lww = LwwValue::decode(tuple.payload.as_slice())
             .map_err(|e| Error::Kvs(format!("GET_BYTES: failed to decode LWW value: {}", e)))?;
+
+        // Monotonic read enforcement: if we've seen a higher timestamp for
+        // this key before, return the cached value instead of the stale one.
+        if let Some((cached_ts, cached_val)) = self.lww_read_cache.get(&key_str) {
+            if lww.timestamp < *cached_ts {
+                return Ok(cached_val.clone());
+            }
+        }
+
+        // Update the high-water mark for this key.
+        self.lww_read_cache
+            .insert(key_str, (lww.timestamp, lww.value.clone()));
         Ok(lww.value)
     }
 
@@ -1135,9 +1155,10 @@ impl KVSClient {
         }
     }
 
-    /// Clear the key-address cache.
+    /// Clear the key-address cache and the monotonic read cache.
     pub fn clear_cache(&mut self) {
-        self.key_address_cache.clear()
+        self.key_address_cache.clear();
+        self.lww_read_cache.clear();
     }
 
     /// Set the request timeout duration.
@@ -1167,8 +1188,12 @@ mod tests {
     }
 
     fn make_get_response(key: &str, value: &[u8]) -> Vec<u8> {
+        make_get_response_with_ts(key, value, 1)
+    }
+
+    fn make_get_response_with_ts(key: &str, value: &[u8], timestamp: u64) -> Vec<u8> {
         let lww = LwwValue {
-            timestamp: 1,
+            timestamp,
             value: value.to_vec(),
         };
         let response = KeyResponse {
@@ -1703,5 +1728,74 @@ mod tests {
         let encoded = set.encode_to_vec();
         let decoded = KVSClient::decode_monitoring_ips(&encoded);
         assert!(decoded.is_empty());
+    }
+
+    #[tokio::test]
+    async fn monotonic_read_returns_cached_on_stale() {
+        let mut client = mock_client(200);
+        let worker = "tcp://127.0.0.1:6200";
+        let key = "mono_key";
+
+        // First read: timestamp 100, value "new"
+        client.push_mock_response(true, Some(make_routing_response(key, worker)));
+        client.push_mock_response(false, Some(make_get_response_with_ts(key, b"new", 100)));
+        let val = client.get(key).await.expect("first GET failed");
+        assert_eq!(val, "new");
+
+        // Second read: stale timestamp 50, value "old" — should return cached "new"
+        client.push_mock_response(false, Some(make_get_response_with_ts(key, b"old", 50)));
+        let val = client.get(key).await.expect("stale GET failed");
+        assert_eq!(
+            val, "new",
+            "Monotonic read should return cached value on stale response"
+        );
+    }
+
+    #[tokio::test]
+    async fn monotonic_read_updates_on_newer() {
+        let mut client = mock_client(201);
+        let worker = "tcp://127.0.0.1:6200";
+        let key = "mono_key2";
+
+        // First read: timestamp 100
+        client.push_mock_response(true, Some(make_routing_response(key, worker)));
+        client.push_mock_response(false, Some(make_get_response_with_ts(key, b"first", 100)));
+        let val = client.get(key).await.expect("first GET failed");
+        assert_eq!(val, "first");
+
+        // Second read: newer timestamp 200 — should update and return new value
+        client.push_mock_response(false, Some(make_get_response_with_ts(key, b"second", 200)));
+        let val = client.get(key).await.expect("newer GET failed");
+        assert_eq!(
+            val, "second",
+            "Monotonic read should accept newer timestamp"
+        );
+    }
+
+    #[tokio::test]
+    async fn monotonic_read_cache_cleared_with_clear_cache() {
+        let mut client = mock_client(202);
+        let worker = "tcp://127.0.0.1:6200";
+        let key = "mono_clear";
+
+        // Read with timestamp 100
+        client.push_mock_response(true, Some(make_routing_response(key, worker)));
+        client.push_mock_response(false, Some(make_get_response_with_ts(key, b"cached", 100)));
+        client.get(key).await.expect("first GET failed");
+
+        // Clear cache
+        client.clear_cache();
+
+        // Read with lower timestamp 50 — should succeed since cache was cleared
+        client.push_mock_response(true, Some(make_routing_response(key, worker)));
+        client.push_mock_response(
+            false,
+            Some(make_get_response_with_ts(key, b"after_clear", 50)),
+        );
+        let val = client.get(key).await.expect("GET after clear failed");
+        assert_eq!(
+            val, "after_clear",
+            "After clear_cache, stale values should be accepted"
+        );
     }
 }

--- a/docs/lattices.md
+++ b/docs/lattices.md
@@ -226,10 +226,12 @@ support them, but no implementation exists in this codebase.
 - **PRAM**: Would compose monotonic reads, monotonic writes, and
   read-your-writes — each of which would need explicit enforcement.
 
-**Emergent properties** (not enforced, but partially hold):
-- **Monotonic Reads**: Holds on a single replica because lattice merge is
-  monotonically increasing. Not guaranteed across replicas during gossip
-  convergence (stale reads are possible).
+**Emergent properties**:
+- **Monotonic Reads**: **Enforced** in all client libraries. Each client
+  tracks the highest LWW timestamp seen per key. If a GET response has
+  a lower timestamp (e.g., from a stale replica), the client returns the
+  previously cached value instead. This guarantees that once a client
+  reads a value, subsequent reads never return an older version.
 - **Monotonic Writes**: Emergent from LWW's monotonically increasing
   timestamps. Not a separate implementation.
 - **Read Your Writes**: Holds when reading from the same replica that


### PR DESCRIPTION
## Summary

Enforce monotonic reads in all four client libraries (Rust, C++, Python, Go). Once a client reads a value for a key, subsequent reads never return an older version — even if routed to a stale replica.

## How it works

Each client tracks the highest LWW timestamp seen per key. When a GET response has a lower timestamp than the tracked maximum, the cached value is returned instead of the stale one. This guarantees monotonic reads within a client session without retries or additional network round-trips.

## Changes

| Client | Cache location | Enforcement point |
|--------|---------------|-------------------|
| Rust | `KVSClient.lww_read_cache: HashMap<Key, (u64, Vec<u8>)>` | `get_bytes()` |
| C++ | `annalib::lww_read_cache` (namespace scope) | `decode_lww_value(key, payload)` |
| Python | `AnnaTcpClient._lww_read_cache` (instance dict) | `get()` after `_deserialize()` |
| Go | `KVSClient.lwwReadCache map[string]lwwCacheEntry` | `Get()` after `parseLWWPayload()` |

No protobuf or server changes needed — the LWW timestamp is already present in every GET response.

## Tests

3 new Rust unit tests:
- `monotonic_read_returns_cached_on_stale` — stale response returns cached value
- `monotonic_read_updates_on_newer` — newer response updates cache
- `monotonic_read_cache_cleared_with_clear_cache` — `clear_cache()` resets tracking

## Scope

This is the first of the consistency levels from #441. Monotonic reads apply to LWW values (the default and most common type). Set, Causal, Priority types use different versioning and would need separate tracking.

## Pre-commit checks
- `make clippy` - pass
- `make fmt` - pass
- `make test` - all tests pass (110 Rust, all C++/Python/Go)

Partially addresses #441