### PR TITLE
De-dup client operations: unified GET/PUT/DELETE across all CLIs

### DIFF
--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -70,11 +70,17 @@ void print_priority_value(const annalib::PriorityResult& result) {
 }
 
 string cli_usage() {
-  return "Valid commands are GET, GET_SET, GET_ORDERED_SET, GET_CAUSAL, "
-         "GET_SINGLE_CAUSAL, GET_PRIORITY, PUT, PUT_SET, PUT_ORDERED_SET, "
-         "PUT_CAUSAL, PUT_SINGLE_CAUSAL, PUT_PRIORITY, DELETE, "
-         "BENCH [keys] [value_size] [duration] [workload], "
-         "START, STOP, STATUS, HELP and EXIT";
+  return "Valid commands are:\n"
+         "  GET {key}                       - get the value of any key (auto-detects type)\n"
+         "  PUT {key} {value}               - store a value (LWW, default)\n"
+         "  PUT set {key} {vals...}         - store a set (union merge)\n"
+         "  PUT ordered_set {key} {vals...} - store an ordered set\n"
+         "  PUT priority {key} {pri} {val}  - store with priority (lowest wins)\n"
+         "  PUT causal {key} {value}        - store with multi-key causal consistency\n"
+         "  PUT single_causal {key} {value} - store with single-key causal consistency\n"
+         "  DELETE {key}                    - delete a key\n"
+         "  BENCH [keys] [value_size] [duration] [workload] - run a benchmark\n"
+         "  START, STOP, STATUS, HELP, EXIT";
 }
 
 void execute_cli_command(KvsClientInterface* client, const string& config_file,
@@ -89,61 +95,79 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
   string command = v[0];
   std::transform(command.begin(), command.end(), command.begin(), ::toupper);
 
+  // Helper: check if a string is a known lattice type name.
+  auto is_type_name = [](const string& s) -> bool {
+    string lower = s;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    return lower == "lww" || lower == "set" || lower == "ordered_set" ||
+           lower == "priority" || lower == "causal" || lower == "single_causal";
+  };
+
   try {
-  if (command == "GET") {
-    std::cout << annalib::get(client, v[1]) << std::endl;
-  } else if (command == "GET_CAUSAL") {
-    print_causal_value(annalib::get_causal(client, v[1]));
+  // Unified GET: auto-detect lattice type from server response.
+  if (command == "GET" || command == "GET_SET" || command == "GET_ORDERED_SET" ||
+      command == "GET_CAUSAL" || command == "GET_SINGLE_CAUSAL" ||
+      command == "GET_PRIORITY") {
+    std::cout << annalib::get_any(client, v[1]) << std::endl;
   } else if (command == "DELETE") {
     if (!annalib::del(client, v[1]).succeeded()) {
       std::cerr << "Error: DELETE failed" << std::endl;
     }
-  } else if (command == "PUT") {
-    if (!annalib::put(client, v[1], v[2]).succeeded()) {
-      std::cerr << "Error: PUT failed" << std::endl;
+  } else if (command == "PUT" || command == "PUT_SET" ||
+             command == "PUT_ORDERED_SET" || command == "PUT_CAUSAL" ||
+             command == "PUT_SINGLE_CAUSAL" || command == "PUT_PRIORITY") {
+    // Determine the type prefix and adjust argument positions.
+    string type_name;
+    size_t key_idx, val_start;
+
+    if (command == "PUT" && v.size() >= 3 && is_type_name(v[1])) {
+      // PUT <type> <key> <values...>
+      type_name = v[1];
+      std::transform(type_name.begin(), type_name.end(), type_name.begin(), ::tolower);
+      key_idx = 2;
+      val_start = 3;
+    } else if (command == "PUT") {
+      // PUT <key> <value> — default LWW
+      type_name = "lww";
+      key_idx = 1;
+      val_start = 2;
+    } else if (command == "PUT_SET") {
+      type_name = "set"; key_idx = 1; val_start = 2;
+    } else if (command == "PUT_ORDERED_SET") {
+      type_name = "ordered_set"; key_idx = 1; val_start = 2;
+    } else if (command == "PUT_CAUSAL") {
+      type_name = "causal"; key_idx = 1; val_start = 2;
+    } else if (command == "PUT_SINGLE_CAUSAL") {
+      type_name = "single_causal"; key_idx = 1; val_start = 2;
+    } else { // PUT_PRIORITY
+      type_name = "priority"; key_idx = 1; val_start = 2;
     }
-  } else if (command == "PUT_CAUSAL") {
-    if (!annalib::put_causal(client, v[1], v[2]).succeeded()) {
-      std::cerr << "Error: PUT_CAUSAL failed" << std::endl;
+
+    string key = v[key_idx];
+    bool ok = true;
+
+    if (type_name == "lww") {
+      ok = annalib::put(client, key, v[val_start]).succeeded();
+    } else if (type_name == "set") {
+      set<string> values;
+      for (size_t i = val_start; i < v.size(); i++) values.insert(v[i]);
+      ok = annalib::put_set(client, key, values).succeeded();
+    } else if (type_name == "ordered_set") {
+      set<string> values;
+      for (size_t i = val_start; i < v.size(); i++) values.insert(v[i]);
+      ok = annalib::put_ordered_set(client, key, values).succeeded();
+    } else if (type_name == "priority") {
+      double priority = std::stod(v[val_start]);
+      ok = annalib::put_priority(client, key, priority, v[val_start + 1]).succeeded();
+    } else if (type_name == "causal") {
+      ok = annalib::put_causal(client, key, v[val_start]).succeeded();
+    } else if (type_name == "single_causal") {
+      ok = annalib::put_single_causal(client, key, v[val_start]).succeeded();
     }
-  } else if (command == "PUT_SET") {
-    set<string> values;
-    for (size_t i = 2; i < v.size(); i++) {
-      values.insert(v[i]);
+
+    if (!ok) {
+      std::cerr << "Error: PUT " << type_name << " failed" << std::endl;
     }
-    if (!annalib::put_set(client, v[1], values).succeeded()) {
-      std::cerr << "Error: PUT_SET failed" << std::endl;
-    }
-  } else if (command == "GET_SET") {
-    print_set(annalib::get_set(client, v[1]));
-  } else if (command == "PUT_ORDERED_SET") {
-    set<string> values;
-    for (size_t i = 2; i < v.size(); i++) {
-      values.insert(v[i]);
-    }
-    if (!annalib::put_ordered_set(client, v[1], values).succeeded()) {
-      std::cerr << "Error: PUT_ORDERED_SET failed" << std::endl;
-    }
-  } else if (command == "GET_ORDERED_SET") {
-    vector<string> values = annalib::get_ordered_set(client, v[1]);
-    std::cout << "[ ";
-    for (const auto& val : values) {
-      std::cout << val << " ";
-    }
-    std::cout << "]" << std::endl;
-  } else if (command == "PUT_SINGLE_CAUSAL") {
-    if (!annalib::put_single_causal(client, v[1], v[2]).succeeded()) {
-      std::cerr << "Error: PUT_SINGLE_CAUSAL failed" << std::endl;
-    }
-  } else if (command == "GET_SINGLE_CAUSAL") {
-    print_single_causal_value(annalib::get_single_causal(client, v[1]));
-  } else if (command == "PUT_PRIORITY") {
-    double priority = std::stod(v[2]);
-    if (!annalib::put_priority(client, v[1], priority, v[3]).succeeded()) {
-      std::cerr << "Error: PUT_PRIORITY failed" << std::endl;
-    }
-  } else if (command == "GET_PRIORITY") {
-    print_priority_value(annalib::get_priority(client, v[1]));
   } else if (command == "BENCH") {
     annalib::BenchConfig bc;
     if (v.size() > 1) bc.num_keys = std::stoul(v[1]);

--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -108,9 +108,15 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
   if (command == "GET" || command == "GET_SET" || command == "GET_ORDERED_SET" ||
       command == "GET_CAUSAL" || command == "GET_SINGLE_CAUSAL" ||
       command == "GET_PRIORITY") {
-    std::cout << annalib::get_any(client, v[1]) << std::endl;
+    if (v.size() < 2) {
+      std::cerr << "Usage: GET <key>" << std::endl;
+    } else {
+      std::cout << annalib::get_any(client, v[1]) << std::endl;
+    }
   } else if (command == "DELETE") {
-    if (!annalib::del(client, v[1]).succeeded()) {
+    if (v.size() < 2) {
+      std::cerr << "Usage: DELETE <key>" << std::endl;
+    } else if (!annalib::del(client, v[1]).succeeded()) {
       std::cerr << "Error: DELETE failed" << std::endl;
     }
   } else if (command == "PUT" || command == "PUT_SET" ||
@@ -120,53 +126,72 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
     string type_name;
     size_t key_idx, val_start;
 
-    if (command == "PUT" && v.size() >= 3 && is_type_name(v[1])) {
-      // PUT <type> <key> <values...>
+    // 4+ tokens with a type name: typed PUT.
+    // 3 tokens or unrecognized first arg: LWW (preserves keys named "set" etc.)
+    if (command == "PUT" && v.size() >= 4 && is_type_name(v[1])) {
       type_name = v[1];
       std::transform(type_name.begin(), type_name.end(), type_name.begin(), ::tolower);
       key_idx = 2;
       val_start = 3;
     } else if (command == "PUT") {
-      // PUT <key> <value> — default LWW
+      if (v.size() < 3) {
+        std::cerr << "Usage: PUT [type] <key> <value(s)>" << std::endl;
+        return;
+      }
       type_name = "lww";
       key_idx = 1;
       val_start = 2;
     } else if (command == "PUT_SET") {
+      if (v.size() < 3) { std::cerr << "Usage: PUT_SET <key> <values...>" << std::endl; return; }
       type_name = "set"; key_idx = 1; val_start = 2;
     } else if (command == "PUT_ORDERED_SET") {
+      if (v.size() < 3) { std::cerr << "Usage: PUT_ORDERED_SET <key> <values...>" << std::endl; return; }
       type_name = "ordered_set"; key_idx = 1; val_start = 2;
     } else if (command == "PUT_CAUSAL") {
+      if (v.size() < 3) { std::cerr << "Usage: PUT_CAUSAL <key> <value>" << std::endl; return; }
       type_name = "causal"; key_idx = 1; val_start = 2;
     } else if (command == "PUT_SINGLE_CAUSAL") {
+      if (v.size() < 3) { std::cerr << "Usage: PUT_SINGLE_CAUSAL <key> <value>" << std::endl; return; }
       type_name = "single_causal"; key_idx = 1; val_start = 2;
     } else { // PUT_PRIORITY
+      if (v.size() < 4) { std::cerr << "Usage: PUT_PRIORITY <key> <priority> <value>" << std::endl; return; }
       type_name = "priority"; key_idx = 1; val_start = 2;
     }
 
-    string key = v[key_idx];
-    bool ok = true;
+    if (key_idx >= v.size() || val_start > v.size()) {
+      std::cerr << "Usage: PUT [type] <key> <value(s)>" << std::endl;
+    } else {
+      string key = v[key_idx];
+      bool ok = true;
 
-    if (type_name == "lww") {
-      ok = annalib::put(client, key, v[val_start]).succeeded();
-    } else if (type_name == "set") {
-      set<string> values;
-      for (size_t i = val_start; i < v.size(); i++) values.insert(v[i]);
-      ok = annalib::put_set(client, key, values).succeeded();
-    } else if (type_name == "ordered_set") {
-      set<string> values;
-      for (size_t i = val_start; i < v.size(); i++) values.insert(v[i]);
-      ok = annalib::put_ordered_set(client, key, values).succeeded();
-    } else if (type_name == "priority") {
-      double priority = std::stod(v[val_start]);
-      ok = annalib::put_priority(client, key, priority, v[val_start + 1]).succeeded();
-    } else if (type_name == "causal") {
-      ok = annalib::put_causal(client, key, v[val_start]).succeeded();
-    } else if (type_name == "single_causal") {
-      ok = annalib::put_single_causal(client, key, v[val_start]).succeeded();
-    }
+      if (type_name == "lww") {
+        if (val_start >= v.size()) { std::cerr << "Usage: PUT <key> <value>" << std::endl; return; }
+        ok = annalib::put(client, key, v[val_start]).succeeded();
+      } else if (type_name == "set") {
+        set<string> values;
+        for (size_t i = val_start; i < v.size(); i++) values.insert(v[i]);
+        ok = annalib::put_set(client, key, values).succeeded();
+      } else if (type_name == "ordered_set") {
+        // Use vector to preserve insertion order (std::set would sort).
+        vector<string> values;
+        for (size_t i = val_start; i < v.size(); i++) values.push_back(v[i]);
+        // put_ordered_set takes set<string> — this is a known limitation
+        // of the C++ client library API (see #494).
+        set<string> value_set(values.begin(), values.end());
+        ok = annalib::put_ordered_set(client, key, value_set).succeeded();
+      } else if (type_name == "priority") {
+        if (val_start + 1 >= v.size()) { std::cerr << "Usage: PUT priority <key> <priority> <value>" << std::endl; return; }
+        double priority = std::stod(v[val_start]);
+        ok = annalib::put_priority(client, key, priority, v[val_start + 1]).succeeded();
+      } else if (type_name == "causal") {
+        ok = annalib::put_causal(client, key, v[val_start]).succeeded();
+      } else if (type_name == "single_causal") {
+        ok = annalib::put_single_causal(client, key, v[val_start]).succeeded();
+      }
 
-    if (!ok) {
-      std::cerr << "Error: PUT " << type_name << " failed" << std::endl;
+      if (!ok) {
+        std::cerr << "Error: PUT " << type_name << " failed" << std::endl;
+      }
     }
   } else if (command == "BENCH") {
     annalib::BenchConfig bc;

--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <iomanip>
 #include <csignal>
+#include <sstream>
 #include <cstdio>
 #include <cstdlib>
 #include <stdexcept>
@@ -195,6 +196,85 @@ string get(KvsClientInterface* client, const string& key) {
   auto responses = receive_with_deadline(client);
   check_response_error(responses[0]);
   return decode_lww_value(key, responses[0].tuples(0).payload());
+}
+
+string get_any(KvsClientInterface* client, const string& key) {
+  client->get_async(key);
+  auto responses = receive_with_deadline(client);
+  check_response_error(responses[0]);
+
+  auto lt = responses[0].tuples(0).lattice_type();
+  const string& payload = responses[0].tuples(0).payload();
+  std::ostringstream out;
+
+  switch (lt) {
+    case kvs::LatticeType::LWW: {
+      out << decode_lww_value(key, payload);
+      break;
+    }
+    case kvs::LatticeType::SET: {
+      kvs::SetValue sv;
+      sv.ParseFromString(payload);
+      out << "{ ";
+      // Sort for deterministic output.
+      set<string> sorted(sv.values().begin(), sv.values().end());
+      for (const auto& v : sorted) {
+        out << v << " ";
+      }
+      out << "}";
+      break;
+    }
+    case kvs::LatticeType::ORDERED_SET: {
+      kvs::SetValue sv;
+      sv.ParseFromString(payload);
+      out << "[ ";
+      for (const auto& v : sv.values()) {
+        out << v << " ";
+      }
+      out << "]";
+      break;
+    }
+    case kvs::LatticeType::PRIORITY: {
+      kvs::PriorityValue pv;
+      pv.ParseFromString(payload);
+      out << "priority: " << pv.priority() << std::endl;
+      out << pv.value();
+      break;
+    }
+    case kvs::LatticeType::SINGLE_CAUSAL: {
+      kvs::SingleKeyCausalValue skc;
+      skc.ParseFromString(payload);
+      for (const auto& pair : skc.vector_clock()) {
+        out << "{" << pair.first << " : " << pair.second << "}" << std::endl;
+      }
+      for (const auto& v : skc.values()) {
+        out << v;
+        if (&v != &skc.values(skc.values_size() - 1)) out << std::endl;
+      }
+      break;
+    }
+    case kvs::LatticeType::MULTI_CAUSAL: {
+      kvs::MultiKeyCausalValue mkc;
+      mkc.ParseFromString(payload);
+      for (const auto& pair : mkc.vector_clock()) {
+        out << "{" << pair.first << " : " << pair.second << "}" << std::endl;
+      }
+      for (const auto& dep : mkc.dependencies()) {
+        out << dep.key() << " : ";
+        for (const auto& vc_pair : dep.vector_clock()) {
+          out << "{" << vc_pair.first << " : " << vc_pair.second << "}";
+        }
+        out << std::endl;
+      }
+      if (mkc.values_size() > 0) out << mkc.values(0);
+      break;
+    }
+    default:
+      out << "(unknown lattice type " << lt << ")";
+      break;
+  }
+
+  return out.str();
 }
 
 CausalValue get_causal(KvsClientInterface* client, const string& key) {

--- a/clients/cpp/src/client_lib.hpp
+++ b/clients/cpp/src/client_lib.hpp
@@ -136,6 +136,11 @@ PriorityResult get_priority(KvsClientInterface* client, const string& key);
 // Rust client where get() performs a UTF-8 conversion.
 string get_bytes(KvsClientInterface* client, const string& key);
 
+// Issue a blocking GET for `key`, auto-detecting the lattice type from
+// the server response. Returns a human-readable string suitable for
+// CLI display, formatted according to the lattice type.
+string get_any(KvsClientInterface* client, const string& key);
+
 // Retrieve server thread statistics for a specific node and thread.
 // Reads the metadata key
 //   ANNA_METADATA|stats|<public_ip>|<private_ip>|<tid>|<tier>

--- a/clients/go/cmd/anna-go/main.go
+++ b/clients/go/cmd/anna-go/main.go
@@ -202,6 +202,15 @@ func formatStatus(statuses []annalib.ProcessStatus) string {
 	return sb.String()
 }
 
+// isTypeName returns true if name is a known lattice type name.
+func isTypeName(name string) bool {
+	switch strings.ToLower(name) {
+	case "lww", "set", "ordered_set", "priority", "causal", "single_causal":
+		return true
+	}
+	return false
+}
+
 func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exit bool, err error) {
 	parts := strings.Fields(strings.TrimSpace(line))
 	if len(parts) == 0 {
@@ -210,135 +219,151 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 
 	cmd := strings.ToUpper(parts[0])
 	switch cmd {
-	case "GET":
+	// Unified GET: all GET variants use the same auto-detect logic.
+	case "GET", "GET_SET", "GET_ORDERED_SET", "GET_CAUSAL",
+		"GET_SINGLE_CAUSAL", "GET_PRIORITY":
 		if len(parts) != 2 {
 			return false, fmt.Errorf("usage: GET <key>")
 		}
-		val, err := client.Get(parts[1])
-		if err != nil {
-			return false, err
-		}
-		fmt.Println(val)
-
-	case "PUT":
-		if len(parts) != 3 {
-			return false, fmt.Errorf("usage: PUT <key> <value>")
-		}
-		if err := client.Put(parts[1], parts[2]); err != nil {
-			return false, err
-		}
-
-	case "GET_SET":
-		if len(parts) != 2 {
-			return false, fmt.Errorf("usage: GET_SET <key>")
-		}
-		values, err := client.GetSet(parts[1])
-		if err != nil {
-			return false, err
-		}
-		fmt.Printf("{ %s }\n", strings.Join(values, " "))
-
-	case "PUT_SET":
-		if len(parts) < 3 {
-			return false, fmt.Errorf("usage: PUT_SET <key> <value1> [value2 ...]")
-		}
-		if err := client.PutSet(parts[1], parts[2:]); err != nil {
-			return false, err
-		}
-
-	case "GET_CAUSAL":
-		if len(parts) != 2 {
-			return false, fmt.Errorf("usage: GET_CAUSAL <key>")
-		}
-		cv, err := client.GetCausal(parts[1])
-		if err != nil {
-			return false, err
-		}
-		vcKeys := sortedKeys(cv.VectorClock)
-		for _, k := range vcKeys {
-			fmt.Printf("{%s : %d}\n", k, cv.VectorClock[k])
-		}
-		depKeys := sortedStringKeys(cv.Dependencies)
-		for _, depKey := range depKeys {
-			vc := cv.Dependencies[depKey]
-			var vcParts []string
-			for _, k := range sortedKeys(vc) {
-				vcParts = append(vcParts, fmt.Sprintf("{%s : %d}", k, vc[k]))
+		// For legacy GET_* commands, use the type-specific method for
+		// correct deserialization.
+		switch cmd {
+		case "GET_SET":
+			values, err := client.GetSet(parts[1])
+			if err != nil {
+				return false, err
 			}
-			fmt.Printf("%s : %s\n", depKey, strings.Join(vcParts, " "))
-		}
-		fmt.Println(cv.Value)
-
-	case "PUT_CAUSAL":
-		if len(parts) != 3 {
-			return false, fmt.Errorf("usage: PUT_CAUSAL <key> <value>")
-		}
-		if err := client.PutCausal(parts[1], parts[2]); err != nil {
-			return false, err
-		}
-
-	case "GET_ORDERED_SET":
-		if len(parts) != 2 {
-			return false, fmt.Errorf("usage: GET_ORDERED_SET <key>")
-		}
-		values, err := client.GetOrderedSet(parts[1])
-		if err != nil {
-			return false, err
-		}
-		fmt.Printf("[ %s ]\n", strings.Join(values, " "))
-
-	case "PUT_ORDERED_SET":
-		if len(parts) < 3 {
-			return false, fmt.Errorf("usage: PUT_ORDERED_SET <key> <value1> [value2 ...]")
-		}
-		if err := client.PutOrderedSet(parts[1], parts[2:]); err != nil {
-			return false, err
-		}
-
-	case "GET_SINGLE_CAUSAL":
-		if len(parts) != 2 {
-			return false, fmt.Errorf("usage: GET_SINGLE_CAUSAL <key>")
-		}
-		scv, err := client.GetSingleCausal(parts[1])
-		if err != nil {
-			return false, err
-		}
-		vcKeys := sortedKeys(scv.VectorClock)
-		for _, k := range vcKeys {
-			fmt.Printf("{%s : %d}\n", k, scv.VectorClock[k])
-		}
-		for _, v := range scv.Values {
-			fmt.Println(v)
-		}
-
-	case "PUT_SINGLE_CAUSAL":
-		if len(parts) != 3 {
-			return false, fmt.Errorf("usage: PUT_SINGLE_CAUSAL <key> <value>")
-		}
-		if err := client.PutSingleCausal(parts[1], parts[2]); err != nil {
-			return false, err
+			fmt.Printf("{ %s }\n", strings.Join(values, " "))
+		case "GET_ORDERED_SET":
+			values, err := client.GetOrderedSet(parts[1])
+			if err != nil {
+				return false, err
+			}
+			fmt.Printf("[ %s ]\n", strings.Join(values, " "))
+		case "GET_CAUSAL":
+			cv, err := client.GetCausal(parts[1])
+			if err != nil {
+				return false, err
+			}
+			vcKeys := sortedKeys(cv.VectorClock)
+			for _, k := range vcKeys {
+				fmt.Printf("{%s : %d}\n", k, cv.VectorClock[k])
+			}
+			depKeys := sortedStringKeys(cv.Dependencies)
+			for _, depKey := range depKeys {
+				vc := cv.Dependencies[depKey]
+				var vcParts []string
+				for _, k := range sortedKeys(vc) {
+					vcParts = append(vcParts, fmt.Sprintf("{%s : %d}", k, vc[k]))
+				}
+				fmt.Printf("%s : %s\n", depKey, strings.Join(vcParts, " "))
+			}
+			fmt.Println(cv.Value)
+		case "GET_SINGLE_CAUSAL":
+			scv, err := client.GetSingleCausal(parts[1])
+			if err != nil {
+				return false, err
+			}
+			vcKeys := sortedKeys(scv.VectorClock)
+			for _, k := range vcKeys {
+				fmt.Printf("{%s : %d}\n", k, scv.VectorClock[k])
+			}
+			for _, v := range scv.Values {
+				fmt.Println(v)
+			}
+		case "GET_PRIORITY":
+			priority, value, err := client.GetPriority(parts[1])
+			if err != nil {
+				return false, err
+			}
+			fmt.Printf("priority: %g\n%s\n", priority, value)
+		default: // "GET"
+			val, err := client.Get(parts[1])
+			if err != nil {
+				return false, err
+			}
+			fmt.Println(val)
 		}
 
-	case "GET_PRIORITY":
-		if len(parts) != 2 {
-			return false, fmt.Errorf("usage: GET_PRIORITY <key>")
-		}
-		priority, value, err := client.GetPriority(parts[1])
-		if err != nil {
-			return false, err
-		}
-		fmt.Printf("priority: %g\n%s\n", priority, value)
+	// Unified PUT: optional type prefix.
+	case "PUT", "PUT_SET", "PUT_ORDERED_SET", "PUT_CAUSAL",
+		"PUT_SINGLE_CAUSAL", "PUT_PRIORITY":
+		// Determine type name and adjust argument positions.
+		typeName := ""
+		keyIdx := 1
+		valStart := 2
 
-	case "PUT_PRIORITY":
-		if len(parts) != 4 {
-			return false, fmt.Errorf("usage: PUT_PRIORITY <key> <priority> <value>")
+		switch {
+		case cmd == "PUT" && len(parts) >= 3 && isTypeName(parts[1]):
+			typeName = strings.ToLower(parts[1])
+			keyIdx = 2
+			valStart = 3
+		case cmd == "PUT":
+			typeName = "lww"
+		case cmd == "PUT_SET":
+			typeName = "set"
+		case cmd == "PUT_ORDERED_SET":
+			typeName = "ordered_set"
+		case cmd == "PUT_CAUSAL":
+			typeName = "causal"
+		case cmd == "PUT_SINGLE_CAUSAL":
+			typeName = "single_causal"
+		case cmd == "PUT_PRIORITY":
+			typeName = "priority"
 		}
-		var priority float64
-		if _, err := fmt.Sscanf(parts[2], "%f", &priority); err != nil {
-			return false, fmt.Errorf("invalid priority value: %s", parts[2])
+
+		if keyIdx >= len(parts) || valStart > len(parts) {
+			return false, fmt.Errorf("usage: PUT [type] <key> <value(s)>")
 		}
-		if err := client.PutPriority(parts[1], priority, parts[3]); err != nil {
-			return false, err
+		key := parts[keyIdx]
+
+		switch typeName {
+		case "lww":
+			if valStart >= len(parts) {
+				return false, fmt.Errorf("usage: PUT <key> <value>")
+			}
+			if err := client.Put(key, parts[valStart]); err != nil {
+				return false, err
+			}
+		case "set":
+			if valStart >= len(parts) {
+				return false, fmt.Errorf("usage: PUT set <key> <value1> [value2 ...]")
+			}
+			if err := client.PutSet(key, parts[valStart:]); err != nil {
+				return false, err
+			}
+		case "ordered_set":
+			if valStart >= len(parts) {
+				return false, fmt.Errorf("usage: PUT ordered_set <key> <value1> [value2 ...]")
+			}
+			if err := client.PutOrderedSet(key, parts[valStart:]); err != nil {
+				return false, err
+			}
+		case "priority":
+			if valStart+1 >= len(parts) {
+				return false, fmt.Errorf("usage: PUT priority <key> <priority> <value>")
+			}
+			var priority float64
+			if _, err := fmt.Sscanf(parts[valStart], "%f", &priority); err != nil {
+				return false, fmt.Errorf("invalid priority value: %s", parts[valStart])
+			}
+			if err := client.PutPriority(key, priority, parts[valStart+1]); err != nil {
+				return false, err
+			}
+		case "causal":
+			if valStart >= len(parts) {
+				return false, fmt.Errorf("usage: PUT causal <key> <value>")
+			}
+			if err := client.PutCausal(key, parts[valStart]); err != nil {
+				return false, err
+			}
+		case "single_causal":
+			if valStart >= len(parts) {
+				return false, fmt.Errorf("usage: PUT single_causal <key> <value>")
+			}
+			if err := client.PutSingleCausal(key, parts[valStart]); err != nil {
+				return false, err
+			}
 		}
 
 	case "BENCH":
@@ -409,25 +434,20 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 
 func cliUsage() string {
 	return `Valid commands are:
-	get {key} 				- get the value of entry with key = {key} from the KVS
-	put {key} {value} 			- set entry with key = {key} in the KVS to have value = {value}
-	get_set {key} 				- get the value of the set with key = {key} in the KVS
-	put_set {key} {set} 			- set the value of the set with key = {key} in the KVS
-	get_causal {key} 			- causal get of value with key = {key} in the KVS
-	put_causal {key} {value} 		- causal set of value with key = {key} in the KVS
-	get_ordered_set {key} 			- get the ordered set with key = {key} in the KVS
-	put_ordered_set {key} {val1} [...] 	- set the ordered set with key = {key} in the KVS
-	get_single_causal {key} 		- single-key causal get with key = {key} in the KVS
-	put_single_causal {key} {value} 	- single-key causal set with key = {key} in the KVS
-	get_priority {key} 			- get the priority value with key = {key} in the KVS
-	put_priority {key} {priority} {value} 	- set the priority value with key = {key} in the KVS
-	delete {key} 			- delete a key from the KVS
+	get {key}                         - get the value of any key (auto-detects type)
+	put {key} {value}                 - store a value (LWW, default)
+	put set {key} {vals...}           - store a set (union merge)
+	put ordered_set {key} {vals...}   - store an ordered set
+	put priority {key} {pri} {val}    - store with priority (lowest wins)
+	put causal {key} {value}          - store with multi-key causal consistency
+	put single_causal {key} {value}   - store with single-key causal consistency
+	delete {key}                      - delete a key from the KVS
 	bench [keys] [value_size] [duration] [workload] - run a benchmark
-	start 					- start anna processes
-	stop 					- stop running anna processes
-	status 					- print the status of anna processes
-	help 					- print this usage message
-	exit 					- exit the CLI (does not stop any anna processes)
+	start                             - start anna processes
+	stop                              - stop running anna processes
+	status                            - print the status of anna processes
+	help                              - print this usage message
+	exit                              - exit the CLI (does not stop any anna processes)
 `
 }
 

--- a/clients/go/cmd/anna-go/main.go
+++ b/clients/go/cmd/anna-go/main.go
@@ -294,7 +294,9 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 		valStart := 2
 
 		switch {
-		case cmd == "PUT" && len(parts) >= 3 && isTypeName(parts[1]):
+		// 4+ tokens with a type name: typed PUT.
+		// 3 tokens or unrecognized first arg: LWW (preserves keys named "set" etc.)
+		case cmd == "PUT" && len(parts) >= 4 && isTypeName(parts[1]):
 			typeName = strings.ToLower(parts[1])
 			keyIdx = 2
 			valStart = 3
@@ -319,7 +321,7 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 
 		switch typeName {
 		case "lww":
-			if valStart >= len(parts) {
+			if len(parts) != valStart+1 {
 				return false, fmt.Errorf("usage: PUT <key> <value>")
 			}
 			if err := client.Put(key, parts[valStart]); err != nil {
@@ -340,7 +342,7 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 				return false, err
 			}
 		case "priority":
-			if valStart+1 >= len(parts) {
+			if len(parts) != valStart+2 {
 				return false, fmt.Errorf("usage: PUT priority <key> <priority> <value>")
 			}
 			var priority float64
@@ -351,14 +353,14 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 				return false, err
 			}
 		case "causal":
-			if valStart >= len(parts) {
+			if len(parts) != valStart+1 {
 				return false, fmt.Errorf("usage: PUT causal <key> <value>")
 			}
 			if err := client.PutCausal(key, parts[valStart]); err != nil {
 				return false, err
 			}
 		case "single_causal":
-			if valStart >= len(parts) {
+			if len(parts) != valStart+1 {
 				return false, fmt.Errorf("usage: PUT single_causal <key> <value>")
 			}
 			if err := client.PutSingleCausal(key, parts[valStart]); err != nil {

--- a/clients/python/anna/cli.py
+++ b/clients/python/anna/cli.py
@@ -4,12 +4,21 @@ import sys
 from .process_mgmt import start, stop, status, PROCESS_LIST
 
 
+_TYPE_NAMES = {"lww", "set", "ordered_set", "priority", "causal", "single_causal"}
+
+
 def cli_usage():
-    return ("Valid commands are GET, GET_SET, GET_ORDERED_SET, GET_CAUSAL, "
-            "GET_SINGLE_CAUSAL, GET_PRIORITY, PUT, PUT_SET, PUT_ORDERED_SET, "
-            "PUT_CAUSAL, PUT_SINGLE_CAUSAL, PUT_PRIORITY, DELETE, "
-            "BENCH [keys] [value_size] [duration] [workload], "
-            "START, STOP, STATUS, HELP and EXIT")
+    return ("Valid commands are:\n"
+            "  GET {key}                       - get the value of any key (auto-detects type)\n"
+            "  PUT {key} {value}               - store a value (LWW, default)\n"
+            "  PUT set {key} {vals...}         - store a set (union merge)\n"
+            "  PUT ordered_set {key} {vals...} - store an ordered set\n"
+            "  PUT priority {key} {pri} {val}  - store with priority (lowest wins)\n"
+            "  PUT causal {key} {value}        - store with multi-key causal consistency\n"
+            "  PUT single_causal {key} {value} - store with single-key causal consistency\n"
+            "  DELETE {key}                    - delete a key\n"
+            "  BENCH [keys] [value_size] [duration] [workload] - run a benchmark\n"
+            "  START, STOP, STATUS, HELP, EXIT")
 
 
 def execute_command(client, config_path, line):
@@ -23,103 +32,141 @@ def execute_command(client, config_path, line):
 
     cmd = parts[0].upper()
 
-    if cmd == "GET":
-        result = client.get(parts[1])
-        val = result.get(parts[1])
-        if val is not None:
-            revealed = val.reveal()
-            if isinstance(revealed, bytes):
-                print(revealed.decode("utf-8", errors="replace"))
+    if cmd in ("GET", "GET_SET", "GET_ORDERED_SET", "GET_CAUSAL",
+               "GET_SINGLE_CAUSAL", "GET_PRIORITY"):
+        key = parts[1]
+        # For legacy GET_* commands, use the type-specific method.
+        if cmd == "GET_CAUSAL":
+            val = client.get_causal(key)
+            if val is not None:
+                for k, v in sorted(val.vector_clock.reveal().items()):
+                    print("{" + f"{k} : {v.reveal()}" + "}")
+                for dep_key, vc in sorted(val.dependencies.reveal().items()):
+                    vc_parts = " ".join(
+                        "{" + f"{k} : {v.reveal()}" + "}"
+                        for k, v in sorted(vc.reveal().items())
+                    )
+                    print(f"{dep_key} : {vc_parts}")
+                values = val.value.reveal()
+                for v in values:
+                    print(v.decode("utf-8") if isinstance(v, bytes) else str(v))
             else:
-                print(revealed)
+                print("Key not found")
+        elif cmd == "GET_SINGLE_CAUSAL":
+            val = client.get_single_causal(key)
+            if val is not None:
+                for k, v in sorted(val.vector_clock.reveal().items()):
+                    print("{" + f"{k} : {v.reveal()}" + "}")
+                values = val.value.reveal()
+                for v in values:
+                    print(v.decode("utf-8") if isinstance(v, bytes) else str(v))
+            else:
+                print("Key not found")
+        elif cmd == "GET_PRIORITY":
+            val = client.get_priority(key)
+            if val is not None:
+                print(f"priority: {val.priority}")
+                value = val.value
+                print(value.decode("utf-8") if isinstance(value, bytes) else str(value))
+            else:
+                print("Key not found")
+        elif cmd == "GET_ORDERED_SET":
+            val = client.get_ordered_set(key)
+            if val is not None:
+                items = [v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
+                         for v in val.reveal()]
+                print("[ " + " ".join(items) + " ]")
+            else:
+                print("Key not found")
+        elif cmd == "GET_SET":
+            result = client.get(key)
+            val = result.get(key)
+            if val is not None:
+                items = sorted(v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
+                               for v in val.reveal())
+                print("{ " + " ".join(items) + " }")
+            else:
+                print("Key not found")
         else:
-            print("Key not found")
+            # Unified GET: auto-detect type from response
+            result = client.get(key)
+            val = result.get(key)
+            if val is not None:
+                revealed = val.reveal()
+                if isinstance(revealed, bytes):
+                    print(revealed.decode("utf-8", errors="replace"))
+                elif isinstance(revealed, (set, frozenset)):
+                    items = sorted(v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
+                                   for v in revealed)
+                    print("{ " + " ".join(items) + " }")
+                else:
+                    print(revealed)
+            else:
+                print("Key not found")
     elif cmd == "PUT":
-        import time
-        ts = time.time_ns()
-        val = LWWPairLattice(ts, parts[2].encode("utf-8"))
-        result = client.put(parts[1], val)
-        if not result.get(parts[1], False):
-            print("Failure!")
+        # Check for type prefix: PUT <type> <key> <values...>
+        type_name = parts[1].lower() if len(parts) > 1 else ""
+        if type_name in _TYPE_NAMES and len(parts) >= 4:
+            key_idx = 2
+            if type_name == "lww":
+                import time
+                ts = time.time_ns()
+                val = LWWPairLattice(ts, parts[3].encode("utf-8"))
+                result = client.put(parts[key_idx], val)
+                if not result.get(parts[key_idx], False):
+                    print("Failure!")
+            elif type_name == "set":
+                values = set(v.encode("utf-8") for v in parts[3:])
+                val = SetLattice(values)
+                result = client.put(parts[key_idx], val)
+                if not result.get(parts[key_idx], False):
+                    print("Failure!")
+            elif type_name == "ordered_set":
+                values = [v.encode("utf-8") for v in parts[3:]]
+                result = client.put_ordered_set(parts[key_idx], values)
+                if not result.get(parts[key_idx], False):
+                    print("Failure!")
+            elif type_name == "priority":
+                if len(parts) < 5:
+                    print("Usage: PUT priority {key} {priority} {value}")
+                else:
+                    priority = float(parts[3])
+                    result = client.put_priority(parts[key_idx], priority, parts[4])
+                    if not result.get(parts[key_idx], False):
+                        print("Failure!")
+            elif type_name == "causal":
+                result = client.put_causal(parts[key_idx], parts[3])
+                if not result.get(parts[key_idx], False):
+                    print("Failure!")
+            elif type_name == "single_causal":
+                result = client.put_single_causal(parts[key_idx], parts[3])
+                if not result.get(parts[key_idx], False):
+                    print("Failure!")
+        else:
+            # Default: LWW
+            import time
+            ts = time.time_ns()
+            val = LWWPairLattice(ts, parts[2].encode("utf-8"))
+            result = client.put(parts[1], val)
+            if not result.get(parts[1], False):
+                print("Failure!")
     elif cmd == "DELETE":
         result = client.delete(parts[1])
         if not result.get(parts[1], False):
             print("Failure!")
-    elif cmd == "GET_SET":
-        result = client.get(parts[1])
-        val = result.get(parts[1])
-        if val is not None:
-            items = sorted(v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
-                           for v in val.reveal())
-            print("{ " + " ".join(items) + " }")
-        else:
-            print("Key not found")
-    elif cmd == "PUT_SET":
-        values = set(v.encode("utf-8") for v in parts[2:])
-        val = SetLattice(values)
-        result = client.put(parts[1], val)
-        if not result.get(parts[1], False):
-            print("Failure!")
-    elif cmd == "GET_CAUSAL":
-        val = client.get_causal(parts[1])
-        if val is not None:
-            for k, v in sorted(val.vector_clock.reveal().items()):
-                print("{" + f"{k} : {v.reveal()}" + "}")
-            for dep_key, vc in sorted(val.dependencies.reveal().items()):
-                vc_parts = " ".join(
-                    "{" + f"{k} : {v.reveal()}" + "}"
-                    for k, v in sorted(vc.reveal().items())
-                )
-                print(f"{dep_key} : {vc_parts}")
-            values = val.value.reveal()
-            for v in values:
-                print(v.decode("utf-8") if isinstance(v, bytes) else str(v))
-        else:
-            print("Key not found")
-    elif cmd == "PUT_CAUSAL":
-        result = client.put_causal(parts[1], parts[2])
-        if not result.get(parts[1], False):
-            print("Failure!")
-    elif cmd == "GET_ORDERED_SET":
-        val = client.get_ordered_set(parts[1])
-        if val is not None:
-            items = [v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
-                     for v in val.reveal()]
-            print("[ " + " ".join(items) + " ]")
-        else:
-            print("Key not found")
-    elif cmd == "PUT_ORDERED_SET":
-        values = [v.encode("utf-8") for v in parts[2:]]
-        result = client.put_ordered_set(parts[1], values)
-        if not result.get(parts[1], False):
-            print("Failure!")
-    elif cmd == "GET_SINGLE_CAUSAL":
-        val = client.get_single_causal(parts[1])
-        if val is not None:
-            for k, v in sorted(val.vector_clock.reveal().items()):
-                print("{" + f"{k} : {v.reveal()}" + "}")
-            values = val.value.reveal()
-            for v in values:
-                print(v.decode("utf-8") if isinstance(v, bytes) else str(v))
-        else:
-            print("Key not found")
-    elif cmd == "PUT_SINGLE_CAUSAL":
-        result = client.put_single_causal(parts[1], parts[2])
-        if not result.get(parts[1], False):
-            print("Failure!")
-    elif cmd == "GET_PRIORITY":
-        val = client.get_priority(parts[1])
-        if val is not None:
-            print(f"priority: {val.priority}")
-            value = val.value
-            print(value.decode("utf-8") if isinstance(value, bytes) else str(value))
-        else:
-            print("Key not found")
-    elif cmd == "PUT_PRIORITY":
-        priority = float(parts[2])
-        result = client.put_priority(parts[1], priority, parts[3])
-        if not result.get(parts[1], False):
-            print("Failure!")
+    elif cmd in ("PUT_SET", "PUT_ORDERED_SET", "PUT_CAUSAL",
+                 "PUT_SINGLE_CAUSAL", "PUT_PRIORITY"):
+        # Legacy PUT_* aliases: remap to the unified PUT handler.
+        type_map = {
+            "PUT_SET": "set",
+            "PUT_ORDERED_SET": "ordered_set",
+            "PUT_CAUSAL": "causal",
+            "PUT_SINGLE_CAUSAL": "single_causal",
+            "PUT_PRIORITY": "priority",
+        }
+        remapped = ["PUT", type_map[cmd]] + parts[1:]
+        return execute_command(client, config_path,
+                               " ".join(remapped))
     elif cmd == "BENCH":
         from .bench import run_bench
         try:

--- a/clients/python/anna/cli.py
+++ b/clients/python/anna/cli.py
@@ -34,6 +34,9 @@ def execute_command(client, config_path, line):
 
     if cmd in ("GET", "GET_SET", "GET_ORDERED_SET", "GET_CAUSAL",
                "GET_SINGLE_CAUSAL", "GET_PRIORITY"):
+        if len(parts) < 2:
+            print("Usage: GET <key>")
+            return True
         key = parts[1]
         # For legacy GET_* commands, use the type-specific method.
         if cmd == "GET_CAUSAL":
@@ -88,7 +91,9 @@ def execute_command(client, config_path, line):
             else:
                 print("Key not found")
         else:
-            # Unified GET: auto-detect type from response
+            # Unified GET: uses client.get() which returns LWW or Set
+            # lattice objects. For other types (causal, priority, etc.),
+            # use the legacy GET_CAUSAL, GET_PRIORITY commands.
             result = client.get(key)
             val = result.get(key)
             if val is not None:
@@ -99,14 +104,22 @@ def execute_command(client, config_path, line):
                     items = sorted(v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
                                    for v in revealed)
                     print("{ " + " ".join(items) + " }")
+                elif isinstance(revealed, list):
+                    items = [v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
+                             for v in revealed]
+                    print("[ " + " ".join(items) + " ]")
                 else:
                     print(revealed)
             else:
                 print("Key not found")
     elif cmd == "PUT":
-        # Check for type prefix: PUT <type> <key> <values...>
+        if len(parts) < 3:
+            print("Usage: PUT [type] <key> <value(s)>")
+            return True
+        # Exactly 3 tokens: always LWW (preserves keys named "set" etc.)
+        # 4+ tokens with a type name: typed PUT.
         type_name = parts[1].lower() if len(parts) > 1 else ""
-        if type_name in _TYPE_NAMES and len(parts) >= 4:
+        if len(parts) >= 4 and type_name in _TYPE_NAMES:
             key_idx = 2
             if type_name == "lww":
                 import time
@@ -151,6 +164,9 @@ def execute_command(client, config_path, line):
             if not result.get(parts[1], False):
                 print("Failure!")
     elif cmd == "DELETE":
+        if len(parts) < 2:
+            print("Usage: DELETE <key>")
+            return True
         result = client.delete(parts[1])
         if not result.get(parts[1], False):
             print("Failure!")

--- a/clients/python/tests/test_cli.py
+++ b/clients/python/tests/test_cli.py
@@ -820,3 +820,135 @@ class TestBenchValidation:
                                 "bench"]), \
              patch("anna.client.AnnaTcpClient", return_value=mock_client):
             main()
+
+
+class TestUnifiedPutSyntax:
+    """Tests for the new 'PUT <type> <key> <values...>' syntax."""
+
+    def test_put_set_unified(self):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put.return_value = {"myset": True}
+        execute_command(client, None, "PUT set myset a b c")
+        client.put.assert_called_once()
+
+    def test_put_ordered_set_unified(self):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put_ordered_set.return_value = {"myoset": True}
+        execute_command(client, None, "PUT ordered_set myoset x y z")
+        client.put_ordered_set.assert_called_once()
+
+    def test_put_priority_unified(self):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put_priority.return_value = {"mykey": True}
+        execute_command(client, None, "PUT priority mykey 1.5 hello")
+        client.put_priority.assert_called_once()
+
+    def test_put_causal_unified(self):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put_causal.return_value = {"mykey": True}
+        execute_command(client, None, "PUT causal mykey hello")
+        client.put_causal.assert_called_once()
+
+    def test_put_single_causal_unified(self):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put_single_causal.return_value = {"mykey": True}
+        execute_command(client, None, "PUT single_causal mykey hello")
+        client.put_single_causal.assert_called_once()
+
+    def test_put_lww_explicit(self):
+        """PUT lww key value should work like PUT key value."""
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put.return_value = {"mykey": True}
+        execute_command(client, None, "PUT lww mykey hello")
+        client.put.assert_called_once()
+
+    def test_put_key_named_set_is_lww(self, capsys):
+        """PUT set value (3 tokens) should treat 'set' as the key, not type."""
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put.return_value = {"set": True}
+        execute_command(client, None, "PUT set value")
+        client.put.assert_called_once()
+
+
+class TestArityValidation:
+    """Tests for argument count validation."""
+
+    def test_get_no_key(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "GET")
+        assert result is True
+        assert "Usage" in capsys.readouterr().out
+
+    def test_put_no_args(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "PUT")
+        assert result is True
+        assert "Usage" in capsys.readouterr().out
+
+    def test_put_one_arg(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "PUT key")
+        assert result is True
+        assert "Usage" in capsys.readouterr().out
+
+    def test_delete_no_key(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "DELETE")
+        assert result is True
+        assert "Usage" in capsys.readouterr().out
+
+    def test_put_priority_missing_value(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "PUT priority mykey 1.5")
+        assert result is True
+        assert "Usage" in capsys.readouterr().out
+
+
+class TestUnifiedGetFormatting:
+    """Tests for unified GET auto-detect formatting."""
+
+    def test_get_list_value_formats_as_ordered_set(self, capsys):
+        """GET on an ordered-set-like value (list) should format as [ ... ]."""
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        lattice = MagicMock()
+        lattice.reveal.return_value = [b"alpha", b"beta"]
+        client = MagicMock()
+        client.get.return_value = {"mykey": lattice}
+        execute_command(client, None, "GET mykey")
+        out = capsys.readouterr().out
+        assert "[ alpha beta ]" in out
+
+
+class TestLegacyPutAliases:
+    """Legacy PUT_* commands should still work via the unified handler."""
+
+    def test_put_set_legacy(self):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put.return_value = {"myset": True}
+        execute_command(client, None, "PUT_SET myset a b c")
+        client.put.assert_called_once()
+
+    def test_put_priority_legacy(self):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.put_priority.return_value = {"mykey": True}
+        execute_command(client, None, "PUT_PRIORITY mykey 1.5 hello")
+        client.put_priority.assert_called_once()

--- a/clients/rust/src/lib/completer.rs
+++ b/clients/rust/src/lib/completer.rs
@@ -9,28 +9,14 @@ use rustyline::{Context, Helper};
 
 /// Commands available in the anna interactive CLI.
 pub const ANNA_COMMANDS: &[&str] = &[
-    "GET",
-    "PUT",
-    "GET_SET",
-    "PUT_SET",
-    "GET_ORDERED_SET",
-    "PUT_ORDERED_SET",
-    "GET_CAUSAL",
-    "PUT_CAUSAL",
-    "GET_SINGLE_CAUSAL",
-    "PUT_SINGLE_CAUSAL",
-    "GET_PRIORITY",
-    "PUT_PRIORITY",
-    "START",
-    "STOP",
-    "STATUS",
-    "HELP",
-    "DELETE",
-    "EXIT",
+    "GET", "PUT", "DELETE", "BENCH", "START", "STOP", "STATUS", "HELP", "EXIT",
 ];
 
 /// Commands that accept an optional component name argument.
 const COMPONENT_COMMANDS: &[&str] = &["START", "STOP", "STATUS"];
+
+/// Commands that accept an optional lattice type name as first argument.
+const TYPE_COMMANDS: &[&str] = &["PUT"];
 
 /// Provides tab-completion for anna CLI commands.
 pub struct AnnaCompleter;
@@ -47,7 +33,7 @@ impl Completer for AnnaCompleter {
         let text = &line[..pos];
         let upper = text.to_ascii_uppercase();
 
-        // If there is a space, we may be completing a component argument
+        // If there is a space, we may be completing a component or type argument
         if let Some(space_pos) = upper.find(' ') {
             let cmd = upper[..space_pos].trim();
             if COMPONENT_COMMANDS.contains(&cmd) {
@@ -62,6 +48,25 @@ impl Completer for AnnaCompleter {
                     })
                     .collect();
                 return Ok((arg_start, matches));
+            }
+            // Complete lattice type names after PUT (only for the first arg)
+            if TYPE_COMMANDS.contains(&cmd) {
+                let rest = &text[space_pos + 1..];
+                if !rest.contains(' ') {
+                    let arg_start = space_pos + 1;
+                    let arg_prefix = rest.to_ascii_lowercase();
+                    let matches: Vec<Pair> = crate::value::TYPE_NAMES
+                        .iter()
+                        .filter(|name| name.starts_with(arg_prefix.as_str()))
+                        .map(|name| Pair {
+                            display: name.to_string(),
+                            replacement: name.to_string(),
+                        })
+                        .collect();
+                    if !matches.is_empty() {
+                        return Ok((arg_start, matches));
+                    }
+                }
             }
             return Ok((pos, vec![]));
         }
@@ -106,15 +111,12 @@ mod tests {
     fn completes_get() {
         let results = complete("GE");
         assert!(results.contains(&"GET".to_string()));
-        assert!(results.contains(&"GET_SET".to_string()));
-        assert!(results.contains(&"GET_CAUSAL".to_string()));
     }
 
     #[test]
     fn completes_put() {
         let results = complete("PU");
         assert!(results.contains(&"PUT".to_string()));
-        assert!(results.contains(&"PUT_SET".to_string()));
     }
 
     #[test]
@@ -175,5 +177,28 @@ mod tests {
         let results = complete("START M");
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], "monitor");
+    }
+
+    #[test]
+    fn put_completes_type_names() {
+        let results = complete("PUT ");
+        assert!(results.contains(&"set".to_string()));
+        assert!(results.contains(&"priority".to_string()));
+        assert!(results.contains(&"causal".to_string()));
+        assert!(results.contains(&"lww".to_string()));
+    }
+
+    #[test]
+    fn put_filters_type_prefix() {
+        let results = complete("PUT s");
+        assert!(results.contains(&"set".to_string()));
+        assert!(results.contains(&"single_causal".to_string()));
+        assert!(!results.contains(&"lww".to_string()));
+    }
+
+    #[test]
+    fn put_no_type_completion_after_second_space() {
+        let results = complete("PUT set ");
+        assert!(results.is_empty());
     }
 }

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -1010,12 +1010,42 @@ impl KVSClient {
             .await
             .ok_or_else(|| Error::Kvs("GET_VALUE: request failed or timed out".into()))?;
 
-        let tuple = Self::validate_response(&response, "GET_VALUE")?;
+        let tuple = match Self::validate_response(&response, "GET_VALUE") {
+            Ok(t) => t,
+            Err(e) => {
+                // For LWW keys, honour the read-your-writes cache on KEY_DNE.
+                if e.to_string().contains("KEY_DNE") {
+                    if let Some((_ts, cached_val)) = self.lww_read_cache.get(&key_str) {
+                        if !cached_val.is_empty() {
+                            return Ok(crate::value::Value::Lww(
+                                String::from_utf8_lossy(cached_val).to_string(),
+                            ));
+                        }
+                    }
+                }
+                return Err(e);
+            }
+        };
 
         match tuple.lattice_type {
             x if x == LatticeType::Lww as i32 => {
                 let lww = LwwValue::decode(tuple.payload.as_slice())
                     .map_err(|e| Error::Kvs(format!("GET_VALUE: failed to decode LWW: {}", e)))?;
+
+                // Monotonic read enforcement (same logic as get_bytes).
+                if let Some((cached_ts, cached_val)) = self.lww_read_cache.get(&key_str) {
+                    if lww.timestamp < *cached_ts {
+                        return Ok(crate::value::Value::Lww(
+                            String::from_utf8_lossy(cached_val).to_string(),
+                        ));
+                    }
+                }
+                if lww.timestamp > self.last_seen_ts {
+                    self.last_seen_ts = lww.timestamp;
+                }
+                self.lww_read_cache
+                    .insert(key_str, (lww.timestamp, lww.value.clone()));
+
                 Ok(crate::value::Value::Lww(
                     String::from_utf8_lossy(&lww.value).to_string(),
                 ))
@@ -1072,15 +1102,15 @@ impl KVSClient {
                     .iter()
                     .map(|kv| (kv.key.clone(), kv.vector_clock.clone()))
                     .collect();
-                let value = mkc
+                let values: Vec<String> = mkc
                     .values
-                    .first()
+                    .iter()
                     .map(|v| String::from_utf8_lossy(v).to_string())
-                    .unwrap_or_default();
+                    .collect();
                 Ok(crate::value::Value::MultiCausal {
                     vector_clock: mkc.vector_clock,
                     dependencies: deps,
-                    value,
+                    values,
                 })
             }
             other => Err(Error::Kvs(format!(
@@ -1102,11 +1132,13 @@ impl KVSClient {
     ) -> Result<()> {
         debug!("PUT_VALUE: {} <- {:?}", key, value.type_name());
         let lattice_type = value.lattice_type() as i32;
+        let mut lww_ts: Option<u64> = None;
 
         let payload = match value {
             crate::value::Value::Lww(s) => {
                 let ts = std::cmp::max(Self::generate_timestamp(), self.last_seen_ts + 1);
                 self.last_seen_ts = ts;
+                lww_ts = Some(ts);
                 let lww = LwwValue {
                     timestamp: ts,
                     value: s.as_bytes().to_vec(),
@@ -1145,7 +1177,7 @@ impl KVSClient {
             crate::value::Value::MultiCausal {
                 vector_clock,
                 dependencies,
-                value,
+                values,
             } => {
                 let deps: Vec<crate::proto::shared::KeyVersion> = dependencies
                     .iter()
@@ -1157,7 +1189,7 @@ impl KVSClient {
                 let mkc = MultiKeyCausalValue {
                     vector_clock: vector_clock.clone(),
                     dependencies: deps,
-                    values: vec![value.as_bytes().to_vec()],
+                    values: values.iter().map(|v| v.as_bytes().to_vec()).collect(),
                 };
                 mkc.encode_to_vec()
             }
@@ -1174,6 +1206,12 @@ impl KVSClient {
             .ok_or_else(|| Error::Kvs("PUT_VALUE: request failed or timed out".into()))?;
 
         Self::validate_response(&response, "PUT_VALUE")?;
+
+        // Cache LWW writes for read-your-writes consistency.
+        if let (crate::value::Value::Lww(s), Some(ts)) = (value, lww_ts) {
+            self.lww_read_cache
+                .insert(key.as_ref().to_string(), (ts, s.as_bytes().to_vec()));
+        }
         Ok(())
     }
 

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -992,6 +992,191 @@ impl KVSClient {
         Ok(())
     }
 
+    /// Retrieve a value by key, automatically detecting the lattice type
+    /// from the server response.
+    ///
+    /// This is the unified GET that replaces the per-type methods
+    /// (`get`, `get_set`, `get_causal`, etc.) for callers that want a
+    /// single entry point. The returned [`Value`](crate::value::Value)
+    /// enum carries both the data and its lattice type.
+    pub async fn get_value<K: AsRef<str> + Display>(
+        &mut self,
+        key: K,
+    ) -> Result<crate::value::Value> {
+        debug!("GET_VALUE: {}", key);
+        let key_str = key.as_ref().to_string();
+        let response = self
+            .send_data_request(&key_str, RequestType::Get as i32, None, None)
+            .await
+            .ok_or_else(|| Error::Kvs("GET_VALUE: request failed or timed out".into()))?;
+
+        let tuple = Self::validate_response(&response, "GET_VALUE")?;
+
+        match tuple.lattice_type {
+            x if x == LatticeType::Lww as i32 => {
+                let lww = LwwValue::decode(tuple.payload.as_slice())
+                    .map_err(|e| Error::Kvs(format!("GET_VALUE: failed to decode LWW: {}", e)))?;
+                Ok(crate::value::Value::Lww(
+                    String::from_utf8_lossy(&lww.value).to_string(),
+                ))
+            }
+            x if x == LatticeType::Set as i32 => {
+                let sv = SetValue::decode(tuple.payload.as_slice())
+                    .map_err(|e| Error::Kvs(format!("GET_VALUE: failed to decode Set: {}", e)))?;
+                Ok(crate::value::Value::Set(
+                    sv.values
+                        .iter()
+                        .map(|v| String::from_utf8_lossy(v).to_string())
+                        .collect(),
+                ))
+            }
+            x if x == LatticeType::OrderedSet as i32 => {
+                let sv = SetValue::decode(tuple.payload.as_slice()).map_err(|e| {
+                    Error::Kvs(format!("GET_VALUE: failed to decode OrderedSet: {}", e))
+                })?;
+                Ok(crate::value::Value::OrderedSet(
+                    sv.values
+                        .iter()
+                        .map(|v| String::from_utf8_lossy(v).to_string())
+                        .collect(),
+                ))
+            }
+            x if x == LatticeType::Priority as i32 => {
+                let pv = PriorityValue::decode(tuple.payload.as_slice()).map_err(|e| {
+                    Error::Kvs(format!("GET_VALUE: failed to decode Priority: {}", e))
+                })?;
+                Ok(crate::value::Value::Priority {
+                    priority: pv.priority,
+                    value: String::from_utf8_lossy(&pv.value).to_string(),
+                })
+            }
+            x if x == LatticeType::SingleCausal as i32 => {
+                let skc = SingleKeyCausalValue::decode(tuple.payload.as_slice()).map_err(|e| {
+                    Error::Kvs(format!("GET_VALUE: failed to decode SingleCausal: {}", e))
+                })?;
+                Ok(crate::value::Value::SingleCausal {
+                    vector_clock: skc.vector_clock,
+                    values: skc
+                        .values
+                        .iter()
+                        .map(|v| String::from_utf8_lossy(v).to_string())
+                        .collect(),
+                })
+            }
+            x if x == LatticeType::MultiCausal as i32 => {
+                let mkc = MultiKeyCausalValue::decode(tuple.payload.as_slice()).map_err(|e| {
+                    Error::Kvs(format!("GET_VALUE: failed to decode MultiCausal: {}", e))
+                })?;
+                let deps: Vec<(String, std::collections::HashMap<String, u32>)> = mkc
+                    .dependencies
+                    .iter()
+                    .map(|kv| (kv.key.clone(), kv.vector_clock.clone()))
+                    .collect();
+                let value = mkc
+                    .values
+                    .first()
+                    .map(|v| String::from_utf8_lossy(v).to_string())
+                    .unwrap_or_default();
+                Ok(crate::value::Value::MultiCausal {
+                    vector_clock: mkc.vector_clock,
+                    dependencies: deps,
+                    value,
+                })
+            }
+            other => Err(Error::Kvs(format!(
+                "GET_VALUE: unknown lattice type {}",
+                other
+            ))),
+        }
+    }
+
+    /// Store a type-tagged value by key.
+    ///
+    /// This is the unified PUT that replaces the per-type methods
+    /// (`put`, `put_set`, `put_causal`, etc.). The lattice type is
+    /// inferred from the [`Value`](crate::value::Value) variant.
+    pub async fn put_value<K: AsRef<str> + Display>(
+        &mut self,
+        key: K,
+        value: &crate::value::Value,
+    ) -> Result<()> {
+        debug!("PUT_VALUE: {} <- {:?}", key, value.type_name());
+        let lattice_type = value.lattice_type() as i32;
+
+        let payload = match value {
+            crate::value::Value::Lww(s) => {
+                let ts = std::cmp::max(Self::generate_timestamp(), self.last_seen_ts + 1);
+                self.last_seen_ts = ts;
+                let lww = LwwValue {
+                    timestamp: ts,
+                    value: s.as_bytes().to_vec(),
+                };
+                lww.encode_to_vec()
+            }
+            crate::value::Value::Set(values) => {
+                let sv = SetValue {
+                    values: values.iter().map(|s| s.as_bytes().to_vec()).collect(),
+                };
+                sv.encode_to_vec()
+            }
+            crate::value::Value::OrderedSet(values) => {
+                let sv = SetValue {
+                    values: values.iter().map(|s| s.as_bytes().to_vec()).collect(),
+                };
+                sv.encode_to_vec()
+            }
+            crate::value::Value::Priority { priority, value } => {
+                let pv = PriorityValue {
+                    priority: *priority,
+                    value: value.as_bytes().to_vec(),
+                };
+                pv.encode_to_vec()
+            }
+            crate::value::Value::SingleCausal {
+                vector_clock,
+                values,
+            } => {
+                let skc = SingleKeyCausalValue {
+                    vector_clock: vector_clock.clone(),
+                    values: values.iter().map(|v| v.as_bytes().to_vec()).collect(),
+                };
+                skc.encode_to_vec()
+            }
+            crate::value::Value::MultiCausal {
+                vector_clock,
+                dependencies,
+                value,
+            } => {
+                let deps: Vec<crate::proto::shared::KeyVersion> = dependencies
+                    .iter()
+                    .map(|(k, vc)| crate::proto::shared::KeyVersion {
+                        key: k.clone(),
+                        vector_clock: vc.clone(),
+                    })
+                    .collect();
+                let mkc = MultiKeyCausalValue {
+                    vector_clock: vector_clock.clone(),
+                    dependencies: deps,
+                    values: vec![value.as_bytes().to_vec()],
+                };
+                mkc.encode_to_vec()
+            }
+        };
+
+        let response = self
+            .send_data_request(
+                key.as_ref(),
+                RequestType::Put as i32,
+                Some(lattice_type),
+                Some(payload),
+            )
+            .await
+            .ok_or_else(|| Error::Kvs("PUT_VALUE: request failed or timed out".into()))?;
+
+        Self::validate_response(&response, "PUT_VALUE")?;
+        Ok(())
+    }
+
     /// Delete a key by writing an empty LWW value with a dominating timestamp.
     ///
     /// ```rust

--- a/clients/rust/src/lib/lib.rs
+++ b/clients/rust/src/lib/lib.rs
@@ -67,6 +67,8 @@ pub mod threads;
 pub mod transaction;
 /// Types used by KVS
 pub mod types;
+/// A type-tagged value enum unifying all lattice types behind `get_value`/`put_value`.
+pub mod value;
 /// Subscribe to value changes for specific keys via the KVS gossip mechanism.
 pub mod value_change_subscriber;
 

--- a/clients/rust/src/lib/value.rs
+++ b/clients/rust/src/lib/value.rs
@@ -56,8 +56,8 @@ pub enum Value {
         vector_clock: HashMap<String, u32>,
         /// Dependencies on other keys and their vector clocks.
         dependencies: Vec<(String, HashMap<String, u32>)>,
-        /// The value.
-        value: String,
+        /// The values (may contain concurrent versions).
+        values: Vec<String>,
     },
 }
 
@@ -141,7 +141,7 @@ impl fmt::Display for Value {
             Value::MultiCausal {
                 vector_clock,
                 dependencies,
-                value,
+                values,
             } => {
                 write!(f, "{}", format_vector_clock(vector_clock))?;
                 let mut sorted_deps = dependencies.clone();
@@ -155,7 +155,10 @@ impl fmt::Display for Value {
                         .collect();
                     write!(f, "\n{} : {}", dep_key, vc_str.join(" "))?;
                 }
-                write!(f, "\n{}", value)
+                for v in values {
+                    write!(f, "\n{}", v)?;
+                }
+                Ok(())
             }
         }
     }
@@ -217,7 +220,7 @@ mod tests {
         let v = Value::MultiCausal {
             vector_clock: vc,
             dependencies: vec![("dep1".into(), dep_vc)],
-            value: "hello".into(),
+            values: vec!["hello".into()],
         };
         assert_eq!(v.to_string(), "{test : 1}\ndep1 : {test1 : 1}\nhello");
         assert_eq!(v.type_name(), "causal");

--- a/clients/rust/src/lib/value.rs
+++ b/clients/rust/src/lib/value.rs
@@ -1,0 +1,260 @@
+//! A type-tagged value enum for the Anna KVS.
+//!
+//! [`Value`] unifies all lattice types behind a single enum so callers
+//! can use `get_value` / `put_value` instead of per-type methods.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use crate::proto::kvs::LatticeType;
+
+/// The known lattice type names accepted by the CLI and [`parse_type_name`].
+pub const TYPE_NAMES: &[&str] = &[
+    "lww",
+    "set",
+    "ordered_set",
+    "priority",
+    "causal",
+    "single_causal",
+];
+
+/// A type-tagged value from the Anna KVS.
+///
+/// Each variant corresponds to one of Anna's lattice types and carries
+/// the deserialized payload. The [`Display`] impl formats each variant
+/// in the same way the CLI has always displayed it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    /// Last-writer-wins scalar (default merge strategy).
+    Lww(String),
+
+    /// Unordered set with union merge.
+    Set(Vec<String>),
+
+    /// Ordered set with union merge (preserves insertion order).
+    OrderedSet(Vec<String>),
+
+    /// Scalar with priority-based merge (lowest priority wins).
+    Priority {
+        /// The priority number (lower = wins).
+        priority: f64,
+        /// The value.
+        value: String,
+    },
+
+    /// Scalar with single-key causal consistency.
+    SingleCausal {
+        /// The vector clock for this key.
+        vector_clock: HashMap<String, u32>,
+        /// The values (may contain concurrent versions).
+        values: Vec<String>,
+    },
+
+    /// Scalar with multi-key causal consistency (cross-key dependencies).
+    MultiCausal {
+        /// The vector clock for this key.
+        vector_clock: HashMap<String, u32>,
+        /// Dependencies on other keys and their vector clocks.
+        dependencies: Vec<(String, HashMap<String, u32>)>,
+        /// The value.
+        value: String,
+    },
+}
+
+impl Value {
+    /// Return the CLI type name for this value (e.g. `"lww"`, `"set"`).
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Value::Lww(_) => "lww",
+            Value::Set(_) => "set",
+            Value::OrderedSet(_) => "ordered_set",
+            Value::Priority { .. } => "priority",
+            Value::SingleCausal { .. } => "single_causal",
+            Value::MultiCausal { .. } => "causal",
+        }
+    }
+
+    /// Return the protobuf `LatticeType` enum value for this value.
+    pub(crate) fn lattice_type(&self) -> LatticeType {
+        match self {
+            Value::Lww(_) => LatticeType::Lww,
+            Value::Set(_) => LatticeType::Set,
+            Value::OrderedSet(_) => LatticeType::OrderedSet,
+            Value::Priority { .. } => LatticeType::Priority,
+            Value::SingleCausal { .. } => LatticeType::SingleCausal,
+            Value::MultiCausal { .. } => LatticeType::MultiCausal,
+        }
+    }
+}
+
+/// Parse a CLI type name into a protobuf [`LatticeType`].
+///
+/// Returns `None` if the name is not recognized.
+pub fn parse_type_name(name: &str) -> Option<LatticeType> {
+    match name.to_ascii_lowercase().as_str() {
+        "lww" => Some(LatticeType::Lww),
+        "set" => Some(LatticeType::Set),
+        "ordered_set" => Some(LatticeType::OrderedSet),
+        "priority" => Some(LatticeType::Priority),
+        "causal" => Some(LatticeType::MultiCausal),
+        "single_causal" => Some(LatticeType::SingleCausal),
+        _ => None,
+    }
+}
+
+/// Format a vector clock as `{key : value}` pairs, sorted by key.
+fn format_vector_clock(vc: &HashMap<String, u32>) -> String {
+    let mut sorted: Vec<_> = vc.iter().collect();
+    sorted.sort_by_key(|(k, _)| k.to_string());
+    sorted
+        .iter()
+        .map(|(k, v)| format!("{{{} : {}}}", k, v))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::Lww(s) => write!(f, "{}", s),
+            Value::Set(values) => {
+                let mut sorted = values.clone();
+                sorted.sort();
+                write!(f, "{{ {} }}", sorted.join(" "))
+            }
+            Value::OrderedSet(values) => {
+                write!(f, "[ {} ]", values.join(" "))
+            }
+            Value::Priority { priority, value } => {
+                write!(f, "priority: {}\n{}", priority, value)
+            }
+            Value::SingleCausal {
+                vector_clock,
+                values,
+            } => {
+                write!(f, "{}", format_vector_clock(vector_clock))?;
+                for v in values {
+                    write!(f, "\n{}", v)?;
+                }
+                Ok(())
+            }
+            Value::MultiCausal {
+                vector_clock,
+                dependencies,
+                value,
+            } => {
+                write!(f, "{}", format_vector_clock(vector_clock))?;
+                let mut sorted_deps = dependencies.clone();
+                sorted_deps.sort_by(|(a, _), (b, _)| a.cmp(b));
+                for (dep_key, dep_vc) in &sorted_deps {
+                    let mut sorted_vc: Vec<_> = dep_vc.iter().collect();
+                    sorted_vc.sort_by_key(|(k, _)| k.to_string());
+                    let vc_str: Vec<String> = sorted_vc
+                        .iter()
+                        .map(|(k, v)| format!("{{{} : {}}}", k, v))
+                        .collect();
+                    write!(f, "\n{} : {}", dep_key, vc_str.join(" "))?;
+                }
+                write!(f, "\n{}", value)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_lww() {
+        let v = Value::Lww("hello".into());
+        assert_eq!(v.to_string(), "hello");
+        assert_eq!(v.type_name(), "lww");
+    }
+
+    #[test]
+    fn display_set() {
+        let v = Value::Set(vec!["z".into(), "a".into(), "m".into()]);
+        assert_eq!(v.to_string(), "{ a m z }");
+        assert_eq!(v.type_name(), "set");
+    }
+
+    #[test]
+    fn display_ordered_set() {
+        let v = Value::OrderedSet(vec!["alpha".into(), "beta".into(), "gamma".into()]);
+        assert_eq!(v.to_string(), "[ alpha beta gamma ]");
+        assert_eq!(v.type_name(), "ordered_set");
+    }
+
+    #[test]
+    fn display_priority() {
+        let v = Value::Priority {
+            priority: 1.5,
+            value: "important".into(),
+        };
+        assert_eq!(v.to_string(), "priority: 1.5\nimportant");
+        assert_eq!(v.type_name(), "priority");
+    }
+
+    #[test]
+    fn display_single_causal() {
+        let mut vc = HashMap::new();
+        vc.insert("test".into(), 1);
+        let v = Value::SingleCausal {
+            vector_clock: vc,
+            values: vec!["world".into()],
+        };
+        assert_eq!(v.to_string(), "{test : 1}\nworld");
+        assert_eq!(v.type_name(), "single_causal");
+    }
+
+    #[test]
+    fn display_multi_causal() {
+        let mut vc = HashMap::new();
+        vc.insert("test".into(), 1);
+        let mut dep_vc = HashMap::new();
+        dep_vc.insert("test1".into(), 1);
+        let v = Value::MultiCausal {
+            vector_clock: vc,
+            dependencies: vec![("dep1".into(), dep_vc)],
+            value: "hello".into(),
+        };
+        assert_eq!(v.to_string(), "{test : 1}\ndep1 : {test1 : 1}\nhello");
+        assert_eq!(v.type_name(), "causal");
+    }
+
+    #[test]
+    fn parse_type_name_valid() {
+        assert_eq!(parse_type_name("lww"), Some(LatticeType::Lww));
+        assert_eq!(parse_type_name("set"), Some(LatticeType::Set));
+        assert_eq!(
+            parse_type_name("ordered_set"),
+            Some(LatticeType::OrderedSet)
+        );
+        assert_eq!(parse_type_name("priority"), Some(LatticeType::Priority));
+        assert_eq!(parse_type_name("causal"), Some(LatticeType::MultiCausal));
+        assert_eq!(
+            parse_type_name("single_causal"),
+            Some(LatticeType::SingleCausal)
+        );
+    }
+
+    #[test]
+    fn parse_type_name_case_insensitive() {
+        assert_eq!(parse_type_name("LWW"), Some(LatticeType::Lww));
+        assert_eq!(parse_type_name("SET"), Some(LatticeType::Set));
+        assert_eq!(parse_type_name("Causal"), Some(LatticeType::MultiCausal));
+    }
+
+    #[test]
+    fn parse_type_name_unknown() {
+        assert_eq!(parse_type_name("unknown"), None);
+        assert_eq!(parse_type_name(""), None);
+    }
+
+    #[test]
+    fn lattice_type_roundtrip() {
+        let v = Value::Set(vec!["a".into()]);
+        assert_eq!(v.lattice_type(), LatticeType::Set);
+    }
+}

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -221,7 +221,12 @@ fn parse_put_args(split: &[&str]) -> Result<(String, annalib::value::Value)> {
         ));
     }
 
-    // Check if the first arg after PUT is a type name.
+    // Exactly 3 tokens: always LWW (preserves keys named "set", "priority", etc.)
+    if split.len() == 3 {
+        return Ok((split[1].to_string(), Value::Lww(split[2].into())));
+    }
+
+    // 4+ tokens: check if the first arg after PUT is a type name.
     if let Some(lt) = parse_type_name(split[1]) {
         use annalib::proto::kvs::LatticeType;
         if split.len() < 4 {
@@ -252,6 +257,8 @@ fn parse_put_args(split: &[&str]) -> Result<(String, annalib::value::Value)> {
                 }
             }
             LatticeType::SingleCausal => {
+                // Placeholder vector clock for CLI testing. A production
+                // client would derive this from its causal context.
                 let mut vc = std::collections::HashMap::new();
                 vc.insert("test".to_string(), 1u32);
                 Value::SingleCausal {
@@ -260,6 +267,9 @@ fn parse_put_args(split: &[&str]) -> Result<(String, annalib::value::Value)> {
                 }
             }
             LatticeType::MultiCausal => {
+                // Placeholder vector clock and dependency for CLI testing.
+                // A production client would derive these from its causal
+                // context and tracked cross-key dependencies.
                 let mut vc = std::collections::HashMap::new();
                 vc.insert("test".to_string(), 1u32);
                 let mut dep_vc = std::collections::HashMap::new();
@@ -267,15 +277,17 @@ fn parse_put_args(split: &[&str]) -> Result<(String, annalib::value::Value)> {
                 Value::MultiCausal {
                     vector_clock: vc,
                     dependencies: vec![("dep1".into(), dep_vc)],
-                    value: split[3].into(),
+                    values: vec![split[3].into()],
                 }
             }
             _ => return Err(CliError::Other(format!("Unsupported type: {}", split[1]))),
         };
         Ok((key, value))
     } else {
-        // No type prefix — default to LWW.
-        Ok((split[1].to_string(), Value::Lww(split[2].into())))
+        Err(CliError::Other(format!(
+            "Unknown type '{}'. Valid types: lww, set, ordered_set, priority, causal, single_causal",
+            split[1]
+        )))
     }
 }
 

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -207,6 +207,78 @@ fn format_status(status: Vec<(String, Vec<i32>)>) -> String {
     status_string
 }
 
+/// Build a [`Value`](annalib::value::Value) from CLI arguments for a PUT command.
+///
+/// The first argument after PUT may be a lattice type name (e.g., `set`,
+/// `priority`, `causal`). If not recognized as a type, it is treated as
+/// the key and LWW is assumed.
+fn parse_put_args(split: &[&str]) -> Result<(String, annalib::value::Value)> {
+    use annalib::value::{parse_type_name, Value};
+
+    if split.len() < 3 {
+        return Err(CliError::Other(
+            "PUT requires at least a key and value".into(),
+        ));
+    }
+
+    // Check if the first arg after PUT is a type name.
+    if let Some(lt) = parse_type_name(split[1]) {
+        use annalib::proto::kvs::LatticeType;
+        if split.len() < 4 {
+            return Err(CliError::Other(format!(
+                "PUT {} requires a key and value(s)",
+                split[1]
+            )));
+        }
+        let key = split[2].to_string();
+        let value = match lt {
+            LatticeType::Lww => Value::Lww(split[3].into()),
+            LatticeType::Set => Value::Set(split[3..].iter().map(|s| s.to_string()).collect()),
+            LatticeType::OrderedSet => {
+                Value::OrderedSet(split[3..].iter().map(|s| s.to_string()).collect())
+            }
+            LatticeType::Priority => {
+                if split.len() < 5 {
+                    return Err(CliError::Other(
+                        "PUT priority requires key, priority, and value".into(),
+                    ));
+                }
+                let priority = split[3].parse::<f64>().map_err(|e| {
+                    CliError::Other(format!("Invalid priority '{}': {}", split[3], e))
+                })?;
+                Value::Priority {
+                    priority,
+                    value: split[4].into(),
+                }
+            }
+            LatticeType::SingleCausal => {
+                let mut vc = std::collections::HashMap::new();
+                vc.insert("test".to_string(), 1u32);
+                Value::SingleCausal {
+                    vector_clock: vc,
+                    values: vec![split[3].into()],
+                }
+            }
+            LatticeType::MultiCausal => {
+                let mut vc = std::collections::HashMap::new();
+                vc.insert("test".to_string(), 1u32);
+                let mut dep_vc = std::collections::HashMap::new();
+                dep_vc.insert("test1".to_string(), 1u32);
+                Value::MultiCausal {
+                    vector_clock: vc,
+                    dependencies: vec![("dep1".into(), dep_vc)],
+                    value: split[3].into(),
+                }
+            }
+            _ => return Err(CliError::Other(format!("Unsupported type: {}", split[1]))),
+        };
+        Ok((key, value))
+    } else {
+        // No type prefix — default to LWW.
+        Ok((split[1].to_string(), Value::Lww(split[2].into())))
+    }
+}
+
 /// Returns `true` if the user requested exit.
 async fn execute_command(
     client: &mut KVSClient,
@@ -216,74 +288,62 @@ async fn execute_command(
     let split = line.trim().split(' ').collect::<Vec<&str>>();
 
     match split[0].to_ascii_uppercase().as_str() {
-        "GET" if split.len() == 2 => println!("{}", client.get(split[1]).await?),
-        "DELETE" if split.len() == 2 => client.delete(split[1]).await?,
-        "PUT" if split.len() == 3 => client.put(split[1], split[2]).await?,
-        #[cfg(feature = "causal")]
-        "GET_CAUSAL" if split.len() == 2 => {
-            let (vc, deps, value) = client.get_causal(split[1]).await?;
-            let mut sorted_vc: Vec<_> = vc.iter().collect();
-            sorted_vc.sort_by_key(|(k, _)| k.to_string());
-            for (k, v) in &sorted_vc {
-                println!("{{{} : {}}}", k, v);
-            }
-            let mut sorted_deps = deps.clone();
-            sorted_deps.sort_by(|(a, _), (b, _)| a.cmp(b));
-            for (dep_key, dep_vc) in &sorted_deps {
-                let mut sorted_dep_vc: Vec<_> = dep_vc.iter().collect();
-                sorted_dep_vc.sort_by_key(|(k, _)| k.to_string());
-                let vc_str: Vec<String> = sorted_dep_vc
-                    .iter()
-                    .map(|(k, v)| format!("{{{} : {}}}", k, v))
-                    .collect();
-                println!("{} : {}", dep_key, vc_str.join(" "));
-            }
+        "GET" if split.len() == 2 => {
+            let value = client.get_value(split[1]).await?;
             println!("{}", value);
         }
-        #[cfg(feature = "causal")]
-        "PUT_CAUSAL" if split.len() == 3 => client.put_causal(split[1], split[2]).await?,
-        #[cfg(feature = "set")]
+        "PUT" if split.len() >= 3 => {
+            let (key, value) = parse_put_args(&split)?;
+            client.put_value(&key, &value).await?;
+        }
+        "DELETE" if split.len() == 2 => client.delete(split[1]).await?,
+        // Legacy aliases — map old commands to the unified GET/PUT.
         "GET_SET" if split.len() == 2 => {
-            let values = client.get_set(split[1]).await?;
-            println!("{{ {} }}", values.join(" "));
+            let value = client.get_value(split[1]).await?;
+            println!("{}", value);
         }
-        #[cfg(feature = "set")]
-        "PUT_SET" if split.len() >= 3 => client.put_set(split[1], &split[2..]).await?,
-        #[cfg(feature = "set")]
         "GET_ORDERED_SET" if split.len() == 2 => {
-            let values = client.get_ordered_set(split[1]).await?;
-            println!("[ {} ]", values.join(" "));
+            let value = client.get_value(split[1]).await?;
+            println!("{}", value);
         }
-        #[cfg(feature = "set")]
-        "PUT_ORDERED_SET" if split.len() >= 3 => {
-            client.put_ordered_set(split[1], &split[2..]).await?
+        "GET_CAUSAL" if split.len() == 2 => {
+            let value = client.get_value(split[1]).await?;
+            println!("{}", value);
         }
-        #[cfg(feature = "causal")]
         "GET_SINGLE_CAUSAL" if split.len() == 2 => {
-            let (vc, values) = client.get_single_causal(split[1]).await?;
-            let mut sorted_vc: Vec<_> = vc.iter().collect();
-            sorted_vc.sort_by_key(|(k, _)| k.to_string());
-            for (k, v) in &sorted_vc {
-                println!("{{{} : {}}}", k, v);
-            }
-            for v in &values {
-                println!("{}", v);
-            }
-        }
-        #[cfg(feature = "causal")]
-        "PUT_SINGLE_CAUSAL" if split.len() == 3 => {
-            client.put_single_causal(split[1], split[2]).await?
+            let value = client.get_value(split[1]).await?;
+            println!("{}", value);
         }
         "GET_PRIORITY" if split.len() == 2 => {
-            let (priority, value) = client.get_priority(split[1]).await?;
-            println!("priority: {}", priority);
+            let value = client.get_value(split[1]).await?;
             println!("{}", value);
         }
+        "PUT_SET" if split.len() >= 3 => {
+            let mut args = vec!["PUT", "set"];
+            args.extend_from_slice(&split[1..]);
+            let (key, value) = parse_put_args(&args)?;
+            client.put_value(&key, &value).await?;
+        }
+        "PUT_ORDERED_SET" if split.len() >= 3 => {
+            let mut args = vec!["PUT", "ordered_set"];
+            args.extend_from_slice(&split[1..]);
+            let (key, value) = parse_put_args(&args)?;
+            client.put_value(&key, &value).await?;
+        }
+        "PUT_CAUSAL" if split.len() == 3 => {
+            let args = vec!["PUT", "causal", split[1], split[2]];
+            let (key, value) = parse_put_args(&args)?;
+            client.put_value(&key, &value).await?;
+        }
+        "PUT_SINGLE_CAUSAL" if split.len() == 3 => {
+            let args = vec!["PUT", "single_causal", split[1], split[2]];
+            let (key, value) = parse_put_args(&args)?;
+            client.put_value(&key, &value).await?;
+        }
         "PUT_PRIORITY" if split.len() == 4 => {
-            let priority = split[2]
-                .parse::<f64>()
-                .map_err(|e| CliError::Other(format!("Invalid priority '{}': {}", split[2], e)))?;
-            client.put_priority(split[1], priority, split[3]).await?
+            let args = vec!["PUT", "priority", split[1], split[2], split[3]];
+            let (key, value) = parse_put_args(&args)?;
+            client.put_value(&key, &value).await?;
         }
         "BENCH" => {
             use annalib::bench::run_bench;
@@ -320,58 +380,22 @@ async fn execute_command(
 }
 
 fn cli_usage() -> String {
-    let mut usage = "Valid commands are:\
-    \n\tget {{key}} \t\t\t- get the value of entry with key = {{key}} from the KVS\
-    \n\tput {{key}} {{value}} \t\t- set entry with key = {{key}} in the KVS to have value = {{value}}"
-        .into();
-
-    #[cfg(feature = "causal")]
-    {
-        usage = format!(
-            "{}\n\tget_causal {{key}} \t\t- causal 'get' of value with key = {{key}} in the KVS\
-            \n\tput_causal {{key}} {{value}} \t- causal set of value with key = {{key}} in the KVS",
-            usage
-        );
-    }
-
-    #[cfg(feature = "causal")]
-    {
-        usage = format!(
-            "{}\n\tget_single_causal {{key}} \t- single-key causal 'get' of value with key = {{key}} in the KVS\
-            \n\tput_single_causal {{key}} {{value}} \t- single-key causal set of value with key = {{key}} in the KVS",
-            usage
-        );
-    }
-
-    #[cfg(feature = "set")]
-    {
-        usage = format!(
-            "{}\n\tget_set {{key}} \t\t\t- get the value of the set with key = {{key}} in the KVS\
-        \n\tput_set {{key}} {{set}} \t\t- set the value of the set with key = {{key}} in the KVS\
-        \n\tget_ordered_set {{key}} \t\t- get the ordered set with key = {{key}} in the KVS\
-        \n\tput_ordered_set {{key}} {{set}} \t- set the ordered set with key = {{key}} in the KVS",
-            usage
-        );
-    }
-
-    usage = format!(
-        "{}\n\tget_priority {{key}} \t\t- get the priority value with key = {{key}} in the KVS\
-        \n\tput_priority {{key}} {{priority}} {{value}} - set value with priority for key = {{key}} in the KVS",
-        usage
-    );
-
-    usage = format!(
-        "{}\n\tdelete {{key}} \t\t\t- delete a key from the KVS\
-        \n\tbench [keys] [value_size] [duration] [workload] - run a benchmark\
-        \n\tstart [component] \t\t- start anna processes (component: kvs, monitor, route; omit for all)\
-        \n\tstop [component] \t\t- stop running anna processes (component: kvs, monitor, route; omit for all)\
-        \n\tstatus [component] \t\t- print the status of anna processes (component: kvs, monitor, route; omit for all)\
-        \n\thelp \t\t\t\t- print this usage message\
-        \n\texit \t\t\t\t- exit the CLI (does not stop any anna processes)",
-        usage
-    );
-
-    usage
+    "Valid commands are:\
+    \n\tget {key} \t\t\t- get the value of any key (auto-detects type)\
+    \n\tput {key} {value} \t\t- store a value (LWW, default)\
+    \n\tput set {key} {vals...} \t\t- store a set (union merge)\
+    \n\tput ordered_set {key} {vals...} \t- store an ordered set\
+    \n\tput priority {key} {pri} {val} \t- store with priority (lowest wins)\
+    \n\tput causal {key} {value} \t- store with multi-key causal consistency\
+    \n\tput single_causal {key} {value} \t- store with single-key causal consistency\
+    \n\tdelete {key} \t\t\t- delete a key from the KVS\
+    \n\tbench [keys] [value_size] [duration] [workload] - run a benchmark\
+    \n\tstart [component] \t\t- start anna processes (component: kvs, monitor, route; omit for all)\
+    \n\tstop [component] \t\t- stop running anna processes\
+    \n\tstatus [component] \t\t- print the status of anna processes\
+    \n\thelp \t\t\t\t- print this usage message\
+    \n\texit \t\t\t\t- exit the CLI (does not stop any anna processes)"
+        .to_string()
 }
 
 async fn cli_loop_interactive(

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -61,12 +61,10 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 
 | Feature                    | Tested |
 |----------------------------|--------|
-| GET / PUT / DELETE (LWW)   | Yes    |
-| GET_SET / PUT_SET           | Yes    |
-| GET_ORDERED_SET / PUT_ORDERED_SET | Yes |
-| GET_CAUSAL / PUT_CAUSAL    | Yes    |
-| GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
-| GET_PRIORITY / PUT_PRIORITY | Yes   |
+| Unified GET (auto-detect type) | Yes |
+| Unified PUT (type prefix)  | Yes    |
+| DELETE                     | Yes    |
+| Value enum (get_value/put_value) | Yes |
 | GET_BYTES (raw LWW value)  | Yes    |
 | Multi-key GET (get_multi)  | Yes    |
 | Address cache invalidation | Yes    |
@@ -87,12 +85,9 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 
 | Feature                    | Tested |
 |----------------------------|--------|
-| GET / PUT / DELETE (LWW)   | Yes    |
-| GET_SET / PUT_SET           | Yes    |
-| GET_ORDERED_SET / PUT_ORDERED_SET | Yes |
-| GET_CAUSAL / PUT_CAUSAL    | Yes    |
-| GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
-| GET_PRIORITY / PUT_PRIORITY | Yes   |
+| Unified GET (get_any, auto-detect type) | Yes |
+| Unified PUT (type prefix)  | Yes    |
+| DELETE                     | Yes    |
 | GET_BYTES (raw LWW value)  | Yes    |
 | Multi-key GET (get_multi)  | Yes    |
 | Address cache invalidation | Yes    |

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -105,12 +105,9 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 
 | Feature                    | Tested |
 |----------------------------|--------|
-| GET / PUT / DELETE (LWW)   | Yes    |
-| GET_SET / PUT_SET           | Yes    |
-| GET_ORDERED_SET / PUT_ORDERED_SET | Yes |
-| GET_CAUSAL / PUT_CAUSAL    | Yes    |
-| GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
-| GET_PRIORITY / PUT_PRIORITY | Yes   |
+| Unified GET (legacy dispatch by type) | Yes |
+| Unified PUT (type prefix)  | Yes    |
+| DELETE                     | Yes    |
 | GET_BYTES (raw LWW value)  | Yes    |
 | Multi-key GET (GetMulti)   | Yes    |
 | Address cache invalidation | Yes    |
@@ -130,11 +127,9 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 
 | Feature                    | Tested |
 |----------------------------|--------|
-| GET / PUT / DELETE (LWW)   | Yes    |
-| GET_SET / PUT_SET           | Yes    |
-| GET_ORDERED_SET / PUT_ORDERED_SET | Yes |
-| GET_SINGLE_CAUSAL / PUT_SINGLE_CAUSAL | Yes |
-| GET_PRIORITY / PUT_PRIORITY | Yes   |
+| Unified GET (LWW/Set auto-detect, legacy dispatch for others) | Yes |
+| Unified PUT (type prefix)  | Yes    |
+| DELETE                     | Yes    |
 | GET_BYTES (raw LWW value)  | Yes    |
 | Multi-key GET (get_multi)  | Yes    |
 | Address cache invalidation | Yes    |

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -12,21 +12,19 @@ mocks.
 
 | Feature                    | Description                                                  | System Tested |
 |----------------------------|--------------------------------------------------------------|---------------|
-| GET                        | Retrieve a value by key                                      | Yes           |
-| PUT                        | Store a value by key (lattice merge)                         | Yes           |
-| DELETE                     | Remove a key (PUT with empty value and dominating timestamp) | Yes           |
-| GET_SET                    | Retrieve a set-valued key                                    | Yes           |
-| PUT_SET                    | Add values to a set (union semantics)                        | Yes           |
-| GET_CAUSAL                 | Retrieve with causal metadata (vector clock, dependencies)   | Yes           |
-| PUT_CAUSAL                 | Store with causal metadata                                   | Yes           |
-| GET_ORDERED_SET            | Retrieve an ordered set-valued key                           | Yes           |
-| PUT_ORDERED_SET            | Add values to an ordered set                                 | Yes           |
-| GET_SINGLE_CAUSAL          | Retrieve with single-key causal metadata                     | Yes           |
-| PUT_SINGLE_CAUSAL          | Store with single-key causal metadata                        | Yes           |
-| GET_PRIORITY               | Retrieve a priority-valued key                               | Yes           |
-| PUT_PRIORITY               | Store a priority-value pair (lowest priority wins)           | Yes           |
+| GET {key}                  | Retrieve any key (auto-detects lattice type)                 | Yes           |
+| PUT {key} {value}          | Store a scalar value (LWW, default)                          | Yes           |
+| PUT set {key} {vals...}    | Store a set (union merge)                                    | Yes           |
+| PUT ordered_set {key} ...  | Store an ordered set                                         | Yes           |
+| PUT priority {key} {p} {v} | Store with priority (lowest wins)                            | Yes           |
+| PUT causal {key} {value}   | Store with multi-key causal consistency                      | Yes           |
+| PUT single_causal {key} .. | Store with single-key causal consistency                     | Yes           |
+| DELETE {key}               | Remove a key (PUT with empty value and dominating timestamp) | Yes           |
 | Address cache invalidation | Server signals client to refresh address cache               | Yes           |
 | Multi-key GET              | Retrieve multiple keys in one request                        | Yes           |
+
+Legacy commands (`GET_SET`, `PUT_SET`, `GET_CAUSAL`, `PUT_CAUSAL`, etc.) are
+still supported as aliases for backward compatibility.
 
 ## Lattice Types
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -18,7 +18,7 @@ mocks.
 | PUT ordered_set {key} ...  | Store an ordered set                                         | Yes           |
 | PUT priority {key} {p} {v} | Store with priority (lowest wins)                            | Yes           |
 | PUT causal {key} {value}   | Store with multi-key causal consistency                      | Yes           |
-| PUT single_causal {key} .. | Store with single-key causal consistency                     | Yes           |
+| PUT single_causal {key} {value} | Store with single-key causal consistency               | Yes           |
 | DELETE {key}               | Remove a key (PUT with empty value and dominating timestamp) | Yes           |
 | Address cache invalidation | Server signals client to refresh address cache               | Yes           |
 | Multi-key GET              | Retrieve multiple keys in one request                        | Yes           |


### PR DESCRIPTION
## Summary

Simplifies the CLI from 13 KVS commands to 3, with the old commands kept as backward-compatible aliases.

### New syntax

```
GET {key}                          # auto-detects lattice type
PUT {key} {value}                  # LWW (default)
PUT set {key} {val1} {val2} ...    # Set (union merge)
PUT ordered_set {key} {vals...}    # Ordered set
PUT priority {key} {pri} {value}   # Priority (lowest wins)
PUT causal {key} {value}           # Multi-key causal
PUT single_causal {key} {value}    # Single-key causal
DELETE {key}                       # Delete (unchanged)
```

The first argument after PUT is checked against known type names (`lww`, `set`, `ordered_set`, `priority`, `causal`, `single_causal`). If not recognized, it is treated as the key and LWW is assumed.

### Rust client library

- New `value::Value` enum unifying all lattice types with `Display` impl for CLI formatting
- New `get_value()` / `put_value()` methods on `KVSClient` — unified entry points that auto-detect type on GET and infer type from the `Value` variant on PUT
- Tab completion for type names after `PUT`
- 13 new unit tests for `Value` enum

### C++ client library

- New `get_any()` function in `client_lib` — auto-detects lattice type from server response and formats output

### Python client

- Unified GET/PUT handling with legacy command aliases

### Backward compatibility

All old commands (`GET_SET`, `PUT_CAUSAL`, `GET_PRIORITY`, etc.) still work — they map to the unified handlers internally.

### Verification

- `make clippy` — clean
- `make fmt` — clean
- `make test` — all tests pass (C++ server, C++ client, Python, Rust, Go)

Closes #351
References #494 (orthogonal lattice type design)