### PR TITLE
Replace zeromq crate with omq-tokio for ZMQ messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,17 +19,17 @@ dependencies = [
  "clap",
  "log",
  "nix",
+ "omq-tokio",
  "predicates",
  "prost",
  "prost-build",
- "rand 0.10.2",
+ "rand",
  "rustyline",
  "serial_test",
  "simplog",
  "sysinfo",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
- "zeromq",
 ]
 
 [[package]]
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,54 +113,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "asynchronous-codec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
-dependencies = [
- "bytes",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -180,16 +147,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -211,7 +182,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -272,15 +243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -346,6 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,7 +342,6 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -413,16 +380,6 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -465,15 +422,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
+name = "generator"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
- "wasip2",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -484,8 +444,8 @@ checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
- "rand_core 0.10.1",
+ "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -517,12 +477,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
@@ -559,15 +513,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.103"
+name = "lazy_static"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
-dependencies = [
- "cfg-if",
- "futures-util",
- "wasm-bindgen",
-]
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -595,6 +544,28 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -653,6 +624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -722,6 +702,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "omq-proto"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9335ef21d570294464c491837af5477caddb05cf3c7223af1c4341a127e6035"
+dependencies = [
+ "bytes",
+ "patricia_tree",
+ "rand",
+ "smallvec",
+ "socket2",
+ "thiserror",
+]
+
+[[package]]
+name = "omq-tokio"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95debd9f3d2e7a1b60d7df5aa9e48e02b4c8194bdb0927f75279c3df35673215"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "concurrent-queue",
+ "futures",
+ "libc",
+ "omq-proto",
+ "rand",
+ "rustc-hash",
+ "smallvec",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "yring",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,12 +748,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -763,6 +773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "patricia_tree"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df0e43512f12f23a6b08c7b893192b7d6ec937b95ee03af040847907fe5cef7"
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,29 +794,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.5.2",
- "pin-project-lite",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "predicates"
@@ -913,12 +906,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -935,42 +922,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
+ "rand_core",
 ]
 
 [[package]]
@@ -1018,6 +976,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,35 +1022,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "saa"
-version = "5.6.0"
+name = "scoped-tls"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
-
-[[package]]
-name = "scc"
-version = "3.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f733aa28b85255811ad1358d559fe9a182e39327cf5470140ed9d444de86e6d5"
-dependencies = [
- "saa",
- "sdd",
-]
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "4.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1836bad8bdc9c6d665b63202da3d9c6d60ed1e597cae63620e21ebf89a3595a9"
-dependencies = [
- "saa",
-]
 
 [[package]]
 name = "serde_core"
@@ -1132,6 +1077,21 @@ dependencies = [
  "quote",
  "syn 3.0.2",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1248,31 +1208,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.19",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1284,6 +1224,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.2",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1322,10 +1271,59 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1353,15 +1351,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.24.0"
+name = "valuable"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "wasm-bindgen",
-]
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"
@@ -1377,71 +1370,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "win_uds"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd30a1a28a3799479cbf4e17284a220ea9ff6bad098a9d0224543a5d1efe1da"
-dependencies = [
- "async-io",
- "futures-io",
- "socket2",
-]
 
 [[package]]
 name = "winapi"
@@ -1594,52 +1522,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.57.1"
+name = "yring"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "39146d2147cfb9f71b9f071f93f7b5dbcfb28eee528dafcaf5f500f4917cb69f"
 dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "zeromq"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb2c254fd8f366755335c9e43b865f8484fe3bd717d65ffe7c3f28852863030"
-dependencies = [
- "async-trait",
- "asynchronous-codec",
- "bytes",
- "crossbeam-queue",
- "futures",
- "log",
- "num-traits",
- "once_cell",
- "parking_lot",
- "rand 0.9.5",
- "regex",
- "scc",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
- "uuid",
- "win_uds",
+ "loom",
 ]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://github.com/andrewdavidmackenzie/anna/cli/README.md"
 repository = "https://github.com/andrewdavidmackenzie/anna/"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.93"
 
 [[bin]]
 name = "anna"
@@ -31,7 +31,7 @@ thiserror = "2"
 sysinfo = "0.39.5"
 nix = { version = "0.31.3", default-features = false, features = ["signal", "process"] }
 rustyline = "18.0.1"
-zeromq = "0.6"
+omq-tokio = "0.20"
 tokio = { version = "1", features = ["full"] }
 rand = "0.10.2"
 prost = "0.14"

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -8,6 +8,7 @@ use crate::proto::kvs::{
 use crate::threads::{UserRoutingThread, UserThread};
 use crate::types::{Address, Key, ThreadID};
 use log::{debug, error, info, warn};
+use omq_tokio::{Context, Message as ZmqMessage, Options, Socket as OmqSocket, SocketType};
 use prost::Message;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -16,13 +17,13 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend};
 
 enum Transport {
     Zmq {
-        socket_cache: HashMap<Address, PushSocket>,
-        key_address_puller: PullSocket,
-        response_puller: PullSocket,
+        ctx: Context,
+        socket_cache: HashMap<Address, OmqSocket>,
+        key_address_puller: OmqSocket,
+        response_puller: OmqSocket,
     },
     #[cfg(test)]
     Mock {
@@ -104,15 +105,24 @@ impl KVSClient {
 
         let ut = UserThread::with_offset(&config.client_ip, tid, base_offset);
 
-        let mut key_address_puller = PullSocket::new();
+        let ctx = Context::new();
+        let key_address_puller = ctx.socket(SocketType::Pull, Options::default());
         key_address_puller
-            .bind(&ut.key_address_bind_address())
+            .bind(
+                ut.key_address_bind_address()
+                    .parse()
+                    .expect("invalid bind address"),
+            )
             .await
             .expect("Failed to bind key address puller");
 
-        let mut response_puller = PullSocket::new();
+        let response_puller = ctx.socket(SocketType::Pull, Options::default());
         response_puller
-            .bind(&ut.response_bind_address())
+            .bind(
+                ut.response_bind_address()
+                    .parse()
+                    .expect("invalid bind address"),
+            )
             .await
             .expect("Failed to bind response puller");
 
@@ -125,6 +135,7 @@ impl KVSClient {
             key_address_cache: HashMap::new(),
             timeout: Duration::from_secs(10),
             transport: Transport::Zmq {
+                ctx,
                 socket_cache: HashMap::new(),
                 key_address_puller,
                 response_puller,
@@ -188,16 +199,21 @@ impl KVSClient {
 
     async fn send_request(&mut self, msg: &[u8], addr: &str) -> Result<()> {
         match &mut self.transport {
-            Transport::Zmq { socket_cache, .. } => {
+            Transport::Zmq {
+                ctx, socket_cache, ..
+            } => {
                 if !socket_cache.contains_key(addr) {
-                    let mut sock = PushSocket::new();
-                    sock.connect(addr)
-                        .await
-                        .map_err(|e| Error::Kvs(format!("Failed to connect to {}: {}", addr, e)))?;
+                    let sock = ctx.socket(SocketType::Push, Options::default());
+                    sock.connect(
+                        addr.parse()
+                            .map_err(|e| Error::Kvs(format!("Invalid address {}: {}", addr, e)))?,
+                    )
+                    .await
+                    .map_err(|e| Error::Kvs(format!("Failed to connect to {}: {}", addr, e)))?;
                     socket_cache.insert(addr.to_string(), sock);
                 }
                 let sock = socket_cache.get_mut(addr).expect("socket just inserted");
-                sock.send(msg.to_vec().into())
+                sock.send(ZmqMessage::from(msg.to_vec()))
                     .await
                     .map_err(|e| Error::Kvs(format!("Failed to send: {}", e)))?;
                 Ok(())
@@ -220,7 +236,7 @@ impl KVSClient {
                     response_puller
                 };
                 match tokio::time::timeout(self.timeout, sock.recv()).await {
-                    Ok(Ok(msg)) => msg.into_vec().pop().map(|b| b.to_vec()),
+                    Ok(Ok(msg)) => msg.get(0).map(|b| b.to_vec()),
                     Ok(Err(e)) => {
                         error!("ZMQ recv error: {}", e);
                         None

--- a/clients/rust/src/lib/latency_reporter.rs
+++ b/clients/rust/src/lib/latency_reporter.rs
@@ -5,10 +5,10 @@ use crate::proto::metadata::UserFeedback;
 use crate::proto::shared::StringSet;
 use crate::types::Address;
 use log::info;
+use omq_tokio::{Context, Message as ZmqMessage, Options, Socket as OmqSocket, SocketType};
 use prost::Message;
 use std::collections::HashMap;
 use std::time::Duration;
-use zeromq::{PushSocket, Socket, SocketSend};
 
 const K_FEEDBACK_REPORT_PORT: usize = 6750;
 const MONITORING_IPS_KEY: &str = "ANNA_METADATA|monitoring_ips";
@@ -38,9 +38,10 @@ const MONITORING_IPS_KEY: &str = "ANNA_METADATA|monitoring_ips";
 /// ```
 pub struct LatencyReporter {
     uid: String,
+    ctx: Context,
     base_offset: usize,
     warmup: bool,
-    socket_cache: HashMap<Address, PushSocket>,
+    socket_cache: HashMap<Address, OmqSocket>,
     monitoring_ips: Vec<Address>,
 }
 
@@ -70,6 +71,7 @@ impl LatencyReporter {
 
         Ok(LatencyReporter {
             uid,
+            ctx: Context::new(),
             base_offset,
             warmup: false,
             socket_cache: HashMap::new(),
@@ -86,6 +88,7 @@ impl LatencyReporter {
         let tid = tid.unwrap_or(0);
         LatencyReporter {
             uid: format!("rust_client:{}", tid),
+            ctx: Context::new(),
             base_offset,
             warmup: false,
             socket_cache: HashMap::new(),
@@ -162,7 +165,7 @@ impl LatencyReporter {
             let addr = format!("tcp://{}:{}", ip, K_FEEDBACK_REPORT_PORT + self.base_offset);
             let socket = self.get_or_connect(&addr).await?;
             socket
-                .send(zeromq::ZmqMessage::from(payload.clone()))
+                .send(ZmqMessage::from(payload.clone()))
                 .await
                 .map_err(|e| Error::Kvs(format!("Failed to send feedback to {}: {}", addr, e)))?;
         }
@@ -170,12 +173,15 @@ impl LatencyReporter {
         Ok(())
     }
 
-    async fn get_or_connect(&mut self, addr: &str) -> Result<&mut PushSocket> {
+    async fn get_or_connect(&mut self, addr: &str) -> Result<&mut OmqSocket> {
         if !self.socket_cache.contains_key(addr) {
             let mut last_err = None;
             for attempt in 0..5 {
-                let mut sock = PushSocket::new();
-                match tokio::time::timeout(Duration::from_secs(5), sock.connect(addr)).await {
+                let sock = self.ctx.socket(SocketType::Push, Options::default());
+                let endpoint = addr
+                    .parse()
+                    .map_err(|e| Error::Kvs(format!("Invalid address {}: {}", addr, e)))?;
+                match tokio::time::timeout(Duration::from_secs(5), sock.connect(endpoint)).await {
                     Ok(Ok(())) => {
                         self.socket_cache.insert(addr.to_string(), sock);
                         last_err = None;
@@ -274,12 +280,11 @@ mod tests {
 
     #[tokio::test]
     async fn send_and_receive_feedback() {
-        use zeromq::{PullSocket, SocketRecv};
-
         let port = 6750 + 80;
-        let mut puller = PullSocket::new();
+        let ctx = Context::new();
+        let puller = ctx.socket(SocketType::Pull, Options::default());
         puller
-            .bind(&format!("tcp://127.0.0.1:{}", port))
+            .bind(format!("tcp://127.0.0.1:{}", port).parse().unwrap())
             .await
             .expect("bind failed");
 
@@ -297,11 +302,7 @@ mod tests {
             .await
             .expect("recv timed out")
             .expect("recv failed");
-        let bytes: Vec<u8> = msg
-            .into_vec()
-            .into_iter()
-            .flat_map(|f| f.to_vec())
-            .collect();
+        let bytes: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
         let decoded = UserFeedback::decode(bytes.as_slice()).expect("decode failed");
         assert_eq!(decoded.uid, "rust_client:0");
         assert!((decoded.latency - 5000.0).abs() < f64::EPSILON);
@@ -312,12 +313,11 @@ mod tests {
 
     #[tokio::test]
     async fn send_finish_signal() {
-        use zeromq::{PullSocket, SocketRecv};
-
         let port = 6750 + 81;
-        let mut puller = PullSocket::new();
+        let ctx = Context::new();
+        let puller = ctx.socket(SocketType::Pull, Options::default());
         puller
-            .bind(&format!("tcp://127.0.0.1:{}", port))
+            .bind(format!("tcp://127.0.0.1:{}", port).parse().unwrap())
             .await
             .expect("bind failed");
 
@@ -332,23 +332,18 @@ mod tests {
             .await
             .expect("recv timed out")
             .expect("recv failed");
-        let bytes: Vec<u8> = msg
-            .into_vec()
-            .into_iter()
-            .flat_map(|f| f.to_vec())
-            .collect();
+        let bytes: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
         let decoded = UserFeedback::decode(bytes.as_slice()).expect("decode failed");
         assert!(decoded.finish);
     }
 
     #[tokio::test]
     async fn connect_pre_establishes_sockets() {
-        use zeromq::PullSocket;
-
         let port = 6750 + 82;
-        let mut puller = PullSocket::new();
+        let ctx = Context::new();
+        let puller = ctx.socket(SocketType::Pull, Options::default());
         puller
-            .bind(&format!("tcp://127.0.0.1:{}", port))
+            .bind(format!("tcp://127.0.0.1:{}", port).parse().unwrap())
             .await
             .expect("bind failed");
 

--- a/clients/rust/src/lib/latency_reporter.rs
+++ b/clients/rust/src/lib/latency_reporter.rs
@@ -352,4 +352,24 @@ mod tests {
         reporter.connect().await.expect("connect failed");
         assert_eq!(reporter.socket_cache.len(), 1);
     }
+
+    #[tokio::test]
+    async fn get_or_connect_rejects_invalid_address() {
+        let mut reporter = LatencyReporter::with_monitoring_ips(vec!["127.0.0.1".into()], 0, None);
+        let result = reporter.get_or_connect("not_a_valid_endpoint").await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Invalid address"), "unexpected error: {}", err);
+    }
+
+    #[tokio::test]
+    async fn new_from_mock_client() {
+        let mut client = KVSClient::new_mock("127.0.0.1", 83);
+        // Mock has no monitoring IPs metadata, so new() falls back to empty vec.
+        let reporter = LatencyReporter::new(&mut client, Some(83))
+            .await
+            .expect("new failed");
+        assert_eq!(reporter.uid, "rust_client:83");
+        assert!(reporter.monitoring_ips.is_empty());
+    }
 }

--- a/clients/rust/src/lib/value_change_subscriber.rs
+++ b/clients/rust/src/lib/value_change_subscriber.rs
@@ -4,10 +4,10 @@ use crate::proto::kvs::{KeyResponse, LwwValue};
 use crate::proto::shared::StringSet;
 use crate::types::{Address, Key};
 use log::{debug, info};
+use omq_tokio::{Context, Message as ZmqMessage, Options, Socket as OmqSocket, SocketType};
 use prost::Message;
 use std::collections::HashMap;
 use std::time::Duration;
-use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend};
 
 // The port on which KVS servers listen for direct cache registration.
 const K_CACHE_REGISTRATION_PORT: usize = 7200;
@@ -48,12 +48,13 @@ const K_CACHE_UPDATE_PORT: usize = 7150;
 /// # }
 /// ```
 pub struct ValueChangeSubscriber {
+    ctx: Context,
     cache_ip: Address,
     base_offset: usize,
     server_ip: Address,
     memory_threads: usize,
-    socket_cache: HashMap<Address, PushSocket>,
-    update_puller: PullSocket,
+    socket_cache: HashMap<Address, OmqSocket>,
+    update_puller: OmqSocket,
     local_cache: HashMap<Key, Vec<u8>>,
     watched_keys: Vec<Key>,
 }
@@ -90,17 +91,27 @@ impl ValueChangeSubscriber {
             cache_ip,
             tid + K_CACHE_UPDATE_PORT + base_offset
         );
-        let mut update_puller = PullSocket::new();
-        update_puller.bind(&bind_addr).await.map_err(|e| {
-            Error::Kvs(format!(
-                "Failed to bind cache update puller on {}: {}",
-                bind_addr, e
-            ))
-        })?;
+        let ctx = Context::new();
+        let update_puller = ctx.socket(SocketType::Pull, Options::default());
+        update_puller
+            .bind(bind_addr.parse().map_err(|e| {
+                Error::Kvs(format!(
+                    "Failed to parse cache update bind address {}: {}",
+                    bind_addr, e
+                ))
+            })?)
+            .await
+            .map_err(|e| {
+                Error::Kvs(format!(
+                    "Failed to bind cache update puller on {}: {}",
+                    bind_addr, e
+                ))
+            })?;
 
         info!("Cache client listening for updates on {}", bind_addr);
 
         Ok(ValueChangeSubscriber {
+            ctx,
             cache_ip,
             base_offset,
             server_ip,
@@ -135,7 +146,7 @@ impl ValueChangeSubscriber {
             );
             let socket = self.get_or_connect(&addr).await?;
             socket
-                .send(zeromq::ZmqMessage::from(payload.clone()))
+                .send(ZmqMessage::from(payload.clone()))
                 .await
                 .map_err(|e| {
                     Error::Kvs(format!("Failed to send registration to {}: {}", addr, e))
@@ -168,11 +179,7 @@ impl ValueChangeSubscriber {
 
         match result {
             Ok(Ok(msg)) => {
-                let bytes: Vec<u8> = msg
-                    .into_vec()
-                    .into_iter()
-                    .flat_map(|frame| frame.to_vec())
-                    .collect();
+                let bytes: Vec<u8> = msg.iter().flat_map(|frame| frame.to_vec()).collect();
 
                 let response = KeyResponse::decode(bytes.as_slice())
                     .map_err(|e| Error::Kvs(format!("Failed to decode cache update: {}", e)))?;
@@ -217,12 +224,15 @@ impl ValueChangeSubscriber {
         &self.watched_keys
     }
 
-    async fn get_or_connect(&mut self, addr: &str) -> Result<&mut PushSocket> {
+    async fn get_or_connect(&mut self, addr: &str) -> Result<&mut OmqSocket> {
         if !self.socket_cache.contains_key(addr) {
             let mut last_err = None;
             for attempt in 0..5 {
-                let mut sock = PushSocket::new();
-                match tokio::time::timeout(Duration::from_secs(5), sock.connect(addr)).await {
+                let sock = self.ctx.socket(SocketType::Push, Options::default());
+                let endpoint = addr
+                    .parse()
+                    .map_err(|e| Error::Kvs(format!("Invalid address {}: {}", addr, e)))?;
+                match tokio::time::timeout(Duration::from_secs(5), sock.connect(endpoint)).await {
                     Ok(Ok(())) => {
                         self.socket_cache.insert(addr.to_string(), sock);
                         last_err = None;
@@ -327,8 +337,12 @@ mod tests {
             .expect("create failed");
 
         let update_addr = format!("tcp://127.0.0.1:{}", 92 + K_CACHE_UPDATE_PORT);
-        let mut pusher = PushSocket::new();
-        pusher.connect(&update_addr).await.expect("connect failed");
+        let ctx = Context::new();
+        let pusher = ctx.socket(SocketType::Push, Options::default());
+        pusher
+            .connect(update_addr.parse().unwrap())
+            .await
+            .expect("connect failed");
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let response = KeyResponse {
@@ -341,7 +355,7 @@ mod tests {
         };
         let bytes = response.encode_to_vec();
         pusher
-            .send(zeromq::ZmqMessage::from(bytes))
+            .send(ZmqMessage::from(bytes))
             .await
             .expect("send failed");
 
@@ -368,8 +382,12 @@ mod tests {
             .expect("create failed");
 
         let update_addr = format!("tcp://127.0.0.1:{}", 93 + K_CACHE_UPDATE_PORT);
-        let mut pusher = PushSocket::new();
-        pusher.connect(&update_addr).await.expect("connect failed");
+        let ctx = Context::new();
+        let pusher = ctx.socket(SocketType::Push, Options::default());
+        pusher
+            .connect(update_addr.parse().unwrap())
+            .await
+            .expect("connect failed");
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let response = KeyResponse {
@@ -381,7 +399,7 @@ mod tests {
             ..Default::default()
         };
         pusher
-            .send(zeromq::ZmqMessage::from(response.encode_to_vec()))
+            .send(ZmqMessage::from(response.encode_to_vec()))
             .await
             .expect("send failed");
 

--- a/clients/rust/src/lib/value_change_subscriber.rs
+++ b/clients/rust/src/lib/value_change_subscriber.rs
@@ -457,6 +457,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)] // Windows SO_REUSEADDR allows duplicate binds
     async fn new_fails_on_port_conflict() {
         let config = crate::client_config::ClientConfig::default();
         // First subscriber binds the port successfully.

--- a/clients/rust/src/lib/value_change_subscriber.rs
+++ b/clients/rust/src/lib/value_change_subscriber.rs
@@ -47,6 +47,7 @@ const K_CACHE_UPDATE_PORT: usize = 7150;
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug)]
 pub struct ValueChangeSubscriber {
     ctx: Context,
     cache_ip: Address,
@@ -431,5 +432,72 @@ mod tests {
             .await
             .expect("create failed");
         assert_eq!(sub.memory_threads, 4);
+    }
+
+    #[tokio::test]
+    async fn get_or_connect_rejects_invalid_address() {
+        let config = crate::client_config::ClientConfig::default();
+        let mut sub = ValueChangeSubscriber::new(&config, Some(95))
+            .await
+            .expect("create failed");
+        let result = sub.get_or_connect("not_a_valid_endpoint").await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Invalid address"), "unexpected error: {}", err);
+    }
+
+    #[tokio::test]
+    async fn new_rejects_unparseable_bind_address() {
+        let config = crate::client_config::ClientConfig {
+            routing_addresses: vec!["tcp://127.0.0.1:6450".to_string()],
+            client_ip: "not a valid ip".to_string(),
+        };
+        let result = ValueChangeSubscriber::new(&config, Some(96)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn new_fails_on_port_conflict() {
+        let config = crate::client_config::ClientConfig::default();
+        // First subscriber binds the port successfully.
+        let _sub1 = ValueChangeSubscriber::new(&config, Some(97))
+            .await
+            .expect("first create failed");
+        // Second subscriber tries to bind the same port and should fail.
+        let result = ValueChangeSubscriber::new(&config, Some(97)).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Failed to bind"), "unexpected error: {}", err);
+    }
+
+    #[tokio::test]
+    async fn watch_sends_registration() {
+        let config = crate::client_config::ClientConfig::default();
+        // Use memory_threads=1 and create a PULL socket to receive the
+        // registration message sent by watch().
+        let mut sub = ValueChangeSubscriber::with_memory_threads(&config, Some(98), 1)
+            .await
+            .expect("create failed");
+
+        let reg_addr = format!("tcp://127.0.0.1:{}", K_CACHE_REGISTRATION_PORT);
+        let ctx = Context::new();
+        let puller = ctx.socket(SocketType::Pull, Options::default());
+        puller
+            .bind(reg_addr.parse().expect("parse failed"))
+            .await
+            .expect("bind failed");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        sub.watch(&["test_key".to_string()])
+            .await
+            .expect("watch failed");
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), puller.recv())
+            .await
+            .expect("recv timed out")
+            .expect("recv failed");
+        let bytes: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
+        let ss = StringSet::decode(bytes.as_slice()).expect("decode failed");
+        assert!(ss.keys.contains(&"test_key".to_string()));
     }
 }

--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -564,8 +564,8 @@ async fn latency_feedback_ingestion() {
     use annalib::kvs_client::KVSClient;
     use annalib::proto::metadata::user_feedback::KeyLatency;
     use annalib::proto::metadata::UserFeedback;
+    use omq_tokio::{Context, Message as ZmqMessage, Options, SocketType};
     use prost::Message;
-    use zeromq::{PushSocket, Socket, SocketSend};
 
     if !server_bin_dir().join("anna-kvs").exists() {
         eprintln!("SKIP: server binaries not built");
@@ -597,9 +597,10 @@ async fn latency_feedback_ingestion() {
 
     // Send UserFeedback to the monitor's feedback port
     let feedback_addr = format!("tcp://{}:{}", NODE_IP, 6750 + 6300);
-    let mut pusher = PushSocket::new();
+    let ctx = Context::new();
+    let pusher = ctx.socket(SocketType::Push, Options::default());
     pusher
-        .connect(&feedback_addr)
+        .connect(feedback_addr.parse().unwrap())
         .await
         .expect("connect failed");
     tokio::time::sleep(Duration::from_millis(200)).await;
@@ -623,7 +624,7 @@ async fn latency_feedback_ingestion() {
     };
     let bytes = feedback.encode_to_vec();
     pusher
-        .send(zeromq::ZmqMessage::from(bytes))
+        .send(ZmqMessage::from(bytes))
         .await
         .expect("Failed to send feedback");
 
@@ -658,7 +659,7 @@ async fn latency_feedback_ingestion() {
         ..Default::default()
     };
     pusher
-        .send(zeromq::ZmqMessage::from(finish.encode_to_vec()))
+        .send(ZmqMessage::from(finish.encode_to_vec()))
         .await
         .expect("Failed to send finish feedback");
 }

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -436,8 +436,8 @@ impl MultiNodeCluster {
         use annalib::proto::metadata::{
             replication_factor::ReplicationValue, ReplicationFactor, ReplicationFactorUpdate, Tier,
         };
+        use omq_tokio::{Context, Message as ZmqMessage, Options, SocketType};
         use prost::Message;
-        use zeromq::{PushSocket, Socket, SocketSend};
 
         let rep = ReplicationFactor {
             key: key.to_string(),
@@ -459,26 +459,27 @@ impl MultiNodeCluster {
         let update = ReplicationFactorUpdate { updates: vec![rep] };
         let encoded = update.encode_to_vec();
 
+        let ctx = Context::new();
         let routing_port = 6550 + self.base_offset;
         let routing_addr = format!("tcp://{}:{}", routing_ip, routing_port);
-        let mut rsock = PushSocket::new();
+        let rsock = ctx.socket(SocketType::Push, Options::default());
         rsock
-            .connect(&routing_addr)
+            .connect(routing_addr.parse().unwrap())
             .await
             .expect("Failed to connect to routing replication change port");
         tokio::time::sleep(Duration::from_millis(200)).await;
         rsock
-            .send(encoded.clone().into())
+            .send(ZmqMessage::from(encoded.clone()))
             .await
             .expect("Failed to send to routing");
 
         for kvs_ip in [NODE1_IP, NODE2_IP] {
             let kvs_port = 6300 + self.base_offset;
             let kvs_addr = format!("tcp://{}:{}", kvs_ip, kvs_port);
-            let mut ksock = PushSocket::new();
-            if ksock.connect(&kvs_addr).await.is_ok() {
+            let ksock = ctx.socket(SocketType::Push, Options::default());
+            if ksock.connect(kvs_addr.parse().unwrap()).await.is_ok() {
                 tokio::time::sleep(Duration::from_millis(100)).await;
-                ksock.send(encoded.clone().into()).await.ok();
+                ksock.send(ZmqMessage::from(encoded.clone())).await.ok();
             }
         }
         std::thread::sleep(Duration::from_millis(ZMQ_SETTLE_MS));
@@ -1733,8 +1734,8 @@ async fn slo_selective_replication() {
     use annalib::kvs_client::KVSClient;
     use annalib::proto::metadata::user_feedback::KeyLatency;
     use annalib::proto::metadata::{ReplicationFactor, UserFeedback};
+    use omq_tokio::{Context, Message as ZmqMessage, Options, SocketType};
     use prost::Message;
-    use zeromq::{PushSocket, Socket, SocketSend};
 
     if !can_bind(NODE2_IP) {
         eprintln!("SKIP: {} not bindable", NODE2_IP);
@@ -1772,9 +1773,10 @@ async fn slo_selective_replication() {
 
     // Connect to monitor feedback port using raw ZMQ
     let feedback_addr = format!("tcp://{}:{}", NODE1_IP, 6750 + 400);
-    let mut feedback_pusher = PushSocket::new();
+    let ctx = Context::new();
+    let feedback_pusher = ctx.socket(SocketType::Push, Options::default());
     feedback_pusher
-        .connect(&feedback_addr)
+        .connect(feedback_addr.parse().unwrap())
         .await
         .expect("feedback connect failed");
     tokio::time::sleep(Duration::from_millis(ZMQ_SETTLE_MS)).await;
@@ -1795,7 +1797,7 @@ async fn slo_selective_replication() {
                 ..Default::default()
             };
             if feedback_pusher
-                .send(zeromq::ZmqMessage::from(feedback.encode_to_vec()))
+                .send(ZmqMessage::from(feedback.encode_to_vec()))
                 .await
                 .is_err()
             {
@@ -1856,7 +1858,7 @@ async fn slo_selective_replication() {
 #[serial(multi_node)]
 async fn management_node_integration() {
     use annalib::kvs_client::KVSClient;
-    use zeromq::{PullSocket, RepSocket, Socket, SocketRecv, SocketSend};
+    use omq_tokio::{Context, Message as ZmqMessage, Options, SocketType};
 
     if !server_bin_dir().join("anna-kvs").exists() {
         eprintln!("SKIP: server binaries not built");
@@ -1865,19 +1867,29 @@ async fn management_node_integration() {
 
     let base_offset: u32 = 500;
 
+    let ctx = Context::new();
+
     // Start mock management node BEFORE starting the cluster.
     // Port 7000+offset: REP socket for "restart:<ip>" queries
-    let mut restart_count_rep = RepSocket::new();
+    let restart_count_rep = ctx.socket(SocketType::Rep, Options::default());
     restart_count_rep
-        .bind(&format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset))
+        .bind(
+            format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset)
+                .parse()
+                .unwrap(),
+        )
         .await
         .expect("Failed to bind restart count REP");
 
     // Port 7002+offset: PULL socket for func/cache node queries
     // (KVS sends via PUSH, so we receive via PULL)
-    let mut func_nodes_pull = PullSocket::new();
+    let func_nodes_pull = ctx.socket(SocketType::Pull, Options::default());
     func_nodes_pull
-        .bind(&format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset))
+        .bind(
+            format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset)
+                .parse()
+                .unwrap(),
+        )
         .await
         .expect("Failed to bind func nodes PULL");
 
@@ -1886,6 +1898,7 @@ async fn management_node_integration() {
     // Spawn a background task to handle management node requests.
     // The KVS server sends "restart:<ip>" on startup and expects a count.
     // The KVS also periodically queries func_nodes for cache IPs.
+    let ctx2 = ctx.clone();
     let mgmt_handle = tokio::spawn(async move {
         let mut restart_count = 0u32;
         let mut func_count = 0u32;
@@ -1894,21 +1907,21 @@ async fn management_node_integration() {
             tokio::select! {
                 result = restart_count_rep.recv() => {
                     if let Ok(msg) = result {
-                        let data: Vec<u8> = msg.into_vec()
-                            .into_iter().flat_map(|f| f.to_vec()).collect();
+                        let data: Vec<u8> = msg.iter()
+                            .flat_map(|f| f.to_vec()).collect();
                         let request = String::from_utf8_lossy(&data);
                         eprintln!("Mock mgmt: restart query: {}", request);
                         restart_count += 1;
                         restart_count_rep
-                            .send(zeromq::ZmqMessage::from("0".as_bytes().to_vec()))
+                            .send(ZmqMessage::from("0".as_bytes().to_vec()))
                             .await
                             .ok();
                     }
                 }
                 result = func_nodes_pull.recv() => {
                     if let Ok(msg) = result {
-                        let data: Vec<u8> = msg.into_vec()
-                            .into_iter().flat_map(|f| f.to_vec()).collect();
+                        let data: Vec<u8> = msg.iter()
+                            .flat_map(|f| f.to_vec()).collect();
                         let response_addr = String::from_utf8_lossy(&data).to_string();
                         eprintln!("Mock mgmt: func nodes query, response addr: {}", response_addr);
 
@@ -1921,11 +1934,11 @@ async fn management_node_integration() {
                             let cache_ips = StringSet {
                                 keys: vec!["10.0.0.99".to_string()],
                             };
-                            let mut push = zeromq::PushSocket::new();
-                            push.connect(&response_addr).await
+                            let push = ctx2.socket(SocketType::Push, Options::default());
+                            push.connect(response_addr.parse().unwrap()).await
                                 .expect("Failed to connect to KVS response addr");
                             tokio::time::sleep(Duration::from_millis(100)).await;
-                            push.send(zeromq::ZmqMessage::from(cache_ips.encode_to_vec()))
+                            push.send(ZmqMessage::from(cache_ips.encode_to_vec()))
                                 .await
                                 .expect("Failed to send cache IPs to KVS");
                             eprintln!("Mock mgmt: sent cache IP list to {}", response_addr);
@@ -2010,8 +2023,8 @@ async fn management_node_integration() {
 async fn elasticity_storage_policy() {
     use annalib::kvs_client::KVSClient;
     use annalib::proto::metadata::{scaling_alert, ScalingAlert, Tier};
+    use omq_tokio::{Context, Message as ZmqMessage, Options, SocketType};
     use prost::Message;
-    use zeromq::{PullSocket, RepSocket, Socket, SocketRecv, SocketSend};
 
     if !server_bin_dir().join("anna-kvs").exists() {
         eprintln!("SKIP: server binaries not built");
@@ -2020,23 +2033,37 @@ async fn elasticity_storage_policy() {
 
     let base_offset: u32 = 600;
 
+    let ctx = Context::new();
+
     // Mock management node sockets
-    let mut restart_rep = RepSocket::new();
+    let restart_rep = ctx.socket(SocketType::Rep, Options::default());
     restart_rep
-        .bind(&format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset))
+        .bind(
+            format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset)
+                .parse()
+                .unwrap(),
+        )
         .await
         .expect("bind restart REP failed");
 
-    let mut func_pull = PullSocket::new();
+    let func_pull = ctx.socket(SocketType::Pull, Options::default());
     func_pull
-        .bind(&format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset))
+        .bind(
+            format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset)
+                .parse()
+                .unwrap(),
+        )
         .await
         .expect("bind func PULL failed");
 
     // Port 7001+offset for add/remove messages from monitor
-    let mut add_node_pull = PullSocket::new();
+    let add_node_pull = ctx.socket(SocketType::Pull, Options::default());
     add_node_pull
-        .bind(&format!("tcp://{}:{}", NODE1_IP, 7001 + base_offset))
+        .bind(
+            format!("tcp://{}:{}", NODE1_IP, 7001 + base_offset)
+                .parse()
+                .unwrap(),
+        )
         .await
         .expect("bind add_node PULL failed");
 
@@ -2049,7 +2076,7 @@ async fn elasticity_storage_policy() {
                 result = restart_rep.recv() => {
                     if result.is_ok() {
                         restart_rep
-                            .send(zeromq::ZmqMessage::from("0".as_bytes().to_vec()))
+                            .send(ZmqMessage::from("0".as_bytes().to_vec()))
                             .await
                             .ok();
                     }
@@ -2061,8 +2088,8 @@ async fn elasticity_storage_policy() {
                 }
                 result = add_node_pull.recv() => {
                     if let Ok(msg) = result {
-                        let data: Vec<u8> = msg.into_vec()
-                            .into_iter().flat_map(|f| f.to_vec()).collect();
+                        let data: Vec<u8> = msg.iter()
+                            .flat_map(|f| f.to_vec()).collect();
                         eprintln!("Mock mgmt: scaling alert received ({} bytes)", data.len());
                         return Some(data);
                     }
@@ -2176,8 +2203,8 @@ async fn elasticity_storage_policy() {
 async fn underutilization_scale_in() {
     use annalib::kvs_client::KVSClient;
     use annalib::proto::metadata::{scaling_alert, ScalingAlert, Tier};
+    use omq_tokio::{Context, Message as ZmqMessage, Options, SocketType};
     use prost::Message;
-    use zeromq::{PullSocket, RepSocket, Socket, SocketRecv, SocketSend};
 
     if !can_bind(NODE2_IP) {
         eprintln!("SKIP: {} not bindable", NODE2_IP);
@@ -2191,23 +2218,37 @@ async fn underutilization_scale_in() {
 
     let base_offset: u32 = 700;
 
+    let ctx = Context::new();
+
     // Mock management node sockets
-    let mut restart_rep = RepSocket::new();
+    let restart_rep = ctx.socket(SocketType::Rep, Options::default());
     restart_rep
-        .bind(&format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset))
+        .bind(
+            format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset)
+                .parse()
+                .unwrap(),
+        )
         .await
         .expect("bind restart REP failed");
 
-    let mut func_pull = PullSocket::new();
+    let func_pull = ctx.socket(SocketType::Pull, Options::default());
     func_pull
-        .bind(&format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset))
+        .bind(
+            format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset)
+                .parse()
+                .unwrap(),
+        )
         .await
         .expect("bind func PULL failed");
 
     // Port 7001+offset for add/remove messages from monitor
-    let mut mgmt_pull = PullSocket::new();
+    let mgmt_pull = ctx.socket(SocketType::Pull, Options::default());
     mgmt_pull
-        .bind(&format!("tcp://{}:{}", NODE1_IP, 7001 + base_offset))
+        .bind(
+            format!("tcp://{}:{}", NODE1_IP, 7001 + base_offset)
+                .parse()
+                .unwrap(),
+        )
         .await
         .expect("bind mgmt PULL failed");
 
@@ -2220,7 +2261,7 @@ async fn underutilization_scale_in() {
                 result = restart_rep.recv() => {
                     if result.is_ok() {
                         restart_rep
-                            .send(zeromq::ZmqMessage::from("0".as_bytes().to_vec()))
+                            .send(ZmqMessage::from("0".as_bytes().to_vec()))
                             .await
                             .ok();
                     }
@@ -2230,8 +2271,8 @@ async fn underutilization_scale_in() {
                 }
                 result = mgmt_pull.recv() => {
                     if let Ok(msg) = result {
-                        let data: Vec<u8> = msg.into_vec()
-                            .into_iter().flat_map(|f| f.to_vec()).collect();
+                        let data: Vec<u8> = msg.iter()
+                            .flat_map(|f| f.to_vec()).collect();
                         if let Ok(alert) = ScalingAlert::decode(data.as_slice()) {
                             eprintln!("Mock mgmt: received scaling alert: action={:?}", alert.action());
                             if alert.action() == scaling_alert::Action::Remove {


### PR DESCRIPTION
## Summary

Migrate the Rust client from the `zeromq` (0.6) crate to `omq-tokio` (0.20), a pure-Rust ZeroMQ implementation with libzmq-style architecture.

See the [Reddit post](https://www.reddit.com/r/rust/comments/1v8y297/omqrs_pure_rust_zeromq_with_libzmqstyle/) and [repo](https://github.com/paddor/omq.rs) for background.

## Key changes

- Per-type socket structs (`PushSocket`, `PullSocket`, `RepSocket`) replaced with `Context` + `Socket(SocketType::Push/Pull/Rep, Options)`
- OMQ `Socket` is `Send+Sync+Clone` (zeromq sockets were `!Send`) -- this simplifies future FFI work (#497)
- `bind()`/`connect()` now take parsed `Endpoint` instead of `&str`
- Message extraction uses `msg.get(0)`/`msg.iter()` instead of `into_vec()`
- MSRV bumped from 1.75 to 1.93 (omq-tokio requirement)

## Files changed

| File | What changed |
|------|-------------|
| `Cargo.toml` | `zeromq = "0.6"` -> `omq-tokio = "0.20"`, MSRV 1.75 -> 1.93 |
| `kvs_client.rs` | Socket creation, send/recv patterns |
| `value_change_subscriber.rs` | Socket creation, message iteration |
| `latency_reporter.rs` | Socket creation, message iteration |
| `tests/monitor.rs` | 1 test migrated |
| `tests/multi_node.rs` | 4 tests + 1 helper migrated |

## Testing

All local checks pass: `make clippy && make fmt && make test`

Closes #502