### PR TITLE
Auto-detect server thread count from available cores (0 = auto)

### DIFF
--- a/server/conf/anna-base.yml
+++ b/server/conf/anna-base.yml
@@ -3,8 +3,8 @@ capacities: # in GB
   memory-cap: 45 
   disk-cap: 256
 threads:
-  memory: 4
-  disk: 4
+  memory: 0  # 0 = auto-detect from available cores
+  disk: 0
   routing: 4
   benchmark: 4
 hashing:

--- a/server/conf/anna-config.yml
+++ b/server/conf/anna-config.yml
@@ -46,7 +46,7 @@ capacities: # in GB
   memory-cap: 1 
   disk-cap: 0
 threads:
-  memory: 1
+  memory: 1  # 0 = auto-detect from available cores
   disk: 1
   routing: 1
   benchmark: 1

--- a/server/conf/anna-local.yml
+++ b/server/conf/anna-local.yml
@@ -46,7 +46,7 @@ capacities: # in GB
   memory-cap: 1 
   disk-cap: 0
 threads:
-  memory: 1
+  memory: 1  # 0 = auto-detect from available cores
   disk: 1
   routing: 1
   benchmark: 1

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#include <thread>
+
 #include "kvs/kvs_handlers.hpp"
 #include "signal_handler.hpp"
 #include "yaml-cpp/yaml.h"
@@ -916,6 +918,19 @@ int main(int argc, char *argv[]) {
   YAML::Node threads = conf["threads"];
   kMemoryThreadCount = threads["memory"].as<unsigned>();
   kDiskThreadCount = threads["disk"].as<unsigned>();
+
+  // A thread count of 0 means "auto-detect from available cores".
+  unsigned hw_threads = std::thread::hardware_concurrency();
+  if (hw_threads == 0) hw_threads = 1;  // fallback if detection fails
+
+  if (kMemoryThreadCount == 0) {
+    kMemoryThreadCount = hw_threads;
+    spdlog::info("Auto-detected memory thread count: {}", kMemoryThreadCount);
+  }
+  if (kDiskThreadCount == 0) {
+    kDiskThreadCount = hw_threads;
+    spdlog::info("Auto-detected disk thread count: {}", kDiskThreadCount);
+  }
 
   YAML::Node capacities = conf["capacities"];
   if (capacities["memory-cap-kb"]) {

--- a/server/cpp/src/monitor/monitoring.cpp
+++ b/server/cpp/src/monitor/monitoring.cpp
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#include <thread>
+
 #include "monitor/monitoring_handlers.hpp"
 #include "monitor/monitoring_utils.hpp"
 #include "monitor/policies.hpp"
@@ -152,6 +154,13 @@ int main(int argc, char *argv[]) {
   YAML::Node threads = conf["threads"];
   kMemoryThreadCount = threads["memory"].as<unsigned>();
   kDiskThreadCount = threads["disk"].as<unsigned>();
+
+  // A thread count of 0 means "auto-detect from available cores".
+  unsigned hw_threads = std::thread::hardware_concurrency();
+  if (hw_threads == 0) hw_threads = 1;  // fallback if detection fails
+
+  if (kMemoryThreadCount == 0) kMemoryThreadCount = hw_threads;
+  if (kDiskThreadCount == 0) kDiskThreadCount = hw_threads;
 
   YAML::Node capacities = conf["capacities"];
   if (capacities["memory-cap-kb"]) {

--- a/server/cpp/src/route/routing.cpp
+++ b/server/cpp/src/route/routing.cpp
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#include <thread>
+
 #include "route/routing_handlers.hpp"
 #include "signal_handler.hpp"
 #include "yaml-cpp/yaml.h"
@@ -171,6 +173,14 @@ int main(int argc, char *argv[]) {
   unsigned kMemoryThreadCount = threads["memory"].as<unsigned>();
   unsigned kDiskThreadCount = threads["disk"].as<unsigned>();
   kRoutingThreadCount = threads["routing"].as<unsigned>();
+
+  // A thread count of 0 means "auto-detect from available cores".
+  unsigned hw_threads = std::thread::hardware_concurrency();
+  if (hw_threads == 0) hw_threads = 1;  // fallback if detection fails
+
+  if (kMemoryThreadCount == 0) kMemoryThreadCount = hw_threads;
+  if (kDiskThreadCount == 0) kDiskThreadCount = hw_threads;
+  if (kRoutingThreadCount == 0) kRoutingThreadCount = hw_threads;
 
   YAML::Node capacities = conf["capacities"];
   kMemoryNodeCapacity = capacities["memory-cap"].as<unsigned>() * 1000000;

--- a/server/cpp/tests/monitor/test_config_yaml_parsing.hpp
+++ b/server/cpp/tests/monitor/test_config_yaml_parsing.hpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <fstream>
 #include <string>
+#include <thread>
 #include <unistd.h>
 
 #include "gtest/gtest.h"
@@ -147,12 +148,33 @@ static void apply_timings_config(const YAML::Node &conf) {
   }
 }
 
+// Helper: apply the threads-section parsing pattern, including auto-detect.
+// Mirrors the code in server.cpp / monitoring.cpp / routing.cpp.
+static void apply_threads_config(const YAML::Node &conf) {
+  if (conf["threads"]) {
+    YAML::Node threads = conf["threads"];
+    if (threads["memory"])
+      kMemoryThreadCount = threads["memory"].as<unsigned>();
+    if (threads["disk"])
+      kDiskThreadCount = threads["disk"].as<unsigned>();
+
+    // A thread count of 0 means "auto-detect from available cores".
+    unsigned hw_threads = std::thread::hardware_concurrency();
+    if (hw_threads == 0) hw_threads = 1;
+
+    if (kMemoryThreadCount == 0) kMemoryThreadCount = hw_threads;
+    if (kDiskThreadCount == 0) kDiskThreadCount = hw_threads;
+  }
+}
+
 // A fixture that saves and restores all configurable globals so tests are
 // independent. Each test modifies globals via YAML parsing and they are
 // restored to defaults after.
 class ConfigYamlParsingTest : public ::testing::Test {
 protected:
   // Saved copies of all configurable globals.
+  unsigned saved_kMemoryThreadCount;
+  unsigned saved_kDiskThreadCount;
   unsigned saved_kNodeAdditionBatchSize;
   double saved_kMaxMemoryNodeConsumption;
   double saved_kMinMemoryNodeConsumption;
@@ -178,6 +200,8 @@ protected:
   unsigned saved_kBaseOffset;
 
   void SetUp() override {
+    saved_kMemoryThreadCount = kMemoryThreadCount;
+    saved_kDiskThreadCount = kDiskThreadCount;
     saved_kNodeAdditionBatchSize = kNodeAdditionBatchSize;
     saved_kMaxMemoryNodeConsumption = kMaxMemoryNodeConsumption;
     saved_kMinMemoryNodeConsumption = kMinMemoryNodeConsumption;
@@ -204,6 +228,8 @@ protected:
   }
 
   void TearDown() override {
+    kMemoryThreadCount = saved_kMemoryThreadCount;
+    kDiskThreadCount = saved_kDiskThreadCount;
     kNodeAdditionBatchSize = saved_kNodeAdditionBatchSize;
     kMaxMemoryNodeConsumption = saved_kMaxMemoryNodeConsumption;
     kMinMemoryNodeConsumption = saved_kMinMemoryNodeConsumption;
@@ -563,5 +589,38 @@ TEST_F(ConfigYamlParsingTest, OccupancyLowerGreaterThanUpperIsSwapped) {
   // Values should be swapped so lower <= upper.
   EXPECT_DOUBLE_EQ(kSloOccupancyLower, 0.05);
   EXPECT_DOUBLE_EQ(kSloOccupancyUpper, 0.15);
+  std::remove(path.c_str());
+}
+
+// --- threads section ---
+
+TEST_F(ConfigYamlParsingTest, ThreadsExplicitValues) {
+  auto path = write_temp_yaml("threads:\n  memory: 8\n  disk: 2\n");
+  YAML::Node conf = YAML::LoadFile(path);
+  apply_threads_config(conf);
+  EXPECT_EQ(kMemoryThreadCount, 8u);
+  EXPECT_EQ(kDiskThreadCount, 2u);
+  std::remove(path.c_str());
+}
+
+TEST_F(ConfigYamlParsingTest, ThreadsZeroAutoDetects) {
+  auto path = write_temp_yaml("threads:\n  memory: 0\n  disk: 0\n");
+  YAML::Node conf = YAML::LoadFile(path);
+  apply_threads_config(conf);
+  unsigned hw = std::thread::hardware_concurrency();
+  if (hw == 0) hw = 1;
+  EXPECT_EQ(kMemoryThreadCount, hw);
+  EXPECT_EQ(kDiskThreadCount, hw);
+  std::remove(path.c_str());
+}
+
+TEST_F(ConfigYamlParsingTest, ThreadsPartialAutoDetect) {
+  auto path = write_temp_yaml("threads:\n  memory: 0\n  disk: 3\n");
+  YAML::Node conf = YAML::LoadFile(path);
+  apply_threads_config(conf);
+  unsigned hw = std::thread::hardware_concurrency();
+  if (hw == 0) hw = 1;
+  EXPECT_EQ(kMemoryThreadCount, hw);
+  EXPECT_EQ(kDiskThreadCount, 3u);
   std::remove(path.c_str());
 }


### PR DESCRIPTION
## Summary

A thread count of `0` in the YAML config now means "auto-detect from available cores" using `std::thread::hardware_concurrency()`. If detection fails, falls back to 1.

Applied to all three server components:
- **KVS server** (`server.cpp`): `threads.memory` and `threads.disk`
- **Routing server** (`routing.cpp`): `threads.memory`, `threads.disk`, and `threads.routing`
- **Monitor** (`monitoring.cpp`): `threads.memory` and `threads.disk`

## Config changes

- `anna-base.yml` (production): changed from hardcoded `4` to `0` (auto) for both memory and disk threads
- `anna-config.yml` and `anna-local.yml` (dev): remain at `1` with a comment documenting the convention. Explicit `1` is kept for deterministic test behavior.

## Example

```yaml
threads:
  memory: 0  # 0 = auto-detect from available cores
  disk: 1    # explicit: 1 disk thread
```

On a 10-core machine, the KVS would start 10 memory threads and 1 disk thread.

Closes #505