### PR TITLE
Compact port range from 1201 to 957 by eliminating gaps

### DIFF
--- a/clients/cpp/src/anna_client.hpp
+++ b/clients/cpp/src/anna_client.hpp
@@ -50,8 +50,8 @@ using Key = string;
 #define INCLUDE_THREADS_HPP_
 
 const unsigned kKeyAddressPort = 6450;
-const unsigned kUserResponsePort = 6800;
-const unsigned kUserKeyAddressPort = 6850;
+const unsigned kUserResponsePort = 6600;
+const unsigned kUserKeyAddressPort = 6650;
 
 inline unsigned kBaseOffset = 0;
 

--- a/clients/cpp/src/latency_reporter.hpp
+++ b/clients/cpp/src/latency_reporter.hpp
@@ -21,7 +21,7 @@
 #include "zmq/socket_cache.hpp"
 #include "zmq/zmq_util.hpp"
 
-const unsigned kFeedbackReportPort = 6750;
+const unsigned kFeedbackReportPort = 6953;
 
 class LatencyReporter {
 public:

--- a/clients/cpp/src/value_change_subscriber.hpp
+++ b/clients/cpp/src/value_change_subscriber.hpp
@@ -25,8 +25,8 @@
 #include <vector>
 #include <zmq.hpp>
 
-const unsigned kClientCacheRegistrationPort = 7200;
-const unsigned kClientCacheUpdatePort = 7150;
+const unsigned kClientCacheRegistrationPort = 6900;
+const unsigned kClientCacheUpdatePort = 6850;
 
 /// A cache client that receives key updates pushed from the KVS during gossip.
 ///

--- a/clients/cpp/tests/system/test_system_runner.py
+++ b/clients/cpp/tests/system/test_system_runner.py
@@ -71,7 +71,7 @@ hashing:
   virtual_nodes_per_thread: 3000
 ports:
   base_offset: 0
-  scaling_alert: 7001
+  scaling_alert: 6955
 timings:
   server_report_period: 15
   key_monitoring_period: 60

--- a/clients/cpp/tests/unit/test_value_change_subscriber.cpp
+++ b/clients/cpp/tests/unit/test_value_change_subscriber.cpp
@@ -16,8 +16,8 @@
 #include "value_change_subscriber.hpp"
 
 TEST(ValueChangeSubscriberTest, PortConstants) {
-  EXPECT_EQ(kClientCacheRegistrationPort, 7200u);
-  EXPECT_EQ(kClientCacheUpdatePort, 7150u);
+  EXPECT_EQ(kClientCacheRegistrationPort, 6900u);
+  EXPECT_EQ(kClientCacheUpdatePort, 6850u);
 }
 
 TEST(ValueChangeSubscriberTest, GetCachedMissing) {

--- a/clients/go/annalib/latency_reporter.go
+++ b/clients/go/annalib/latency_reporter.go
@@ -10,7 +10,7 @@ import (
 	benchpb "github.com/andrewdavidmackenzie/anna/clients/go/annalib/proto/benchmark"
 )
 
-const kMonitoringPort = 6750
+const kMonitoringPort = 6953
 
 // LatencyReporter sends UserFeedback to monitoring threads for SLO enforcement.
 type LatencyReporter struct {

--- a/clients/go/annalib/threads.go
+++ b/clients/go/annalib/threads.go
@@ -4,8 +4,8 @@ import "fmt"
 
 const (
 	kKeyAddressPort     = 6450
-	kUserResponsePort   = 6800
-	kUserKeyAddressPort = 6850
+	kUserResponsePort   = 6600
+	kUserKeyAddressPort = 6650
 	bindBase            = "tcp://0.0.0.0:"
 )
 

--- a/clients/go/annalib/threads_test.go
+++ b/clients/go/annalib/threads_test.go
@@ -16,30 +16,30 @@ func TestUserThreadAccessors(t *testing.T) {
 
 func TestUserThreadResponseAddresses(t *testing.T) {
 	ut := NewUserThread("127.0.0.1", 0)
-	if got := ut.ResponseBindAddress(); got != "tcp://0.0.0.0:6800" {
+	if got := ut.ResponseBindAddress(); got != "tcp://0.0.0.0:6600" {
 		t.Errorf("ResponseBindAddress: got %s", got)
 	}
-	if got := ut.ResponseConnectAddress(); got != "tcp://127.0.0.1:6800" {
+	if got := ut.ResponseConnectAddress(); got != "tcp://127.0.0.1:6600" {
 		t.Errorf("ResponseConnectAddress: got %s", got)
 	}
 }
 
 func TestUserThreadKeyAddressAddresses(t *testing.T) {
 	ut := NewUserThread("127.0.0.1", 0)
-	if got := ut.KeyAddressBindAddress(); got != "tcp://0.0.0.0:6850" {
+	if got := ut.KeyAddressBindAddress(); got != "tcp://0.0.0.0:6650" {
 		t.Errorf("KeyAddressBindAddress: got %s", got)
 	}
-	if got := ut.KeyAddressConnectAddress(); got != "tcp://127.0.0.1:6850" {
+	if got := ut.KeyAddressConnectAddress(); got != "tcp://127.0.0.1:6650" {
 		t.Errorf("KeyAddressConnectAddress: got %s", got)
 	}
 }
 
 func TestUserThreadWithTID(t *testing.T) {
 	ut := NewUserThread("10.0.0.1", 5)
-	if got := ut.ResponseBindAddress(); got != "tcp://0.0.0.0:6805" {
+	if got := ut.ResponseBindAddress(); got != "tcp://0.0.0.0:6605" {
 		t.Errorf("ResponseBindAddress with tid=5: got %s", got)
 	}
-	if got := ut.KeyAddressBindAddress(); got != "tcp://0.0.0.0:6855" {
+	if got := ut.KeyAddressBindAddress(); got != "tcp://0.0.0.0:6655" {
 		t.Errorf("KeyAddressBindAddress with tid=5: got %s", got)
 	}
 }

--- a/clients/go/annalib/value_change_subscriber.go
+++ b/clients/go/annalib/value_change_subscriber.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	kCacheRegistrationPort = 7200
-	kCacheUpdatePort       = 7150
+	kCacheRegistrationPort = 6900
+	kCacheUpdatePort       = 6850
 )
 
 // ValueChangeSubscriber subscribes to value changes for specific keys via the KVS gossip mechanism.

--- a/clients/go/annalib/value_change_subscriber_test.go
+++ b/clients/go/annalib/value_change_subscriber_test.go
@@ -157,7 +157,7 @@ func TestWatchRegistersKeys(t *testing.T) {
 	offset := 20500
 
 	// Set up a PULL listener on the registration port so Watch() can connect.
-	regPort := 0 + kCacheRegistrationPort + offset // 27700
+	regPort := 0 + kCacheRegistrationPort + offset // 27400
 	regAddr := fmt.Sprintf("tcp://127.0.0.1:%d", regPort)
 	puller := zmq4.NewPull(context.Background())
 	if err := puller.Listen(regAddr); err != nil {
@@ -302,7 +302,7 @@ func TestRecvUpdateEmptyPayload(t *testing.T) {
 	}
 	defer cc.Close()
 
-	updatePort := 0 + kCacheUpdatePort + offset // 27950
+	updatePort := 0 + kCacheUpdatePort + offset // 27650
 	pusher := zmq4.NewPush(context.Background())
 	if err := pusher.Dial(fmt.Sprintf("tcp://127.0.0.1:%d", updatePort)); err != nil {
 		t.Fatalf("Dial failed: %v", err)

--- a/clients/go/annalib/value_change_subscriber_test.go
+++ b/clients/go/annalib/value_change_subscriber_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestValueChangeSubscriberConstants(t *testing.T) {
-	if kCacheRegistrationPort != 7200 {
-		t.Errorf("expected registration port 7200, got %d", kCacheRegistrationPort)
+	if kCacheRegistrationPort != 6900 {
+		t.Errorf("expected registration port 6900, got %d", kCacheRegistrationPort)
 	}
-	if kCacheUpdatePort != 7150 {
-		t.Errorf("expected update port 7150, got %d", kCacheUpdatePort)
+	if kCacheUpdatePort != 6850 {
+		t.Errorf("expected update port 6850, got %d", kCacheUpdatePort)
 	}
 }
 
@@ -91,7 +91,7 @@ func TestRecvUpdateReceivesPushedValue(t *testing.T) {
 	defer cc.Close()
 
 	pusher := zmq4.NewPush(context.Background())
-	err = pusher.Dial("tcp://127.0.0.1:27350")
+	err = pusher.Dial("tcp://127.0.0.1:27050")
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
@@ -152,8 +152,8 @@ func TestRecvUpdateTimeout(t *testing.T) {
 }
 
 func TestWatchRegistersKeys(t *testing.T) {
-	// offset=20500 → registration port: 0+7200+20500 = 27700
-	// update port: 0+7150+20500 = 27650 (all below 32768)
+	// offset=20500 → registration port: 0+6900+20500 = 27400
+	// update port: 0+6850+20500 = 27350 (all below 32768)
 	offset := 20500
 
 	// Set up a PULL listener on the registration port so Watch() can connect.
@@ -211,7 +211,7 @@ func TestWatchRegistersKeys(t *testing.T) {
 }
 
 func TestWatchMultipleCalls(t *testing.T) {
-	// offset=20600 → registration port: 27800, update port: 27750
+	// offset=20600 → registration port: 27500, update port: 27450
 	offset := 20600
 
 	regPort := 0 + kCacheRegistrationPort + offset
@@ -254,7 +254,7 @@ func TestWatchMultipleCalls(t *testing.T) {
 }
 
 func TestCloseWithPushSockets(t *testing.T) {
-	// offset=20700 → registration port: 27900, update port: 27850
+	// offset=20700 → registration port: 27600, update port: 27550
 	offset := 20700
 
 	regPort := 0 + kCacheRegistrationPort + offset
@@ -293,7 +293,7 @@ func TestCloseWithPushSockets(t *testing.T) {
 }
 
 func TestRecvUpdateEmptyPayload(t *testing.T) {
-	// offset=20800 → update port: 0+7150+20800 = 27950
+	// offset=20800 → update port: 0+6850+20800 = 27650
 	offset := 20800
 
 	cc, err := NewValueChangeSubscriber("127.0.0.1", "127.0.0.1", 1, offset, 0)
@@ -336,7 +336,7 @@ func TestRecvUpdateEmptyPayload(t *testing.T) {
 
 func TestNewValueChangeSubscriberBindError(t *testing.T) {
 	// Bind the update port first, then try to create a subscriber on the same port.
-	// offset=20900 → update port: 0+7150+20900 = 28050
+	// offset=20900 → update port: 0+6850+20900 = 27750
 	offset := 20900
 	updatePort := 0 + kCacheUpdatePort + offset
 	updateAddr := fmt.Sprintf("tcp://127.0.0.1:%d", updatePort)

--- a/clients/python/anna/latency_reporter.py
+++ b/clients/python/anna/latency_reporter.py
@@ -2,7 +2,7 @@ import zmq
 
 from . import benchmark_pb2
 
-K_FEEDBACK_REPORT_PORT = 6750
+K_FEEDBACK_REPORT_PORT = 6953
 
 
 class LatencyReporter:

--- a/clients/python/anna/value_change_subscriber.py
+++ b/clients/python/anna/value_change_subscriber.py
@@ -21,8 +21,8 @@ import zmq
 from .kvs_pb2 import KeyResponse
 from .shared_pb2 import StringSet
 
-CACHE_REGISTRATION_PORT = 7200
-CACHE_UPDATE_PORT = 7150
+CACHE_REGISTRATION_PORT = 6900
+CACHE_UPDATE_PORT = 6850
 
 logger = logging.getLogger(__name__)
 

--- a/clients/python/tests/test_latency_reporter.py
+++ b/clients/python/tests/test_latency_reporter.py
@@ -12,7 +12,7 @@ TEST_PORT = K_FEEDBACK_REPORT_PORT + TEST_OFFSET
 
 class TestLatencyReporterConstants(unittest.TestCase):
     def test_feedback_report_port(self):
-        self.assertEqual(K_FEEDBACK_REPORT_PORT, 6750)
+        self.assertEqual(K_FEEDBACK_REPORT_PORT, 6953)
 
 
 class TestLatencyReporterConstruction(unittest.TestCase):

--- a/clients/python/tests/test_value_change_subscriber.py
+++ b/clients/python/tests/test_value_change_subscriber.py
@@ -25,10 +25,10 @@ from anna.value_change_subscriber import ValueChangeSubscriber, \
 
 class TestValueChangeSubscriberConstants(unittest.TestCase):
     def test_registration_port(self):
-        self.assertEqual(CACHE_REGISTRATION_PORT, 7200)
+        self.assertEqual(CACHE_REGISTRATION_PORT, 6900)
 
     def test_update_port(self):
-        self.assertEqual(CACHE_UPDATE_PORT, 7150)
+        self.assertEqual(CACHE_UPDATE_PORT, 6850)
 
 
 class TestValueChangeSubscriber(unittest.TestCase):
@@ -72,7 +72,7 @@ class TestValueChangeSubscriber(unittest.TestCase):
     def test_recv_update_receives_pushed_value(self):
         ctx = zmq.Context()
         pusher = ctx.socket(zmq.PUSH)
-        pusher.connect("tcp://127.0.0.1:27150")
+        pusher.connect("tcp://127.0.0.1:26850")
         time.sleep(0.1)
 
         response = KeyResponse()
@@ -94,7 +94,7 @@ class TestValueChangeSubscriber(unittest.TestCase):
     def test_recv_update_skips_empty_payload(self):
         ctx = zmq.Context()
         pusher = ctx.socket(zmq.PUSH)
-        pusher.connect("tcp://127.0.0.1:27150")
+        pusher.connect("tcp://127.0.0.1:26850")
         time.sleep(0.1)
 
         response = KeyResponse()
@@ -196,7 +196,7 @@ class TestCloseWithPushSockets(unittest.TestCase):
         )
         # Add a mock push socket
         mock_sock = MagicMock()
-        client.push_sockets["tcp://127.0.0.1:27200"] = mock_sock
+        client.push_sockets["tcp://127.0.0.1:26900"] = mock_sock
 
         client.close()
         self.assertEqual(client.push_sockets, {})

--- a/clients/rust/src/lib/latency_reporter.rs
+++ b/clients/rust/src/lib/latency_reporter.rs
@@ -10,7 +10,7 @@ use prost::Message;
 use std::collections::HashMap;
 use std::time::Duration;
 
-const K_FEEDBACK_REPORT_PORT: usize = 6750;
+const K_FEEDBACK_REPORT_PORT: usize = 6953;
 const MONITORING_IPS_KEY: &str = "ANNA_METADATA|monitoring_ips";
 
 /// Reports client-observed latency to the anna monitor for SLO enforcement.
@@ -280,7 +280,7 @@ mod tests {
 
     #[tokio::test]
     async fn send_and_receive_feedback() {
-        let port = 6750 + 80;
+        let port = 6953 + 80;
         let ctx = Context::new();
         let puller = ctx.socket(SocketType::Pull, Options::default());
         puller
@@ -313,7 +313,7 @@ mod tests {
 
     #[tokio::test]
     async fn send_finish_signal() {
-        let port = 6750 + 81;
+        let port = 6953 + 81;
         let ctx = Context::new();
         let puller = ctx.socket(SocketType::Pull, Options::default());
         puller
@@ -339,7 +339,7 @@ mod tests {
 
     #[tokio::test]
     async fn connect_pre_establishes_sockets() {
-        let port = 6750 + 82;
+        let port = 6953 + 82;
         let ctx = Context::new();
         let puller = ctx.socket(SocketType::Pull, Options::default());
         puller

--- a/clients/rust/src/lib/threads.rs
+++ b/clients/rust/src/lib/threads.rs
@@ -4,16 +4,16 @@ use crate::types::Address;
 const K_KEY_ADDRESS_PORT: usize = 6450;
 
 // The port on which clients receive responses from the KVS.
-const K_USER_RESPONSE_PORT: usize = 6800;
+const K_USER_RESPONSE_PORT: usize = 6600;
 
 // The port on which clients receive responses from the routing tier.
-const K_USER_KEY_ADDRESS_PORT: usize = 6850;
+const K_USER_KEY_ADDRESS_PORT: usize = 6650;
 
 // The port on which cache nodes listen for updates from the KVS.
-const K_CACHE_UPDATE_PORT: usize = 7150;
+const K_CACHE_UPDATE_PORT: usize = 6850;
 
 // The port on which KVS servers listen for direct cache registration messages.
-const K_CACHE_REGISTRATION_PORT: usize = 7200;
+const K_CACHE_REGISTRATION_PORT: usize = 6900;
 
 /// `Thread` is a base type for a number of other thread types
 pub struct Thread {
@@ -189,36 +189,36 @@ mod tests {
     #[test]
     fn user_thread_response_addresses() {
         let ut = UserThread::new(&"10.0.0.1".into(), 0);
-        assert_eq!(ut.response_bind_address(), "tcp://10.0.0.1:6800");
-        assert_eq!(ut.response_connect_address(), "tcp://10.0.0.1:6800");
+        assert_eq!(ut.response_bind_address(), "tcp://10.0.0.1:6600");
+        assert_eq!(ut.response_connect_address(), "tcp://10.0.0.1:6600");
     }
 
     #[test]
     fn user_thread_response_with_offset() {
         let ut = UserThread::new(&"10.0.0.1".into(), 2);
-        assert_eq!(ut.response_bind_address(), "tcp://10.0.0.1:6802");
-        assert_eq!(ut.response_connect_address(), "tcp://10.0.0.1:6802");
+        assert_eq!(ut.response_bind_address(), "tcp://10.0.0.1:6602");
+        assert_eq!(ut.response_connect_address(), "tcp://10.0.0.1:6602");
     }
 
     #[test]
     fn user_thread_key_addresses() {
         let ut = UserThread::new(&"10.0.0.1".into(), 0);
-        assert_eq!(ut.key_address_bind_address(), "tcp://10.0.0.1:6850");
-        assert_eq!(ut.key_address_connect_address(), "tcp://10.0.0.1:6850");
+        assert_eq!(ut.key_address_bind_address(), "tcp://10.0.0.1:6650");
+        assert_eq!(ut.key_address_connect_address(), "tcp://10.0.0.1:6650");
     }
 
     #[test]
     fn user_thread_key_addresses_with_offset() {
         let ut = UserThread::new(&"10.0.0.1".into(), 3);
-        assert_eq!(ut.key_address_bind_address(), "tcp://10.0.0.1:6853");
-        assert_eq!(ut.key_address_connect_address(), "tcp://10.0.0.1:6853");
+        assert_eq!(ut.key_address_bind_address(), "tcp://10.0.0.1:6653");
+        assert_eq!(ut.key_address_connect_address(), "tcp://10.0.0.1:6653");
     }
 
     #[test]
     fn user_thread_with_base_offset() {
         let ut = UserThread::with_offset(&"10.0.0.1".into(), 0, 1000);
-        assert_eq!(ut.response_bind_address(), "tcp://10.0.0.1:7800");
-        assert_eq!(ut.key_address_bind_address(), "tcp://10.0.0.1:7850");
+        assert_eq!(ut.response_bind_address(), "tcp://10.0.0.1:7600");
+        assert_eq!(ut.key_address_bind_address(), "tcp://10.0.0.1:7650");
     }
 
     #[test]
@@ -233,8 +233,8 @@ mod tests {
     #[test]
     fn cache_thread_update_addresses() {
         let ct = UserThread::new(&"10.0.0.1".into(), 1);
-        assert_eq!(ct.cache_update_bind_address(), "tcp://10.0.0.1:7151");
-        assert_eq!(ct.cache_update_connect_address(), "tcp://10.0.0.1:7151");
+        assert_eq!(ct.cache_update_bind_address(), "tcp://10.0.0.1:6851");
+        assert_eq!(ct.cache_update_connect_address(), "tcp://10.0.0.1:6851");
     }
 
     #[test]

--- a/clients/rust/src/lib/value_change_subscriber.rs
+++ b/clients/rust/src/lib/value_change_subscriber.rs
@@ -10,10 +10,10 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 // The port on which KVS servers listen for direct cache registration.
-const K_CACHE_REGISTRATION_PORT: usize = 7200;
+const K_CACHE_REGISTRATION_PORT: usize = 6900;
 
 // The port on which cache nodes receive updates from the KVS.
-const K_CACHE_UPDATE_PORT: usize = 7150;
+const K_CACHE_UPDATE_PORT: usize = 6850;
 
 /// Subscribes to value changes for specific keys via the KVS gossip mechanism.
 ///
@@ -291,12 +291,12 @@ mod tests {
 
     #[test]
     fn cache_registration_port_constant() {
-        assert_eq!(K_CACHE_REGISTRATION_PORT, 7200);
+        assert_eq!(K_CACHE_REGISTRATION_PORT, 6900);
     }
 
     #[test]
     fn cache_update_port_constant() {
-        assert_eq!(K_CACHE_UPDATE_PORT, 7150);
+        assert_eq!(K_CACHE_UPDATE_PORT, 6850);
     }
 
     #[test]

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -196,7 +196,7 @@ async fn system_test_kvs_client() {
     let config_path = generate_config(MEMORY_BASE_OFFSET);
     let _guard = ServerGuard::start(&config_path, MEMORY_BASE_OFFSET);
     let config = client_config(MEMORY_BASE_OFFSET);
-    let mut client = KVSClient::new(&config, Some(50)).await;
+    let mut client = KVSClient::new(&config, Some(5)).await;
 
     test_all_lattice_types(&mut client, "mem").await;
     test_memory_extras(&mut client).await;
@@ -211,7 +211,7 @@ async fn disk_tier_lattice_types() {
     let config_path = generate_disk_config(DISK_BASE_OFFSET);
     let _guard = ServerGuard::start_disk(&config_path, DISK_BASE_OFFSET);
     let config = client_config(DISK_BASE_OFFSET);
-    let mut client = KVSClient::new(&config, Some(51)).await;
+    let mut client = KVSClient::new(&config, Some(6)).await;
 
     test_all_lattice_types(&mut client, "disk").await;
 }

--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -596,7 +596,7 @@ async fn latency_feedback_ingestion() {
     std::thread::sleep(Duration::from_secs(REPORT_PERIOD as u64 + 1));
 
     // Send UserFeedback to the monitor's feedback port
-    let feedback_addr = format!("tcp://{}:{}", NODE_IP, 6750 + 6300);
+    let feedback_addr = format!("tcp://{}:{}", NODE_IP, 6953 + 6300);
     let ctx = Context::new();
     let pusher = ctx.socket(SocketType::Push, Options::default());
     pusher

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -526,7 +526,7 @@ async fn multi_node_cluster_join_and_data_access() {
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(50)).await;
+    let mut client = KVSClient::new(&config, Some(1)).await;
 
     for i in 0..10 {
         let key = format!("multi_node_key_{}", i);
@@ -567,13 +567,13 @@ async fn multi_node_gossip_replication() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(1201);
+    let mut cluster = MultiNodeCluster::new(1057);
 
     cluster.start_full_node(NODE1_IP, 2);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(51)).await;
+    let mut client = KVSClient::new(&config, Some(2)).await;
 
     client
         .put("gossip_test_1", "alpha")
@@ -615,12 +615,12 @@ async fn multi_node_address_cache_invalidation() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(2402);
+    let mut cluster = MultiNodeCluster::new(2014);
 
     cluster.start_full_node(NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(52)).await;
+    let mut client = KVSClient::new(&config, Some(3)).await;
 
     for i in 0..5 {
         client
@@ -667,13 +667,13 @@ async fn multi_node_fault_tolerance() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(3603);
+    let mut cluster = MultiNodeCluster::new(2971);
 
     cluster.start_full_node(NODE1_IP, 2);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(53)).await;
+    let mut client = KVSClient::new(&config, Some(4)).await;
 
     // PUT data and wait for gossip to replicate to both nodes
     client
@@ -693,7 +693,7 @@ async fn multi_node_fault_tolerance() {
     // addresses. Verify fault tolerance by reading each key individually
     // with a fresh client and short timeout. The client's retry logic
     // evicts the dead address on timeout and retries via the live node.
-    let mut reader = KVSClient::new(&config, Some(54)).await;
+    let mut reader = KVSClient::new(&config, Some(5)).await;
     reader.set_timeout(Duration::from_secs(2));
 
     let v1 = reader
@@ -722,11 +722,11 @@ async fn no_servers_error() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(4804);
+    let mut cluster = MultiNodeCluster::new(3928);
     cluster.start_routing_only(NODE1_IP);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(55)).await;
+    let mut client = KVSClient::new(&config, Some(6)).await;
     client.set_timeout(Duration::from_secs(3));
 
     let result = client.put("no_servers_test", "value").await;
@@ -752,12 +752,12 @@ async fn virtual_nodes_key_distribution() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(6005);
+    let mut cluster = MultiNodeCluster::new(4885);
     cluster.start_full_node(NODE1_IP, 1);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(56)).await;
+    let mut client = KVSClient::new(&config, Some(7)).await;
 
     let mut node_counts: HashMap<String, usize> = HashMap::new();
     let num_keys = 100;
@@ -815,12 +815,12 @@ async fn multi_node_replica_survival() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(7206);
+    let mut cluster = MultiNodeCluster::new(5842);
     cluster.start_full_node(NODE1_IP, 2);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(57)).await;
+    let mut client = KVSClient::new(&config, Some(8)).await;
 
     client
         .put("depart_key_1", "data_1")
@@ -838,7 +838,7 @@ async fn multi_node_replica_survival() {
     cluster.kill_process("anna-kvs@127.0.0.2");
 
     // Data should survive on Node 1 via client retry
-    let mut reader = KVSClient::new(&config, Some(58)).await;
+    let mut reader = KVSClient::new(&config, Some(9)).await;
     reader.set_timeout(Duration::from_secs(2));
 
     let v1 = reader
@@ -869,7 +869,7 @@ async fn multi_node_rejoin() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(8407);
+    let mut cluster = MultiNodeCluster::new(7756);
     cluster.start_full_node(NODE1_IP, 2);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
 
@@ -882,7 +882,7 @@ async fn multi_node_rejoin() {
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
 
     // PUT data after rejoin — with replication=2, data goes to both nodes
-    let mut client = KVSClient::new(&config, Some(59)).await;
+    let mut client = KVSClient::new(&config, Some(10)).await;
     client
         .put("rejoin_proof", "on_both_nodes")
         .await
@@ -894,7 +894,7 @@ async fn multi_node_rejoin() {
 
     // Poll Node 2 — routing may still try the dead Node 1 first,
     // so retry until the client's address cache updates
-    let mut reader = KVSClient::new(&config, Some(60)).await;
+    let mut reader = KVSClient::new(&config, Some(11)).await;
     reader.set_timeout(Duration::from_secs(2));
 
     let deadline = Instant::now() + Duration::from_secs(15);
@@ -925,11 +925,11 @@ async fn stateless_routing_recovery() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(9608);
+    let mut cluster = MultiNodeCluster::new(9670);
     cluster.start_full_node(NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(61)).await;
+    let mut client = KVSClient::new(&config, Some(12)).await;
 
     client
         .put("routing_recovery_key", "persistent")
@@ -958,7 +958,7 @@ async fn stateless_routing_recovery() {
     std::thread::sleep(Duration::from_secs(2));
 
     // KVS data is in-memory and lost on restart, so PUT again
-    let mut client2 = KVSClient::new(&config, Some(62)).await;
+    let mut client2 = KVSClient::new(&config, Some(13)).await;
     client2
         .put("post_recovery_key", "recovered")
         .await
@@ -984,15 +984,15 @@ async fn multi_threaded_routing() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(10809);
+    let mut cluster = MultiNodeCluster::new(10627);
     cluster.start_full_node_with_config(NodeConfig {
-        base_offset: 10809,
+        base_offset: 10627,
         routing_threads: 2,
         ..Default::default()
     });
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(63)).await;
+    let mut client = KVSClient::new(&config, Some(14)).await;
 
     for i in 0..10 {
         let key = format!("mt_route_key_{}", i);
@@ -1025,12 +1025,12 @@ async fn replication_aware_routing() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(12010);
+    let mut cluster = MultiNodeCluster::new(11584);
     cluster.start_full_node(NODE1_IP, 2);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 2);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(64)).await;
+    let mut client = KVSClient::new(&config, Some(15)).await;
 
     // PUT a key so routing resolves it
     client
@@ -1070,12 +1070,12 @@ async fn pending_request_queue() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(13211);
+    let mut cluster = MultiNodeCluster::new(12541);
     cluster.start_full_node(NODE1_IP, 1);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(65)).await;
+    let mut client = KVSClient::new(&config, Some(16)).await;
 
     // Rapidly PUT many new keys — each triggers a replication factor lookup
     // that goes through the pending request queue
@@ -1111,11 +1111,11 @@ async fn key_migration_during_join() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(14412);
+    let mut cluster = MultiNodeCluster::new(13498);
     cluster.start_full_node(NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(66)).await;
+    let mut client = KVSClient::new(&config, Some(17)).await;
 
     // PUT initial data on single node
     for i in 0..10 {
@@ -1181,12 +1181,12 @@ async fn per_key_replication_metadata() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(15613);
+    let mut cluster = MultiNodeCluster::new(14455);
     cluster.start_full_node(NODE1_IP, 1);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(68)).await;
+    let mut client = KVSClient::new(&config, Some(18)).await;
 
     // PUT a regular key
     client
@@ -1231,11 +1231,11 @@ async fn self_depart_signal() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(16814);
+    let mut cluster = MultiNodeCluster::new(15412);
     cluster.start_full_node(NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(69)).await;
+    let mut client = KVSClient::new(&config, Some(19)).await;
 
     client
         .put("sd_signal_key", "before_depart")
@@ -1278,13 +1278,13 @@ async fn disk_tier_basic() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(18015);
+    let mut cluster = MultiNodeCluster::new(16369);
 
     // Start cluster with both tiers. Disk-only (replication_memory: 0) is
     // not yet fully working — see #444 for the ongoing fix.
     cluster.start_full_node_with_config(NodeConfig {
         replication_disk: 1,
-        base_offset: 18015,
+        base_offset: 16369,
         ..Default::default()
     });
 
@@ -1421,10 +1421,10 @@ async fn memory_tier_preference() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(19216);
+    let mut cluster = MultiNodeCluster::new(17326);
     cluster.start_full_node_with_config(NodeConfig {
         replication_disk: 1,
-        base_offset: 19216,
+        base_offset: 17326,
         ..Default::default()
     });
     cluster.start_disk_kvs_node(NODE2_IP, NODE1_IP);
@@ -1462,13 +1462,13 @@ async fn cross_tier_gossip() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(20417);
+    let mut cluster = MultiNodeCluster::new(18283);
 
     // Start with replication on both tiers so data gossips across
     cluster.start_full_node_with_config(NodeConfig {
         replication_memory: 1,
         replication_disk: 1,
-        base_offset: 20417,
+        base_offset: 18283,
         ..Default::default()
     });
     cluster.start_disk_kvs_node(NODE2_IP, NODE1_IP);
@@ -1512,10 +1512,10 @@ async fn crash_detection_via_epoch() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(24020);
+    let mut cluster = MultiNodeCluster::new(21154);
     cluster.start_full_node_with_config(NodeConfig {
         replication_memory: 1,
-        base_offset: 24020,
+        base_offset: 21154,
         gossip_epoch: 2,
         ..Default::default()
     });
@@ -1580,7 +1580,7 @@ async fn replication_factor_change() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(21618);
+    let mut cluster = MultiNodeCluster::new(19240);
     cluster.start_full_node(NODE1_IP, 1);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
 
@@ -1629,7 +1629,7 @@ async fn gossip_after_replication_change() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(22819);
+    let mut cluster = MultiNodeCluster::new(20197);
     cluster.start_full_node(NODE1_IP, 1);
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
 
@@ -1669,7 +1669,7 @@ async fn gossip_to_caches() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(25221);
+    let mut cluster = MultiNodeCluster::new(22111);
     cluster.start_full_node(NODE1_IP, 1);
 
     let config = cluster.client_config();
@@ -1742,14 +1742,14 @@ async fn slo_selective_replication() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(400);
+    let mut cluster = MultiNodeCluster::new(23068);
 
     // Start node 1 (full: monitor + route + kvs) with selective-rep enabled
     let cfg1 = NodeConfig {
         node_ip: NODE1_IP,
         seed_ip: NODE1_IP,
         replication_memory: 1,
-        base_offset: 400,
+        base_offset: 23068,
         selective_rep: true,
         ..Default::default()
     };
@@ -1759,7 +1759,7 @@ async fn slo_selective_replication() {
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(50)).await;
+    let mut client = KVSClient::new(&config, Some(1)).await;
 
     let hot_key = "slo_key_0";
 
@@ -1772,7 +1772,7 @@ async fn slo_selective_replication() {
     }
 
     // Connect to monitor feedback port using raw ZMQ
-    let feedback_addr = format!("tcp://{}:{}", NODE1_IP, 6750 + 400);
+    let feedback_addr = format!("tcp://{}:{}", NODE1_IP, 6953 + 23068);
     let ctx = Context::new();
     let feedback_pusher = ctx.socket(SocketType::Push, Options::default());
     feedback_pusher
@@ -1870,23 +1870,23 @@ async fn management_node_integration() {
     let ctx = Context::new();
 
     // Start mock management node BEFORE starting the cluster.
-    // Port 7000+offset: REP socket for "restart:<ip>" queries
+    // Port 6954+offset: REP socket for "restart:<ip>" queries
     let restart_count_rep = ctx.socket(SocketType::Rep, Options::default());
     restart_count_rep
         .bind(
-            format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset)
+            format!("tcp://{}:{}", NODE1_IP, 6954 + base_offset)
                 .parse()
                 .unwrap(),
         )
         .await
         .expect("Failed to bind restart count REP");
 
-    // Port 7002+offset: PULL socket for func/cache node queries
+    // Port 6956+offset: PULL socket for func/cache node queries
     // (KVS sends via PUSH, so we receive via PULL)
     let func_nodes_pull = ctx.socket(SocketType::Pull, Options::default());
     func_nodes_pull
         .bind(
-            format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset)
+            format!("tcp://{}:{}", NODE1_IP, 6956 + base_offset)
                 .parse()
                 .unwrap(),
         )
@@ -2039,7 +2039,7 @@ async fn elasticity_storage_policy() {
     let restart_rep = ctx.socket(SocketType::Rep, Options::default());
     restart_rep
         .bind(
-            format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset)
+            format!("tcp://{}:{}", NODE1_IP, 6954 + base_offset)
                 .parse()
                 .unwrap(),
         )
@@ -2049,18 +2049,18 @@ async fn elasticity_storage_policy() {
     let func_pull = ctx.socket(SocketType::Pull, Options::default());
     func_pull
         .bind(
-            format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset)
+            format!("tcp://{}:{}", NODE1_IP, 6956 + base_offset)
                 .parse()
                 .unwrap(),
         )
         .await
         .expect("bind func PULL failed");
 
-    // Port 7001+offset for add/remove messages from monitor
+    // Port 6955+offset for add/remove messages from monitor
     let add_node_pull = ctx.socket(SocketType::Pull, Options::default());
     add_node_pull
         .bind(
-            format!("tcp://{}:{}", NODE1_IP, 7001 + base_offset)
+            format!("tcp://{}:{}", NODE1_IP, 6955 + base_offset)
                 .parse()
                 .unwrap(),
         )
@@ -2224,7 +2224,7 @@ async fn underutilization_scale_in() {
     let restart_rep = ctx.socket(SocketType::Rep, Options::default());
     restart_rep
         .bind(
-            format!("tcp://{}:{}", NODE1_IP, 7000 + base_offset)
+            format!("tcp://{}:{}", NODE1_IP, 6954 + base_offset)
                 .parse()
                 .unwrap(),
         )
@@ -2234,18 +2234,18 @@ async fn underutilization_scale_in() {
     let func_pull = ctx.socket(SocketType::Pull, Options::default());
     func_pull
         .bind(
-            format!("tcp://{}:{}", NODE1_IP, 7002 + base_offset)
+            format!("tcp://{}:{}", NODE1_IP, 6956 + base_offset)
                 .parse()
                 .unwrap(),
         )
         .await
         .expect("bind func PULL failed");
 
-    // Port 7001+offset for add/remove messages from monitor
+    // Port 6955+offset for add/remove messages from monitor
     let mgmt_pull = ctx.socket(SocketType::Pull, Options::default());
     mgmt_pull
         .bind(
-            format!("tcp://{}:{}", NODE1_IP, 7001 + base_offset)
+            format!("tcp://{}:{}", NODE1_IP, 6955 + base_offset)
                 .parse()
                 .unwrap(),
         )
@@ -2411,7 +2411,7 @@ async fn tiering_movement_policy() {
         return;
     }
 
-    let base_offset: u32 = 7823;
+    let base_offset: u32 = 6799;
     let short_grace: u32 = 5;
 
     let mut cluster = MultiNodeCluster::new(base_offset);
@@ -2506,7 +2506,7 @@ async fn replication_response_wrong_thread() {
         return;
     }
 
-    let base_offset: u32 = 9224;
+    let base_offset: u32 = 8713;
     let mut cluster = MultiNodeCluster::new(base_offset);
 
     // Start 2-node cluster so keys are distributed
@@ -2612,9 +2612,9 @@ async fn tombstone_gc() {
         return;
     }
 
-    let mut cluster = MultiNodeCluster::new(26422);
+    let mut cluster = MultiNodeCluster::new(24025);
     cluster.start_full_node_with_config(NodeConfig {
-        base_offset: 26422,
+        base_offset: 24025,
         gossip_epoch: 2,
         server_report_period: 2,
         tombstone_gc_multiplier: 1, // TTL = 2s * 1 = 2s

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -2518,7 +2518,7 @@ async fn replication_response_wrong_thread() {
     cluster.start_kvs_node(NODE2_IP, NODE1_IP, 1);
 
     let config = cluster.client_config();
-    let mut client = KVSClient::new(&config, Some(100)).await;
+    let mut client = KVSClient::new(&config, Some(20)).await;
 
     // PUT keys across both nodes
     let deadline = Instant::now() + Duration::from_secs(15);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,7 @@ Anna uses ZeroMQ for all communication:
 - **Inter-node** (between machines): ZeroMQ `tcp` transport with Protocol
   Buffer serialization
 - **Client-to-routing**: PUSH/PULL sockets on port 6450
-- **Client-to-KVS**: PUSH/PULL sockets on configurable ports (6800/6850)
+- **Client-to-KVS**: PUSH/PULL sockets on configurable ports (6600/6650)
 
 See [Port Layout](ports.md) for the complete port map (26 port groups across
 6000-7200).

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -198,7 +198,7 @@ while True:
 ### Scaling Alert Protocol
 
 The built-in policy engine communicates scaling recommendations to an
-external system via ZMQ PUSH on the `scaling_alert` port (default 7001).
+external system via ZMQ PUSH on the `scaling_alert` port (default 6955).
 Messages are serialized `ScalingAlert` protobuf messages (defined in
 `server/protobuf/metadata.proto`):
 

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -8,9 +8,9 @@ Features implemented per client. Each client wraps the Anna KVS protocol
 All four clients provide a value change subscription API — a pub-sub
 mechanism for receiving notifications when specific keys are updated
 (including deletes). The subscriber registers interest in keys with the
-KVS server threads via a dedicated registration port (7200). During each
+KVS server threads via a dedicated registration port (6900). During each
 gossip epoch, when a watched key changes, the KVS pushes the new value
-to the subscriber on port 7150.
+to the subscriber on port 6850.
 
 Applications can use this for caching, event-driven updates, replication
 to external systems, or any pattern that needs to react to key changes.

--- a/docs/config.md
+++ b/docs/config.md
@@ -43,7 +43,7 @@ the compiled-in default is used, preserving backward-compatible behavior.
 | Config Key | C++ Variable | Default | Meaning |
 |------------|-------------|---------|---------|
 | `ports.base_offset` | `kBaseOffset` | `0` | Offset added to all port numbers |
-| `ports.scaling_alert` | `kScalingAlertPort` | `7001` | Port on which the external system receives scaling alerts |
+| `ports.scaling_alert` | `kScalingAlertPort` | `6955` | Port on which the external system receives scaling alerts |
 
 ## Storage Configuration
 
@@ -199,7 +199,7 @@ hashing:
   virtual_nodes_per_thread: 3000
 ports:
   base_offset: 0
-  scaling_alert: 7001
+  scaling_alert: 6955
 timings:
   server_report_period: 15
   key_monitoring_period: 60

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -227,7 +227,7 @@ external autoscaler:
 `anna-monitor` contains a built-in policy engine (`storage_policy.cpp`,
 `slo_policy.cpp`, `movement_policy.cpp`) that implements reference decision
 logic, but it depends on an external system
-(`tcp://<scaling_alert_ip>:<ports.scaling_alert>`, default port `7001`,
+(`tcp://<scaling_alert_ip>:<ports.scaling_alert>`, default port `6955`,
 subject to `ports.base_offset`) that is not part of the project. Operators
 can use the client library helpers to implement their own scaling logic.
 

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -14,6 +14,9 @@ actual_port = base_port + tid + base_offset
 
 ## Port Map
 
+All 26 port groups are packed contiguously: 19 per-thread groups at 50-port
+spacing (6000-6900), followed by 7 singleton ports (6950-6956).
+
 ### KVS Server (10 per-thread ports)
 
 | Base Port | Constant | Purpose |
@@ -25,9 +28,9 @@ actual_port = base_port + tid + base_offset
 | 6200 | `kKeyRequestPort` | Receive client GET/PUT/DELETE requests |
 | 6250 | `kGossipPort` | Receive gossip from peer KVS nodes |
 | 6300 | `kServerReplicationChangePort` | Receive replication factor changes from monitor |
-| 7050 | `kCacheIpResponsePort` | Receive cache IP lookup responses |
-| 7100 | `kManagementNodeResponsePort` | Receive management node responses (function node lists) |
-| 7200 | `kCacheRegistrationPort` | Receive cache registration messages from ValueChangeSubscriber clients |
+| 6750 | `kCacheIpResponsePort` | Receive cache IP lookup responses |
+| 6800 | `kManagementNodeResponsePort` | Receive management node responses (function node lists) |
+| 6900 | `kCacheRegistrationPort` | Receive cache registration messages from ValueChangeSubscriber clients |
 
 ### Routing Server (5 per-thread ports)
 
@@ -39,39 +42,34 @@ actual_port = base_port + tid + base_offset
 | 6500 | `kRoutingReplicationResponsePort` | Replication factor query responses |
 | 6550 | `kRoutingReplicationChangePort` | Replication factor change announcements from monitor |
 
-### Monitor (4 singleton ports, no tid)
+### Client (2 per-thread ports)
 
 | Base Port | Constant | Purpose |
 |-----------|----------|---------|
-| 6600 | `kMonitoringNotifyPort` | Cluster membership change notifications |
-| 6650 | `kMonitoringResponsePort` | KVS metadata/stats responses |
-| 6700 | `kDepartDonePort` | Depart-done confirmations from departing nodes |
-| 6750 | `kFeedbackReportPort` | Client latency/throughput feedback (LatencyReporter) |
+| 6600 | `kUserResponsePort` | Receive GET/PUT responses from KVS |
+| 6650 | `kUserKeyAddressPort` | Receive key-address responses from routing |
 
-### Client (3 per-thread ports)
+### Other per-thread ports
 
 | Base Port | Constant | Purpose |
 |-----------|----------|---------|
-| 6800 | `kUserResponsePort` | Receive GET/PUT responses from KVS |
-| 6850 | `kUserKeyAddressPort` | Receive key-address responses from routing |
-| 7150 | `kCacheUpdatePort` | Receive pushed key-value updates (ValueChangeSubscriber) |
+| 6700 | `kBenchmarkCommandPort` | Receive benchmark trigger commands |
+| 6850 | `kCacheUpdatePort` | Receive pushed key-value updates (ValueChangeSubscriber) |
 
-### Benchmark (1 per-thread port)
-
-| Base Port | Constant | Purpose |
-|-----------|----------|---------|
-| 6900 | `kBenchmarkCommandPort` | Receive benchmark trigger commands |
-
-### Management / External System (3 singleton ports, no tid)
+### Singleton ports (no tid, packed at end)
 
 | Base Port | Constant | Purpose |
 |-----------|----------|---------|
-| 7000 | `kManagementRestartCountPort` | KVS queries restart count on startup |
-| 7001 | `kScalingAlertPort` | Monitor sends scaling alerts (add/remove nodes) |
-| 7002 | `kManagementFuncNodesPort` | KVS queries function/cache node lists |
+| 6950 | `kMonitoringNotifyPort` | Cluster membership change notifications |
+| 6951 | `kMonitoringResponsePort` | KVS metadata/stats responses |
+| 6952 | `kDepartDonePort` | Depart-done confirmations from departing nodes |
+| 6953 | `kFeedbackReportPort` | Client latency/throughput feedback (LatencyReporter) |
+| 6954 | `kManagementRestartCountPort` | KVS queries restart count on startup |
+| 6955 | `kScalingAlertPort` | Monitor sends scaling alerts (add/remove nodes) |
+| 6956 | `kManagementFuncNodesPort` | KVS queries function/cache node lists |
 
-These ports are on the external management system, not on Anna nodes. The
-management system is not part of this project. See
+Management ports (6954-6956) are on the external management system, not on
+Anna nodes. The management system is not part of this project. See
 [Autoscaling](autoscaling.md) for details.
 
 ## Port Range Summary
@@ -79,32 +77,13 @@ management system is not part of this project. See
 With `base_offset=0` and 1 thread per component:
 
 - **Minimum port**: 6000 (`kNodeJoinPort`)
-- **Maximum port**: 7200 (`kCacheRegistrationPort`)
-- **Total span**: 1201 ports (but only 26 actually bound)
+- **Maximum port**: 6956 (`kManagementFuncNodesPort`)
+- **Total span**: 957 ports (but only 26 actually bound)
 
-The 50-port spacing between consecutive port groups (6000, 6050, 6100, ...)
-allows up to **50 threads** per component before per-thread port ranges
-collide. This limit is implicit -- there is no constant defining it and
-no runtime validation. Configuring more than 50 threads will cause silent
-port collisions.
-
-### Why the range is 1201 and not smaller
-
-The 26 port groups are not packed contiguously. The layout has gaps:
-
-- Ports 6000-6900: 19 groups, mostly contiguous at 50-port spacing (950 span)
-- Ports 7000-7002: 3 management singletons (3 span)
-- Ports 7050-7200: 4 more groups at 50-port spacing (150 span)
-
-The 100-port gap between 6900 (benchmark) and 7000 (management) and the
-48-port gap between 7002 and 7050 waste 148 ports. Renumbering these groups
-to be contiguous would reduce the range from 1201 to approximately **1053**
-(21 per-thread groups x 50 spacing + 5 singletons).
-
-Further reduction would require reducing the inter-group spacing from 50,
-which limits the maximum thread count. With spacing of 10 (max 10 threads),
-the range shrinks to approximately **260**. With spacing of 4 (max 4
-threads), approximately **104**.
+The 50-port spacing between consecutive per-thread port groups allows up to
+**50 threads** per component before port ranges collide. This limit is
+implicit -- there is no constant defining it and no runtime validation.
+Configuring more than 50 threads will cause silent port collisions.
 
 ## base_offset for Multiple Clusters
 
@@ -112,12 +91,12 @@ The `ports.base_offset` config key shifts all ports by a fixed amount:
 
 ```yaml
 ports:
-  base_offset: 0      # default: ports 6000-7200
-  # base_offset: 2000 # shifts to ports 8000-9200
+  base_offset: 0      # default: ports 6000-6956
+  # base_offset: 2000 # shifts to ports 8000-8956
 ```
 
 This is used in tests to run multiple independent clusters on the same
-machine. Each cluster needs a `base_offset` at least 1201 apart (with 1
+machine. Each cluster needs a `base_offset` at least 957 apart (with 1
 thread) to avoid port conflicts.
 
 ## Multi-Node Deployments
@@ -148,5 +127,5 @@ Port constants are defined in:
 - `clients/python/anna/common.py` -- Python client port constants
 
 Note: the Python client uses different port bases for its own sockets
-(6460 and 6760) compared to the other clients (6800 and 6850). This is a
+(6460 and 6760) compared to the other clients (6600 and 6650). This is a
 historical divergence from the upstream project.

--- a/docs/superpowers/specs/2026-07-21-latency-feedback-api-design.md
+++ b/docs/superpowers/specs/2026-07-21-latency-feedback-api-design.md
@@ -38,7 +38,7 @@ New client-side API for reporting latency feedback to the monitor, following the
 ```
 LatencyReporter::new(client: &mut KVSClient, tid: Option<usize>) -> Result<Self>
     // Discovers monitoring IPs via ANNA_METADATA|monitoring_ips
-    // Connects ZMQ PUSH sockets to each monitor's feedback port (6750 + offset)
+    // Connects ZMQ PUSH sockets to each monitor's feedback port (6953 + offset)
 
 report(latency_us: f64, throughput: f64, key_latencies: &[(String, f64)]) -> Result<()>
     // Builds UserFeedback protobuf, sends to all monitors
@@ -61,7 +61,7 @@ No protobuf changes needed.
 
 ### Socket pattern
 
-- ZMQ PUSH sockets to each monitor's feedback address (`tcp://<ip>:6750+offset`)
+- ZMQ PUSH sockets to each monitor's feedback address (`tcp://<ip>:6953+offset`)
 - Lazy connection with retry (same `get_or_connect` pattern as `ValueChangeSubscriber`)
 - Fan-out: every report goes to all monitoring threads
 

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -13,6 +13,12 @@
 
 set -euo pipefail
 
+# Kill any leftover anna processes from previous runs to avoid port conflicts
+for proc in anna-kvs anna-route anna-monitor; do
+  pkill -f "$proc" 2>/dev/null || true
+done
+sleep 1
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BENCH_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/anna_bench.XXXXXX")"
 BENCH_DATA="${BENCH_ROOT}/data"

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -13,9 +13,11 @@
 
 set -euo pipefail
 
-# Kill any leftover anna processes from previous runs to avoid port conflicts
+# Kill any leftover anna server processes from previous runs to avoid port
+# conflicts. Uses exact binary name matching to avoid killing unrelated
+# processes that happen to contain these strings in their arguments.
 for proc in anna-kvs anna-route anna-monitor; do
-  pkill -f "$proc" 2>/dev/null || true
+  pkill -x "$proc" 2>/dev/null || true
 done
 sleep 1
 

--- a/server/conf/anna-base.yml
+++ b/server/conf/anna-base.yml
@@ -11,7 +11,7 @@ hashing:
   virtual_nodes_per_thread: 3000
 ports:
   base_offset: 0
-  scaling_alert: 7001
+  scaling_alert: 6955
 timings:
   server_report_period: 15
   key_monitoring_period: 60

--- a/server/conf/anna-config.yml
+++ b/server/conf/anna-config.yml
@@ -54,7 +54,7 @@ hashing:
   virtual_nodes_per_thread: 3000
 ports:
   base_offset: 0
-  scaling_alert: 7001
+  scaling_alert: 6955
 timings:
   server_report_period: 15
   key_monitoring_period: 60

--- a/server/conf/anna-local.yml
+++ b/server/conf/anna-local.yml
@@ -54,7 +54,7 @@ hashing:
   virtual_nodes_per_thread: 3000
 ports:
   base_offset: 0
-  scaling_alert: 7001
+  scaling_alert: 6955
 timings:
   server_report_period: 15
   key_monitoring_period: 60

--- a/server/cpp/src/kvs/kvs_threads.hpp
+++ b/server/cpp/src/kvs/kvs_threads.hpp
@@ -43,11 +43,11 @@ const unsigned kServerReplicationChangePort = 6300;
 
 // The port on which KVS servers listen for responses to a request for listing
 // the keys cached at a function node.
-const unsigned kCacheIpResponsePort = 7050;
+const unsigned kCacheIpResponsePort = 6750;
 
 // The port on which KVS servers listen for responses from management node to a
 // request for the list of all existing function nodes.
-const unsigned kManagementNodeResponsePort = 7100;
+const unsigned kManagementNodeResponsePort = 6800;
 
 // The port on which routing servers listen for cluster membership requests.
 const unsigned kSeedPort = 6350;
@@ -64,33 +64,33 @@ const unsigned kRoutingReplicationChangePort = 6550;
 
 // The port on which the monitoring system listens for cluster membership
 // changes.
-const unsigned kMonitoringNotifyPort = 6600;
+const unsigned kMonitoringNotifyPort = 6950;
 
 // The port on which monitoring threads listen for KVS responses when
 // retrieving metadata.
-const unsigned kMonitoringResponsePort = 6650;
+const unsigned kMonitoringResponsePort = 6951;
 
 // The port on which the monitoring system waits for a response from KVS nodes
 // after they have finished departing.
-const unsigned kDepartDonePort = 6700;
+const unsigned kDepartDonePort = 6952;
 
 // The port on which the monitoring nodes listens for performance feedback from
 // clients.
-const unsigned kFeedbackReportPort = 6750;
+const unsigned kFeedbackReportPort = 6953;
 
 // The port on which benchmark nodes listen for triggers.
-const unsigned kBenchmarkCommandPort = 6900;
+const unsigned kBenchmarkCommandPort = 6700;
 
 // The port on which storage nodes retrieve their restart counts from the
 // external management system.
-const unsigned kManagementRestartCountPort = 7000;
+const unsigned kManagementRestartCountPort = 6954;
 
 // The port on which KVS servers listen for direct cache registration messages.
-const unsigned kCacheRegistrationPort = 7200;
+const unsigned kCacheRegistrationPort = 6900;
 
 // The port on which the external management system listens for requests
 // for executor/function node lists.
-const unsigned kManagementFuncNodesPort = 7002;
+const unsigned kManagementFuncNodesPort = 6956;
 
 class ServerThread {
   Address public_ip_;

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -114,8 +114,8 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
 
   // Request the restart count from the external management system.
   // The scaling_alert_ip serves as the address for all external
-  // management services (restart counts on port 7000, scaling alerts
-  // on port 7001, func-node lists on port 7002). When set to "NULL"
+  // management services (restart counts on port 6954, scaling alerts
+  // on port 6955, func-node lists on port 6956). When set to "NULL"
   // (standalone mode), skip the request and use count 0.
   string count_str;
 

--- a/server/cpp/src/threads.hpp
+++ b/server/cpp/src/threads.hpp
@@ -21,17 +21,17 @@
 const unsigned kKeyAddressPort = 6450;
 
 // The port on which clients receive responses from the KVS.
-const unsigned kUserResponsePort = 6800;
+const unsigned kUserResponsePort = 6600;
 
 // The port on which clients receive responses from the routing tier.
-const unsigned kUserKeyAddressPort = 6850;
+const unsigned kUserKeyAddressPort = 6650;
 
 // The port on which cache nodes listen for updates from the KVS.
-const unsigned kCacheUpdatePort = 7150;
+const unsigned kCacheUpdatePort = 6850;
 
 // The port on which the external system receives scaling alerts from the
 // monitor's policy engine.
-inline unsigned kScalingAlertPort = 7001;
+inline unsigned kScalingAlertPort = 6955;
 
 inline unsigned kBaseOffset = 0;
 

--- a/server/cpp/tests/lattices/test_lattices.cpp
+++ b/server/cpp/tests/lattices/test_lattices.cpp
@@ -1088,7 +1088,7 @@ TEST(CacheThreadTest, CacheUpdateAddresses) {
 // Verify thread port constants
 TEST(ThreadPortTest, Constants) {
   EXPECT_EQ(kKeyAddressPort, 6450u);
-  EXPECT_EQ(kUserResponsePort, 6800u);
-  EXPECT_EQ(kUserKeyAddressPort, 6850u);
-  EXPECT_EQ(kCacheUpdatePort, 7150u);
+  EXPECT_EQ(kUserResponsePort, 6600u);
+  EXPECT_EQ(kUserKeyAddressPort, 6650u);
+  EXPECT_EQ(kCacheUpdatePort, 6850u);
 }

--- a/server/cpp/tests/monitor/test_config_defaults.hpp
+++ b/server/cpp/tests/monitor/test_config_defaults.hpp
@@ -121,7 +121,7 @@ TEST(ConfigDefaults, GarbageCollectThresholdDefault) {
 // --- threads.hpp defaults ---
 
 TEST(ConfigDefaults, ScalingAlertPortDefault) {
-  EXPECT_EQ(kScalingAlertPort, 7001u);
+  EXPECT_EQ(kScalingAlertPort, 6955u);
 }
 
 TEST(ConfigDefaults, BaseOffsetDefault) {

--- a/server/cpp/tests/monitor/test_config_yaml_parsing.hpp
+++ b/server/cpp/tests/monitor/test_config_yaml_parsing.hpp
@@ -455,7 +455,7 @@ TEST_F(ConfigYamlParsingTest, EmptyConfigLeavesDefaults) {
   EXPECT_DOUBLE_EQ(kMaxMemoryNodeConsumption, 0.6);
   EXPECT_EQ(kVirtualThreadNum, 3000u);
   EXPECT_EQ(kSloWorst, 3000u);
-  EXPECT_EQ(kScalingAlertPort, 7001u);
+  EXPECT_EQ(kScalingAlertPort, 6955u);
   EXPECT_EQ(kGarbageCollectThreshold, 10000000u);
   EXPECT_EQ(kMetadataReplicationFactor, 1u);
 


### PR DESCRIPTION
## Summary

Renumbers port constants to eliminate the gaps in the port layout, reducing the per-cluster port range from **1201 to 957** (20% reduction).

### Layout change

19 per-thread groups are now packed contiguously at 50-port spacing (6000-6900), followed by 7 singleton ports packed at 6950-6956.

| What moved | Old | New |
|---|---|---|
| Client response ports | 6800-6850 | 6600-6650 |
| Benchmark port | 6900 | 6700 |
| Cache/management ports | 7050-7200 | 6750-6900 |
| Monitor singletons | 6600-6750 | 6950-6953 |
| Management singletons | 7000-7002 | 6954-6956 |

### Test improvements

- Test offset spacing reduced from 1201 to 957
- **3 previously overlapping test offset pairs are resolved** (slo_selective_replication vs cluster_join, tiering_movement_policy vs replica_survival, replication_response_wrong_thread vs stateless_routing_recovery)
- All 29 parallel tests now fit below port 32768 (tombstone_gc was previously at 33622)
- Client tids lowered from 50-69 to 1-19 to avoid per-thread port group collisions with the compacted layout

### Scope

Updated across all 4 client languages (Rust, C++, Go, Python), C++ server, YAML configs, and documentation. 34 files, ~90 individual constant/assertion changes.

Relates to #432