### PR TITLE
Add per-key TTL support

### DIFF
--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -125,20 +125,11 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 
-    - name: Upload server system test coverage
+    - name: Upload server coverage (unit + system tests merged)
       if: matrix.os == 'macos-latest'
       uses: codecov/codecov-action@v6
       with:
-        files: server/cpp/build/server-system.info
-        flags: server-system-tests
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true
-
-    - name: Upload server unit test coverage
-      if: matrix.os == 'macos-latest'
-      uses: codecov/codecov-action@v6
-      with:
-        files: server/cpp/build/server-unit.info
-        flags: server-unit-tests
+        files: server/cpp/build/server.info
+        flags: server-unit-tests,server-system-tests
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -340,6 +340,18 @@ impl KVSClient {
         lattice_type: Option<i32>,
         payload: Option<Vec<u8>>,
     ) -> Option<KeyResponse> {
+        self.send_data_request_with_ttl(key, req_type, lattice_type, payload, 0)
+            .await
+    }
+
+    async fn send_data_request_with_ttl(
+        &mut self,
+        key: &str,
+        req_type: i32,
+        lattice_type: Option<i32>,
+        payload: Option<Vec<u8>>,
+        ttl_seconds: u32,
+    ) -> Option<KeyResponse> {
         const MAX_RETRIES: usize = 5;
 
         for attempt in 0..=MAX_RETRIES {
@@ -364,6 +376,9 @@ impl KVSClient {
             }
             if let Some(cache) = self.key_address_cache.get(key) {
                 tuple.address_cache_size = cache.len() as u32;
+            }
+            if ttl_seconds > 0 {
+                tuple.ttl_seconds = ttl_seconds;
             }
             request.tuples.push(tuple);
 
@@ -648,6 +663,44 @@ impl KVSClient {
         // Cache the written value for read-your-writes consistency.
         // This ensures a subsequent GET returns at least this value,
         // even if routed to a replica that hasn't received it via gossip.
+        self.lww_read_cache
+            .insert(key.as_ref().to_string(), (lww.timestamp, lww.value.clone()));
+        Ok(())
+    }
+
+    /// Store a key-value pair with a TTL (time-to-live) in seconds.
+    ///
+    /// The key will automatically expire after `ttl_seconds` and subsequent
+    /// GETs will return `KEY_DNE`. The TTL is propagated to all replicas
+    /// via gossip.
+    pub async fn put_with_ttl<K: AsRef<str> + Display>(
+        &mut self,
+        key: K,
+        value: &str,
+        ttl_seconds: u32,
+    ) -> Result<()> {
+        debug!("PUT_TTL: {} <- {} (ttl={}s)", key, value, ttl_seconds);
+        let ts = std::cmp::max(Self::generate_timestamp(), self.last_seen_ts + 1);
+        self.last_seen_ts = ts;
+        let lww = LwwValue {
+            timestamp: ts,
+            value: value.as_bytes().to_vec(),
+        };
+        let payload = lww.encode_to_vec();
+
+        let response = self
+            .send_data_request_with_ttl(
+                key.as_ref(),
+                RequestType::Put as i32,
+                Some(LatticeType::Lww as i32),
+                Some(payload),
+                ttl_seconds,
+            )
+            .await
+            .ok_or_else(|| Error::Kvs("PUT_TTL: request failed or timed out".into()))?;
+
+        Self::validate_response(&response, "PUT_TTL")?;
+
         self.lww_read_cache
             .insert(key.as_ref().to_string(), (lww.timestamp, lww.value.clone()));
         Ok(())

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -711,8 +711,9 @@ impl KVSClient {
 
         Self::validate_response(&response, "PUT_TTL")?;
 
-        self.lww_read_cache
-            .insert(key.as_ref().to_string(), (lww.timestamp, lww.value.clone()));
+        // Do not cache TTL values in lww_read_cache -- the cached value
+        // would be returned after the server-side TTL expires, giving
+        // stale reads. TTL keys always go to the server for freshness.
         Ok(())
     }
 

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -352,6 +352,16 @@ impl KVSClient {
         payload: Option<Vec<u8>>,
         ttl_seconds: u32,
     ) -> Option<KeyResponse> {
+        // Compute absolute expiry from relative TTL.
+        let expiry_epoch_ms = if ttl_seconds > 0 {
+            let now_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::from_secs(0))
+                .as_millis() as u64;
+            now_ms + (ttl_seconds as u64) * 1000
+        } else {
+            0
+        };
         const MAX_RETRIES: usize = 5;
 
         for attempt in 0..=MAX_RETRIES {
@@ -377,8 +387,8 @@ impl KVSClient {
             if let Some(cache) = self.key_address_cache.get(key) {
                 tuple.address_cache_size = cache.len() as u32;
             }
-            if ttl_seconds > 0 {
-                tuple.ttl_seconds = ttl_seconds;
+            if expiry_epoch_ms > 0 {
+                tuple.expiry_epoch_ms = expiry_epoch_ms;
             }
             request.tuples.push(tuple);
 

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -3054,7 +3054,7 @@ mod tests {
             .put_with_ttl("ttl_key", "ttl_value", 300)
             .await
             .expect("put_with_ttl failed");
-        // Verify the value is in the read cache
-        assert!(client.lww_read_cache.contains_key("ttl_key"));
+        // TTL values should NOT be cached (they'd be stale after expiry)
+        assert!(!client.lww_read_cache.contains_key("ttl_key"));
     }
 }

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -3042,4 +3042,18 @@ mod tests {
             .await
             .expect("put_value failed");
     }
+
+    #[tokio::test]
+    async fn put_with_ttl_sends_request() {
+        let worker = "tcp://127.0.0.1:6200";
+        let mut client = mock_client(232);
+        client.push_mock_response(true, Some(make_routing_response("ttl_key", worker)));
+        client.push_mock_response(false, Some(make_put_response("ttl_key")));
+        client
+            .put_with_ttl("ttl_key", "ttl_value", 300)
+            .await
+            .expect("put_with_ttl failed");
+        // Verify the value is in the read cache
+        assert!(client.lww_read_cache.contains_key("ttl_key"));
+    }
 }

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -387,7 +387,7 @@ async fn execute_command(
             let value = split[2];
             let ttl: u32 = split[3]
                 .parse()
-                .map_err(|_| annalib::Error::Kvs("TTL must be a positive integer".into()))?;
+                .map_err(|_| annalib::Error::Kvs("TTL must be a non-negative integer".into()))?;
             client.put_with_ttl(key, value, ttl).await?;
         }
         // Legacy aliases — map old commands to the unified GET/PUT.

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -382,6 +382,14 @@ async fn execute_command(
             client.put_value(&key, &value).await?;
         }
         "DELETE" if split.len() == 2 => client.delete(split[1]).await?,
+        "PUT_TTL" if split.len() == 4 => {
+            let key = split[1];
+            let value = split[2];
+            let ttl: u32 = split[3]
+                .parse()
+                .map_err(|_| annalib::Error::Kvs("TTL must be a positive integer".into()))?;
+            client.put_with_ttl(key, value, ttl).await?;
+        }
         // Legacy aliases — map old commands to the unified GET/PUT.
         "GET_SET" if split.len() == 2 => {
             let value = client.get_value(split[1]).await?;
@@ -482,6 +490,7 @@ fn cli_usage() -> String {
     \n\tput priority {key} {pri} {val} \t- store with priority (lowest wins)\
     \n\tput causal {key} {value} \t- store with multi-key causal consistency\
     \n\tput single_causal {key} {value} \t- store with single-key causal consistency\
+    \n\tput_ttl {key} {value} {seconds} \t- store with TTL (auto-expires)\
     \n\tdelete {key} \t\t\t- delete a key from the KVS\
     \n\tbench [keys] [value_size] [duration] [workload] - run a benchmark\
     \n\tstart [component] \t\t- start anna processes (component: kvs, monitor, route; omit for all)\

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -399,10 +399,9 @@ async fn ttl_stress_many_keys() {
             expired_count += 1;
         }
     }
-    assert!(
-        expired_count >= key_count / 2,
-        "at least half the keys should have expired, but only {}/{} did",
-        expired_count,
-        key_count
+    assert_eq!(
+        expired_count, key_count,
+        "all keys should have expired, but only {}/{} did",
+        expired_count, key_count
     );
 }

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -215,3 +215,194 @@ async fn disk_tier_lattice_types() {
 
     test_all_lattice_types(&mut client, "disk").await;
 }
+
+const TTL_EXPIRE_OFFSET: u16 = 210;
+const TTL_PERSIST_OFFSET: u16 = 220;
+const TTL_STRESS_OFFSET: u16 = 230;
+
+/// Generate a config with aggressive TTL GC settings for testing.
+/// Uses gossip_epoch=1s and tombstone_gc_multiplier=1 so TTL-expired
+/// keys are reaped within ~2 seconds.
+fn generate_ttl_config(base_offset: u16) -> String {
+    let config_dir = std::env::temp_dir().join(format!(
+        "anna_ttl_test_{}_{}",
+        std::process::id(),
+        base_offset
+    ));
+    std::fs::create_dir_all(&config_dir).expect("create dir");
+    let config_path = config_dir.join("config.yml");
+    let disk_dir = config_dir.join("disk");
+    std::fs::create_dir_all(&disk_dir).expect("create disk dir");
+    let ip = "127.0.0.1";
+    let content = format!(
+        r#"monitoring:
+  scaling_alert_ip: {ip}
+  ip: {ip}
+routing:
+  monitoring:
+    - {ip}
+  ip: {ip}
+user:
+  monitoring:
+    - {ip}
+  routing:
+    - {ip}
+  ip: {ip}
+server:
+  monitoring:
+    - {ip}
+  routing:
+    - {ip}
+  seed_ip: {ip}
+  public_ip: {ip}
+  private_ip: {ip}
+  scaling_alert_ip: "NULL"
+policy:
+  elasticity: false
+  selective-rep: false
+  tiering: false
+disk: {disk_path}
+capacities:
+  memory-cap: 1
+  disk-cap: 0
+threads:
+  memory: 1
+  disk: 1
+  routing: 1
+replication:
+  memory: 1
+  disk: 0
+  minimum: 1
+  local: 1
+ports:
+  base_offset: {base_offset}
+timings:
+  gossip_epoch: 1
+  tombstone_gc_multiplier: 1
+  server_report_period: 15
+  key_monitoring_period: 60
+  monitoring_timeout: 30
+  data_redistribute_batch: 50
+  grace_period: 120
+  monitoring_response_timeout_ms: 10000
+"#,
+        ip = ip,
+        base_offset = base_offset,
+        disk_path = disk_dir.to_string_lossy(),
+    );
+    std::fs::write(&config_path, content).expect("write config");
+    config_path.to_string_lossy().to_string()
+}
+
+/// Test TTL: PUT with a short TTL, verify GET works before expiry,
+/// then verify GET returns KEY_DNE after expiry.
+#[tokio::test]
+#[cfg(unix)]
+async fn ttl_key_expires() {
+    let config_path = generate_ttl_config(TTL_EXPIRE_OFFSET);
+    let _guard = ServerGuard::start(&config_path, TTL_EXPIRE_OFFSET);
+    let config = client_config(TTL_EXPIRE_OFFSET);
+    let mut client = KVSClient::new(&config, Some(7)).await;
+
+    // PUT with 2-second TTL
+    client
+        .put_with_ttl("ttl_key", "ttl_value", 2)
+        .await
+        .expect("PUT_TTL failed");
+
+    // GET immediately — should succeed
+    let val = client
+        .get("ttl_key")
+        .await
+        .expect("GET before expiry failed");
+    assert_eq!(
+        val, "ttl_value",
+        "value should be readable before TTL expires"
+    );
+
+    // Wait for TTL to expire + GC cycle (gossip_epoch=1s, gc_multiplier=1)
+    tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+
+    // GET after expiry — should fail with KEY_DNE.
+    // Use a fresh client to avoid the read cache.
+    let mut client2 = KVSClient::new(&config, Some(8)).await;
+    let result = client2.get("ttl_key").await;
+    assert!(
+        result.is_err(),
+        "GET after TTL expiry should return error but got: {:?}",
+        result
+    );
+}
+
+/// Test that a key without TTL does not expire.
+#[tokio::test]
+#[cfg(unix)]
+async fn no_ttl_key_persists() {
+    let config_path = generate_ttl_config(TTL_PERSIST_OFFSET);
+    let _guard = ServerGuard::start(&config_path, TTL_PERSIST_OFFSET);
+    let config = client_config(TTL_PERSIST_OFFSET);
+    let mut client = KVSClient::new(&config, Some(7)).await;
+
+    // PUT without TTL
+    client
+        .put("persist_key", "persist_value")
+        .await
+        .expect("PUT failed");
+
+    // Wait longer than the TTL test
+    tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+
+    // GET — should still succeed
+    let val = client
+        .get("persist_key")
+        .await
+        .expect("GET should succeed for non-TTL key");
+    assert_eq!(val, "persist_value");
+}
+
+/// Stress test: PUT many keys with short TTLs, verify they all expire.
+#[tokio::test]
+#[cfg(unix)]
+async fn ttl_stress_many_keys() {
+    let config_path = generate_ttl_config(TTL_STRESS_OFFSET);
+    let _guard = ServerGuard::start(&config_path, TTL_STRESS_OFFSET);
+    let config = client_config(TTL_STRESS_OFFSET);
+    let mut client = KVSClient::new(&config, Some(7)).await;
+
+    let key_count = 50;
+
+    // PUT many keys with 2-second TTL
+    for i in 0..key_count {
+        client
+            .put_with_ttl(&format!("stress_{}", i), &format!("val_{}", i), 2)
+            .await
+            .unwrap_or_else(|e| panic!("PUT_TTL stress_{} failed: {}", i, e));
+    }
+
+    // Verify all readable immediately
+    for i in 0..key_count {
+        let val = client
+            .get(&format!("stress_{}", i))
+            .await
+            .unwrap_or_else(|e| panic!("GET stress_{} failed: {}", i, e));
+        assert_eq!(val, format!("val_{}", i));
+    }
+
+    // Wait for expiry
+    tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+
+    // Fresh client — verify all expired
+    let mut client2 = KVSClient::new(&config, Some(8)).await;
+    let mut expired_count = 0;
+    for i in 0..key_count {
+        if client2.get(&format!("stress_{}", i)).await.is_err() {
+            expired_count += 1;
+        }
+    }
+    assert!(
+        expired_count >= key_count / 2,
+        "at least half the keys should have expired, but only {}/{} did",
+        expired_count,
+        key_count
+    );
+}

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -80,6 +80,7 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | Replication factor management (put_replication_factor) | Yes |
 | Cluster topology discovery (get_cluster_topology) | Yes |
 | Monitoring IP discovery (get_monitoring_ips) | Yes |
+| Per-key TTL (put_with_ttl) | Yes    |
 
 ## C++ Client (`clients/cpp`)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -29,6 +29,7 @@ mocks.
 | PUT causal {key} {value}   | Store with multi-key causal consistency                      | Yes           |
 | PUT single_causal {key} {value} | Store with single-key causal consistency               | Yes           |
 | DELETE {key}               | Remove a key (PUT with empty value and dominating timestamp) | Yes           |
+| PUT_TTL {key} {val} {secs} | Store with TTL (auto-expires after N seconds)                | Yes           |
 | Address cache invalidation | Server signals client to refresh address cache               | Yes           |
 | Multi-key GET              | Retrieve multiple keys in one request                        | Yes           |
 

--- a/server/cpp/src/kvs/gossip_handler.cpp
+++ b/server/cpp/src/kvs/gossip_handler.cpp
@@ -41,10 +41,10 @@ void gossip_handler(unsigned &seed, string &serialized,
           threads.end()) { // this means this worker thread is one of the
                            // responsible threads
         if (stored_key_map.find(key) != stored_key_map.end() &&
-            stored_key_map[key].type_ != tuple.lattice_type()) {
+            stored_key_map[key].type() != tuple.lattice_type()) {
           log->error("Lattice type mismatch: {} from query but {} expected.",
                      LatticeType_Name(tuple.lattice_type()),
-                     kvs::LatticeType_Name(stored_key_map[key].type_));
+                     kvs::LatticeType_Name(stored_key_map[key].type()));
         } else {
           process_put(tuple.key(), tuple.lattice_type(), tuple.payload(),
                       serializers[tuple.lattice_type()], stored_key_map,

--- a/server/cpp/src/kvs/gossip_handler.cpp
+++ b/server/cpp/src/kvs/gossip_handler.cpp
@@ -60,7 +60,8 @@ void gossip_handler(unsigned &seed, string &serialized,
             }
 
             prepare_put_tuple(gossip_map[thread.gossip_connect_address()], key,
-                              tuple.lattice_type(), tuple.payload());
+                              tuple.lattice_type(), tuple.payload(),
+                              tuple.expiry_epoch_ms());
           }
         } else {
           kHashRingUtil->issue_replication_factor_request(
@@ -69,12 +70,14 @@ void gossip_handler(unsigned &seed, string &serialized,
               pushers, seed);
 
           pending_gossip[key].push_back(
-              PendingGossip(tuple.lattice_type(), tuple.payload()));
+              PendingGossip(tuple.lattice_type(), tuple.payload(),
+                            tuple.expiry_epoch_ms()));
         }
       }
     } else {
       pending_gossip[key].push_back(
-          PendingGossip(tuple.lattice_type(), tuple.payload()));
+          PendingGossip(tuple.lattice_type(), tuple.payload(),
+                        tuple.expiry_epoch_ms()));
     }
   }
 

--- a/server/cpp/src/kvs/gossip_handler.cpp
+++ b/server/cpp/src/kvs/gossip_handler.cpp
@@ -48,7 +48,7 @@ void gossip_handler(unsigned &seed, string &serialized,
         } else {
           process_put(tuple.key(), tuple.lattice_type(), tuple.payload(),
                       serializers[tuple.lattice_type()], stored_key_map,
-                      tuple.ttl_seconds());
+                      tuple.expiry_epoch_ms());
         }
       } else {
         if (is_metadata(key)) { // forward the gossip

--- a/server/cpp/src/kvs/gossip_handler.cpp
+++ b/server/cpp/src/kvs/gossip_handler.cpp
@@ -47,7 +47,8 @@ void gossip_handler(unsigned &seed, string &serialized,
                      kvs::LatticeType_Name(stored_key_map[key].type_));
         } else {
           process_put(tuple.key(), tuple.lattice_type(), tuple.payload(),
-                      serializers[tuple.lattice_type()], stored_key_map);
+                      serializers[tuple.lattice_type()], stored_key_map,
+                      tuple.ttl_seconds());
         }
       } else {
         if (is_metadata(key)) { // forward the gossip

--- a/server/cpp/src/kvs/kvs_common.hpp
+++ b/server/cpp/src/kvs/kvs_common.hpp
@@ -15,8 +15,18 @@
 #ifndef KVS_INCLUDE_KVS_COMMON_HPP_
 #define KVS_INCLUDE_KVS_COMMON_HPP_
 
+#include <chrono>
+
 #include "kvs/kvs_types.hpp"
 #include "metadata.pb.h"
+
+// Current time as seconds since Unix epoch.
+inline uint32_t now_epoch_s() {
+  return static_cast<uint32_t>(
+      std::chrono::duration_cast<std::chrono::seconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count());
+}
 
 inline unsigned kMetadataReplicationFactor = 1;
 inline unsigned kMetadataLocalReplicationFactor = 1;
@@ -56,13 +66,13 @@ inline void prepare_get_tuple(kvs::KeyRequest &req, Key key,
 
 inline void prepare_put_tuple(kvs::KeyRequest &req, Key key,
                               kvs::LatticeType lattice_type, string payload,
-                              unsigned ttl_seconds = 0) {
+                              uint64_t expiry_epoch_ms = 0) {
   kvs::KeyTuple *tp = req.add_tuples();
   tp->set_key(std::move(key));
   tp->set_lattice_type(std::move(lattice_type));
   tp->set_payload(std::move(payload));
-  if (ttl_seconds > 0) {
-    tp->set_ttl_seconds(ttl_seconds);
+  if (expiry_epoch_ms > 0) {
+    tp->set_expiry_epoch_ms(expiry_epoch_ms);
   }
 }
 

--- a/server/cpp/src/kvs/kvs_common.hpp
+++ b/server/cpp/src/kvs/kvs_common.hpp
@@ -55,11 +55,15 @@ inline void prepare_get_tuple(kvs::KeyRequest &req, Key key,
 }
 
 inline void prepare_put_tuple(kvs::KeyRequest &req, Key key,
-                              kvs::LatticeType lattice_type, string payload) {
+                              kvs::LatticeType lattice_type, string payload,
+                              unsigned ttl_seconds = 0) {
   kvs::KeyTuple *tp = req.add_tuples();
   tp->set_key(std::move(key));
   tp->set_lattice_type(std::move(lattice_type));
   tp->set_payload(std::move(payload));
+  if (ttl_seconds > 0) {
+    tp->set_ttl_seconds(ttl_seconds);
+  }
 }
 
 #endif // KVS_INCLUDE_KVS_COMMON_HPP_

--- a/server/cpp/src/kvs/kvs_handlers.hpp
+++ b/server/cpp/src/kvs/kvs_handlers.hpp
@@ -111,7 +111,8 @@ std::pair<string, kvs::AnnaError> process_get(const Key &key,
 
 bool process_put(const Key &key, kvs::LatticeType lattice_type,
                  const string &payload, Serializer *serializer,
-                 map<Key, KeyProperty> &stored_key_map);
+                 map<Key, KeyProperty> &stored_key_map,
+                 unsigned ttl_seconds = 0);
 
 bool is_primary_replica(const Key &key,
                         map<Key, KeyReplication> &key_replication_map,

--- a/server/cpp/src/kvs/kvs_handlers.hpp
+++ b/server/cpp/src/kvs/kvs_handlers.hpp
@@ -112,7 +112,7 @@ std::pair<string, kvs::AnnaError> process_get(const Key &key,
 bool process_put(const Key &key, kvs::LatticeType lattice_type,
                  const string &payload, Serializer *serializer,
                  map<Key, KeyProperty> &stored_key_map,
-                 unsigned ttl_seconds = 0);
+                 uint64_t expiry_epoch_ms = 0);
 
 bool is_primary_replica(const Key &key,
                         map<Key, KeyReplication> &key_replication_map,

--- a/server/cpp/src/kvs/replication_change_handler.cpp
+++ b/server/cpp/src/kvs/replication_change_handler.cpp
@@ -145,7 +145,7 @@ void replication_change_handler(
 
   // remove keys
   for (const string &key : remove_set) {
-    if (!serializers[stored_key_map[key].type_]->remove(key)) {
+    if (!serializers[stored_key_map[key].type()]->remove(key)) {
       log->error("Failed to remove key {} during replication change.", key);
     } else {
       stored_key_map.erase(key);

--- a/server/cpp/src/kvs/replication_response_handler.cpp
+++ b/server/cpp/src/kvs/replication_response_handler.cpp
@@ -198,7 +198,8 @@ void replication_response_handler(
                        LatticeType_Name(stored_key_map[key].type()));
           } else {
             process_put(key, gossip.lattice_type_, gossip.payload_,
-                        serializers[gossip.lattice_type_], stored_key_map);
+                        serializers[gossip.lattice_type_], stored_key_map,
+                        gossip.expiry_epoch_ms_);
           }
         }
       } else {
@@ -211,7 +212,8 @@ void replication_response_handler(
 
           for (const PendingGossip &gossip : pending_gossip[key]) {
             prepare_put_tuple(gossip_map[thread.gossip_connect_address()], key,
-                              gossip.lattice_type_, gossip.payload_);
+                              gossip.lattice_type_, gossip.payload_,
+                              gossip.expiry_epoch_ms_);
           }
         }
 

--- a/server/cpp/src/kvs/replication_response_handler.cpp
+++ b/server/cpp/src/kvs/replication_response_handler.cpp
@@ -112,7 +112,8 @@ void replication_response_handler(
                   LatticeType_Name(stored_key_map[key].type_));
             } else {
               process_put(key, request.lattice_type_, request.payload_,
-                          serializers[request.lattice_type_], stored_key_map);
+                          serializers[request.lattice_type_], stored_key_map,
+                          request.ttl_seconds_);
               key_access_tracker[key].insert(now);
 
               access_count += 1;
@@ -157,7 +158,8 @@ void replication_response_handler(
                   LatticeType_Name(stored_key_map[key].type_));
             } else {
               process_put(key, request.lattice_type_, request.payload_,
-                          serializers[request.lattice_type_], stored_key_map);
+                          serializers[request.lattice_type_], stored_key_map,
+                          request.ttl_seconds_);
               tp->set_lattice_type(request.lattice_type_);
               local_changeset.insert(key);
             }

--- a/server/cpp/src/kvs/replication_response_handler.cpp
+++ b/server/cpp/src/kvs/replication_response_handler.cpp
@@ -113,7 +113,7 @@ void replication_response_handler(
             } else {
               process_put(key, request.lattice_type_, request.payload_,
                           serializers[request.lattice_type_], stored_key_map,
-                          request.ttl_seconds_);
+                          request.expiry_epoch_ms_);
               key_access_tracker[key].insert(now);
 
               access_count += 1;
@@ -159,7 +159,7 @@ void replication_response_handler(
             } else {
               process_put(key, request.lattice_type_, request.payload_,
                           serializers[request.lattice_type_], stored_key_map,
-                          request.ttl_seconds_);
+                          request.expiry_epoch_ms_);
               tp->set_lattice_type(request.lattice_type_);
               local_changeset.insert(key);
             }

--- a/server/cpp/src/kvs/replication_response_handler.cpp
+++ b/server/cpp/src/kvs/replication_response_handler.cpp
@@ -102,14 +102,14 @@ void replication_response_handler(
             if (request.lattice_type_ == kvs::LatticeType::NONE) {
               log->error("PUT request missing lattice type.");
             } else if (stored_key_map.find(key) != stored_key_map.end() &&
-                       stored_key_map[key].type_ != kvs::LatticeType::NONE &&
-                       stored_key_map[key].type_ != request.lattice_type_) {
+                       stored_key_map[key].type() != kvs::LatticeType::NONE &&
+                       stored_key_map[key].type() != request.lattice_type_) {
 
               log->error(
                   "Lattice type mismatch for key {}: query is {} but we expect "
                   "{}.",
                   key, LatticeType_Name(request.lattice_type_),
-                  LatticeType_Name(stored_key_map[key].type_));
+                  LatticeType_Name(stored_key_map[key].type()));
             } else {
               process_put(key, request.lattice_type_, request.payload_,
                           serializers[request.lattice_type_], stored_key_map,
@@ -136,12 +136,12 @@ void replication_response_handler(
 
           if (request.type_ == kvs::RequestType::GET) {
             if (stored_key_map.find(key) == stored_key_map.end() ||
-                stored_key_map[key].type_ == kvs::LatticeType::NONE) {
+                stored_key_map[key].type() == kvs::LatticeType::NONE) {
               tp->set_error(kvs::AnnaError::KEY_DNE);
             } else {
               auto res =
-                  process_get(key, serializers[stored_key_map[key].type_]);
-              tp->set_lattice_type(stored_key_map[key].type_);
+                  process_get(key, serializers[stored_key_map[key].type()]);
+              tp->set_lattice_type(stored_key_map[key].type());
               tp->set_payload(res.first);
               tp->set_error(res.second);
             }
@@ -149,13 +149,13 @@ void replication_response_handler(
             if (request.lattice_type_ == kvs::LatticeType::NONE) {
               log->error("PUT request missing lattice type.");
             } else if (stored_key_map.find(key) != stored_key_map.end() &&
-                       stored_key_map[key].type_ != kvs::LatticeType::NONE &&
-                       stored_key_map[key].type_ != request.lattice_type_) {
+                       stored_key_map[key].type() != kvs::LatticeType::NONE &&
+                       stored_key_map[key].type() != request.lattice_type_) {
               log->error(
                   "Lattice type mismatch for key {}: {} from query but {} "
                   "expected.",
                   key, LatticeType_Name(request.lattice_type_),
-                  LatticeType_Name(stored_key_map[key].type_));
+                  LatticeType_Name(stored_key_map[key].type()));
             } else {
               process_put(key, request.lattice_type_, request.payload_,
                           serializers[request.lattice_type_], stored_key_map,
@@ -190,12 +190,12 @@ void replication_response_handler(
       if (std::find(threads.begin(), threads.end(), wt) != threads.end()) {
         for (const PendingGossip &gossip : pending_gossip[key]) {
           if (stored_key_map.find(key) != stored_key_map.end() &&
-              stored_key_map[key].type_ != kvs::LatticeType::NONE &&
-              stored_key_map[key].type_ != gossip.lattice_type_) {
+              stored_key_map[key].type() != kvs::LatticeType::NONE &&
+              stored_key_map[key].type() != gossip.lattice_type_) {
             log->error("Lattice type mismatch for key {}: {} from query but {} "
                        "expected.",
                        key, LatticeType_Name(gossip.lattice_type_),
-                       LatticeType_Name(stored_key_map[key].type_));
+                       LatticeType_Name(stored_key_map[key].type()));
           } else {
             process_put(key, gossip.lattice_type_, gossip.payload_,
                         serializers[gossip.lattice_type_], stored_key_map);

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -583,29 +583,21 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
       working_time_map[10] += time_elapsed;
     }
 
-    // Tombstone GC: reap deleted keys whose tombstone has expired.
-    // Runs on the same cadence as gossip to avoid continuous scanning.
-    if (kTombstoneGcMultiplier > 0 &&
-        std::chrono::duration_cast<std::chrono::microseconds>(
+    // Key expiry GC: reap keys whose expiry_time_ has passed.
+    // This handles both TTL-expired keys and tombstoned (deleted) keys,
+    // which both use the same expiry_time_ field.
+    if (std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now() - gc_start)
                 .count() >= kGossipPeriod) {
-      auto gc_threshold =
-          std::chrono::microseconds(kGossipPeriod) * kTombstoneGcMultiplier;
       auto now = std::chrono::system_clock::now();
+
+      uint32_t now_s = now_epoch_s();
 
       vector<Key> keys_to_reap;
       for (const auto &kv : stored_key_map) {
-        // Reap tombstoned keys (explicit deletes).
-        if (kv.second.size_ == 0 && !is_metadata(kv.first) &&
-            kv.second.tombstone_time_.time_since_epoch().count() > 0 &&
-            std::chrono::duration_cast<std::chrono::microseconds>(
-                now - kv.second.tombstone_time_) > gc_threshold) {
-          keys_to_reap.push_back(kv.first);
-        }
-        // Reap TTL-expired keys.
-        else if (!is_metadata(kv.first) &&
-                 kv.second.expiry_time_.time_since_epoch().count() > 0 &&
-                 now > kv.second.expiry_time_) {
+        if (!is_metadata(kv.first) &&
+            kv.second.expiry_epoch_s_ > 0 &&
+            now_s > kv.second.expiry_epoch_s_) {
           keys_to_reap.push_back(kv.first);
         }
       }
@@ -613,9 +605,9 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
       for (const Key &key : keys_to_reap) {
         if (serializers[stored_key_map[key].type_]->remove(key)) {
           stored_key_map.erase(key);
-          log->info("Tombstone GC: reaped key {}", key);
+          log->info("Key expiry GC: reaped key {}", key);
         } else {
-          log->error("Tombstone GC: failed to remove key {}", key);
+          log->error("Key expiry GC: failed to remove key {}", key);
         }
       }
 

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -363,6 +363,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
 
   // enter event loop
   while (!shutdown_requested.load()) {
+   try {
     if (self_depart_requested.load() && !monitoring_ips.empty()) {
       string depart_done_addr =
           MonitoringThread(monitoring_ips[0]).depart_done_connect_address();
@@ -856,6 +857,13 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
         join_remove_set = std::move(failed_removals);
       }
     }
+   } catch (const zmq::error_t &e) {
+     if (e.num() == EINTR && shutdown_requested.load()) {
+       // ZMQ interrupted by SIGTERM — exit cleanly so gcov data is flushed.
+       break;
+     }
+     throw;  // Re-throw unexpected ZMQ errors.
+   }
   }
 }
 

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -603,7 +603,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
       }
 
       for (const Key &key : keys_to_reap) {
-        if (serializers[stored_key_map[key].type_]->remove(key)) {
+        if (serializers[stored_key_map[key].type()]->remove(key)) {
           stored_key_map.erase(key);
           log->info("Key expiry GC: reaped key {}", key);
         } else {
@@ -632,7 +632,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
       // compute total storage consumption
       unsigned long long consumption = 0;
       for (const auto &key_pair : stored_key_map) {
-        consumption += key_pair.second.size_;
+        consumption += key_pair.second.size();
       }
 
       int index = 0;
@@ -720,7 +720,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
                                global_hash_rings, local_hash_rings, wt)) {
           KeySizeData_KeySize *ks = primary_key_size.add_key_sizes();
           ks->set_key(key_pair.first);
-          ks->set_size(key_pair.second.size_);
+          ks->set_size(key_pair.second.size());
         }
       }
 
@@ -844,7 +844,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
       if (join_gossip_map.size() == 0) {
         set<Key> failed_removals;
         for (const string &key : join_remove_set) {
-          if (!serializers[stored_key_map[key].type_]->remove(key)) {
+          if (!serializers[stored_key_map[key].type()]->remove(key)) {
             log->error("Failed to remove key {} during join cleanup.", key);
             failed_removals.insert(key);
           } else {

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -595,10 +595,17 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
 
       vector<Key> keys_to_reap;
       for (const auto &kv : stored_key_map) {
+        // Reap tombstoned keys (explicit deletes).
         if (kv.second.size_ == 0 && !is_metadata(kv.first) &&
             kv.second.tombstone_time_.time_since_epoch().count() > 0 &&
             std::chrono::duration_cast<std::chrono::microseconds>(
                 now - kv.second.tombstone_time_) > gc_threshold) {
+          keys_to_reap.push_back(kv.first);
+        }
+        // Reap TTL-expired keys.
+        else if (!is_metadata(kv.first) &&
+                 kv.second.expiry_time_.time_since_epoch().count() > 0 &&
+                 now > kv.second.expiry_time_) {
           keys_to_reap.push_back(kv.first);
         }
       }

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -786,10 +786,13 @@ struct PendingRequest {
 
 struct PendingGossip {
   PendingGossip() {}
-  PendingGossip(kvs::LatticeType lattice_type, string payload)
-      : lattice_type_(std::move(lattice_type)), payload_(std::move(payload)) {}
+  PendingGossip(kvs::LatticeType lattice_type, string payload,
+                uint64_t expiry_epoch_ms = 0)
+      : lattice_type_(std::move(lattice_type)), payload_(std::move(payload)),
+        expiry_epoch_ms_(expiry_epoch_ms) {}
   kvs::LatticeType lattice_type_;
   string payload_;
+  uint64_t expiry_epoch_ms_ = 0;
 };
 
 #endif // INCLUDE_KVS_SERVER_UTILS_HPP_

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -769,15 +769,17 @@ using SerializerMap =
 struct PendingRequest {
   PendingRequest() {}
   PendingRequest(kvs::RequestType type, kvs::LatticeType lattice_type, string payload,
-                 Address addr, string response_id)
+                 Address addr, string response_id, unsigned ttl_seconds = 0)
       : type_(type), lattice_type_(std::move(lattice_type)),
-        payload_(std::move(payload)), addr_(addr), response_id_(response_id) {}
+        payload_(std::move(payload)), addr_(addr), response_id_(response_id),
+        ttl_seconds_(ttl_seconds) {}
 
   kvs::RequestType type_;
   kvs::LatticeType lattice_type_;
   string payload_;
   Address addr_;
   string response_id_;
+  unsigned ttl_seconds_ = 0;
 };
 
 struct PendingGossip {

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -29,11 +29,13 @@
 // Gossip period in microseconds (default 10 seconds)
 inline unsigned kGossipPeriod = 10000000;
 
-// Tombstone GC: multiplier of the gossip period. Tombstoned keys (size_ == 0)
-// are reaped after gossip_epoch * tombstone_gc_multiplier seconds. This must
-// be long enough for all replicas to receive the tombstone via gossip.
+// Tombstone GC: multiplier of the gossip period. Deleted keys are reaped
+// after gossip_epoch * tombstone_gc_multiplier microseconds. This must be
+// long enough for all replicas to receive the deletion via gossip.
 // Default 30 means 30 * 10s = 5 minutes with the default gossip epoch.
-// Set to 0 to disable tombstone GC.
+// Also used to compute the expiry_time_ for tombstones (deleted keys).
+// Keys with client-specified TTL use their own expiry, independent of this.
+// Set to 0 to disable tombstone GC (TTL expiry still works).
 inline unsigned kTombstoneGcMultiplier = 30;
 
 // Max keys redistributed per gossip batch
@@ -769,17 +771,17 @@ using SerializerMap =
 struct PendingRequest {
   PendingRequest() {}
   PendingRequest(kvs::RequestType type, kvs::LatticeType lattice_type, string payload,
-                 Address addr, string response_id, unsigned ttl_seconds = 0)
+                 Address addr, string response_id, uint64_t expiry_epoch_ms = 0)
       : type_(type), lattice_type_(std::move(lattice_type)),
         payload_(std::move(payload)), addr_(addr), response_id_(response_id),
-        ttl_seconds_(ttl_seconds) {}
+        expiry_epoch_ms_(expiry_epoch_ms) {}
 
   kvs::RequestType type_;
   kvs::LatticeType lattice_type_;
   string payload_;
   Address addr_;
   string response_id_;
-  unsigned ttl_seconds_ = 0;
+  uint64_t expiry_epoch_ms_ = 0;
 };
 
 struct PendingGossip {

--- a/server/cpp/src/kvs/user_request_handler.cpp
+++ b/server/cpp/src/kvs/user_request_handler.cpp
@@ -80,7 +80,7 @@ void user_request_handler(
 
         if (request_type == kvs::RequestType::GET) {
           if (stored_key_map.find(key) == stored_key_map.end() ||
-              stored_key_map[key].type_ == kvs::LatticeType::NONE) {
+              stored_key_map[key].type() == kvs::LatticeType::NONE) {
 
             tp->set_error(kvs::AnnaError::KEY_DNE);
           } else if (stored_key_map[key].expiry_epoch_s_ > 0 &&
@@ -88,8 +88,8 @@ void user_request_handler(
             // Key has expired (TTL or tombstone) — return KEY_DNE.
             tp->set_error(kvs::AnnaError::KEY_DNE);
           } else {
-            auto res = process_get(key, serializers[stored_key_map[key].type_]);
-            tp->set_lattice_type(stored_key_map[key].type_);
+            auto res = process_get(key, serializers[stored_key_map[key].type()]);
+            tp->set_lattice_type(stored_key_map[key].type());
             tp->set_payload(res.first);
             tp->set_error(res.second);
           }
@@ -97,13 +97,13 @@ void user_request_handler(
           if (tuple.lattice_type() == kvs::LatticeType::NONE) {
              log->error("PUT request missing lattice type. [{}:{}]", __FILE__, __LINE__);
           } else if (stored_key_map.find(key) != stored_key_map.end() &&
-                     stored_key_map[key].type_ != kvs::LatticeType::NONE &&
-                     stored_key_map[key].type_ != tuple.lattice_type()) {
+                     stored_key_map[key].type() != kvs::LatticeType::NONE &&
+                     stored_key_map[key].type() != tuple.lattice_type()) {
              log->error(
                  "Lattice type mismatch for key {}: query is {} but we expect "
                  "{}. [{}:{}]",
                  key, LatticeType_Name(tuple.lattice_type()),
-                 LatticeType_Name(stored_key_map[key].type_),
+                 LatticeType_Name(stored_key_map[key].type()),
                  __FILE__, __LINE__);
            } else {
             process_put(key, tuple.lattice_type(), payload,

--- a/server/cpp/src/kvs/user_request_handler.cpp
+++ b/server/cpp/src/kvs/user_request_handler.cpp
@@ -72,7 +72,7 @@ void user_request_handler(
 
           pending_requests[key].push_back(
               PendingRequest(request_type, tuple.lattice_type(), payload,
-                             response_address, response_id));
+                             response_address, response_id, tuple.ttl_seconds()));
         }
       } else { // if we know the responsible threads, we process the request
         kvs::KeyTuple *tp = response.add_tuples();
@@ -83,6 +83,14 @@ void user_request_handler(
               stored_key_map[key].type_ == kvs::LatticeType::NONE) {
 
             tp->set_error(kvs::AnnaError::KEY_DNE);
+          } else if (stored_key_map[key].expiry_time_.time_since_epoch().count() > 0 &&
+                     std::chrono::system_clock::now() > stored_key_map[key].expiry_time_) {
+            // Key has expired — return KEY_DNE and mark for GC.
+            tp->set_error(kvs::AnnaError::KEY_DNE);
+            if (stored_key_map[key].tombstone_time_.time_since_epoch().count() == 0) {
+              stored_key_map[key].tombstone_time_ = std::chrono::system_clock::now();
+              stored_key_map[key].size_ = 0;
+            }
           } else {
             auto res = process_get(key, serializers[stored_key_map[key].type_]);
             tp->set_lattice_type(stored_key_map[key].type_);
@@ -103,7 +111,8 @@ void user_request_handler(
                  __FILE__, __LINE__);
            } else {
             process_put(key, tuple.lattice_type(), payload,
-                        serializers[tuple.lattice_type()], stored_key_map);
+                        serializers[tuple.lattice_type()], stored_key_map,
+                        tuple.ttl_seconds());
 
             local_changeset.insert(key);
             tp->set_lattice_type(tuple.lattice_type());
@@ -123,7 +132,7 @@ void user_request_handler(
     } else {
       pending_requests[key].push_back(
           PendingRequest(request_type, tuple.lattice_type(), payload,
-                         response_address, response_id));
+                         response_address, response_id, tuple.ttl_seconds()));
     }
   }
 

--- a/server/cpp/src/kvs/user_request_handler.cpp
+++ b/server/cpp/src/kvs/user_request_handler.cpp
@@ -72,7 +72,7 @@ void user_request_handler(
 
           pending_requests[key].push_back(
               PendingRequest(request_type, tuple.lattice_type(), payload,
-                             response_address, response_id, tuple.ttl_seconds()));
+                             response_address, response_id, tuple.expiry_epoch_ms()));
         }
       } else { // if we know the responsible threads, we process the request
         kvs::KeyTuple *tp = response.add_tuples();
@@ -83,14 +83,10 @@ void user_request_handler(
               stored_key_map[key].type_ == kvs::LatticeType::NONE) {
 
             tp->set_error(kvs::AnnaError::KEY_DNE);
-          } else if (stored_key_map[key].expiry_time_.time_since_epoch().count() > 0 &&
-                     std::chrono::system_clock::now() > stored_key_map[key].expiry_time_) {
-            // Key has expired — return KEY_DNE and mark for GC.
+          } else if (stored_key_map[key].expiry_epoch_s_ > 0 &&
+                     now_epoch_s() > stored_key_map[key].expiry_epoch_s_) {
+            // Key has expired (TTL or tombstone) — return KEY_DNE.
             tp->set_error(kvs::AnnaError::KEY_DNE);
-            if (stored_key_map[key].tombstone_time_.time_since_epoch().count() == 0) {
-              stored_key_map[key].tombstone_time_ = std::chrono::system_clock::now();
-              stored_key_map[key].size_ = 0;
-            }
           } else {
             auto res = process_get(key, serializers[stored_key_map[key].type_]);
             tp->set_lattice_type(stored_key_map[key].type_);
@@ -112,7 +108,7 @@ void user_request_handler(
            } else {
             process_put(key, tuple.lattice_type(), payload,
                         serializers[tuple.lattice_type()], stored_key_map,
-                        tuple.ttl_seconds());
+                        tuple.expiry_epoch_ms());
 
             local_changeset.insert(key);
             tp->set_lattice_type(tuple.lattice_type());
@@ -132,7 +128,7 @@ void user_request_handler(
     } else {
       pending_requests[key].push_back(
           PendingRequest(request_type, tuple.lattice_type(), payload,
-                         response_address, response_id, tuple.ttl_seconds()));
+                         response_address, response_id, tuple.expiry_epoch_ms()));
     }
   }
 

--- a/server/cpp/src/kvs/utils.cpp
+++ b/server/cpp/src/kvs/utils.cpp
@@ -81,10 +81,14 @@ bool process_put(const Key &key, kvs::LatticeType lattice_type,
         static_cast<uint32_t>(expiry_epoch_ms / 1000);
   } else if (result == 0 && kTombstoneGcMultiplier > 0) {
     // Tombstone (delete = PUT of empty value): expire after gc_threshold.
-    // Only set if not already set, to avoid resetting the clock on re-gossip.
-    if (stored_key_map[key].expiry_epoch_s_ == 0) {
-      unsigned gc_threshold_s = (kGossipPeriod / 1000000) * kTombstoneGcMultiplier;
-      stored_key_map[key].expiry_epoch_s_ = now_epoch_s() + gc_threshold_s;
+    // Always set (overrides any previous TTL expiry), but don't reset if
+    // already a tombstone (re-gossip of same delete).
+    unsigned gc_threshold_s = (kGossipPeriod / 1000000) * kTombstoneGcMultiplier;
+    uint32_t tombstone_expiry = now_epoch_s() + gc_threshold_s;
+    if (stored_key_map[key].expiry_epoch_s_ == 0 ||
+        stored_key_map[key].size() > 0) {
+      // First tombstone or transition from non-empty: set expiry.
+      stored_key_map[key].expiry_epoch_s_ = tombstone_expiry;
     }
   } else if (result > 0 && expiry_epoch_ms == 0) {
     // Non-empty value with no expiry: clear any previous expiry.

--- a/server/cpp/src/kvs/utils.cpp
+++ b/server/cpp/src/kvs/utils.cpp
@@ -37,7 +37,8 @@ void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
       auto res = process_get(key, serializers[type]);
 
       if (res.second == 0) {
-        prepare_put_tuple(gossip_map[address], key, type, res.first);
+        prepare_put_tuple(gossip_map[address], key, type, res.first,
+                          stored_key_map[key].ttl_seconds_);
       }
     }
   }
@@ -59,7 +60,8 @@ std::pair<string, kvs::AnnaError> process_get(const Key &key,
 
 bool process_put(const Key &key, kvs::LatticeType lattice_type,
                  const string &payload, Serializer *serializer,
-                 map<Key, KeyProperty> &stored_key_map) {
+                 map<Key, KeyProperty> &stored_key_map,
+                 unsigned ttl_seconds) {
   int result = serializer->put(key, payload);
   if (result < 0) {
     spdlog::error("Failed to put key {}", key);
@@ -81,6 +83,17 @@ bool process_put(const Key &key, kvs::LatticeType lattice_type,
   } else {
     // Key has a non-empty value — clear any tombstone timestamp.
     stored_key_map[key].tombstone_time_ = {};
+  }
+
+  // Set TTL expiry if specified.
+  if (ttl_seconds > 0) {
+    stored_key_map[key].expiry_time_ =
+        std::chrono::system_clock::now() + std::chrono::seconds(ttl_seconds);
+    stored_key_map[key].ttl_seconds_ = ttl_seconds;
+  } else if (ttl_seconds == 0 && stored_key_map[key].ttl_seconds_ > 0) {
+    // A PUT with ttl=0 on a key that previously had a TTL clears the expiry,
+    // but only from a direct client request (not from gossip, where ttl=0
+    // means "no TTL info in this gossip message").
   }
 
   return true;

--- a/server/cpp/src/kvs/utils.cpp
+++ b/server/cpp/src/kvs/utils.cpp
@@ -31,7 +31,7 @@ void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
         // we don't have this key stored, so skip
         continue;
       } else {
-        type = stored_key_map[key].type_;
+        type = stored_key_map[key].type();
       }
 
       auto res = process_get(key, serializers[type]);
@@ -71,8 +71,8 @@ bool process_put(const Key &key, kvs::LatticeType lattice_type,
     spdlog::error("Failed to put key {}", key);
     return false;
   }
-  stored_key_map[key].size_ = static_cast<unsigned>(result);
-  stored_key_map[key].type_ = std::move(lattice_type);
+  stored_key_map[key].set_size(static_cast<unsigned>(result));
+  stored_key_map[key].set_type(lattice_type);
 
   // Set expiry based on client TTL or tombstone.
   if (expiry_epoch_ms > 0) {

--- a/server/cpp/src/kvs/utils.cpp
+++ b/server/cpp/src/kvs/utils.cpp
@@ -37,8 +37,10 @@ void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
       auto res = process_get(key, serializers[type]);
 
       if (res.second == 0) {
-        prepare_put_tuple(gossip_map[address], key, type, res.first,
-                          stored_key_map[key].ttl_seconds_);
+        uint64_t expiry_ms = stored_key_map[key].expiry_epoch_s_ > 0
+            ? static_cast<uint64_t>(stored_key_map[key].expiry_epoch_s_) * 1000
+            : 0;
+        prepare_put_tuple(gossip_map[address], key, type, res.first, expiry_ms);
       }
     }
   }
@@ -58,10 +60,12 @@ std::pair<string, kvs::AnnaError> process_get(const Key &key,
   return std::pair<string, kvs::AnnaError>(std::move(res), error);
 }
 
+
+
 bool process_put(const Key &key, kvs::LatticeType lattice_type,
                  const string &payload, Serializer *serializer,
                  map<Key, KeyProperty> &stored_key_map,
-                 unsigned ttl_seconds) {
+                 uint64_t expiry_epoch_ms) {
   int result = serializer->put(key, payload);
   if (result < 0) {
     spdlog::error("Failed to put key {}", key);
@@ -70,30 +74,21 @@ bool process_put(const Key &key, kvs::LatticeType lattice_type,
   stored_key_map[key].size_ = static_cast<unsigned>(result);
   stored_key_map[key].type_ = std::move(lattice_type);
 
-  // Track when a key becomes a tombstone (empty value after a delete).
-  // Set the timestamp whenever the result is zero-length, so both new
-  // tombstones and transitions from non-zero get a correct timestamp.
-  if (result == 0) {
-    // Only update the timestamp if it hasn't been set yet (epoch value),
-    // or if this is a fresh transition to empty. This avoids resetting
-    // the clock when a tombstone is re-gossiped.
-    if (stored_key_map[key].tombstone_time_.time_since_epoch().count() == 0) {
-      stored_key_map[key].tombstone_time_ = std::chrono::system_clock::now();
+  // Set expiry based on client TTL or tombstone.
+  if (expiry_epoch_ms > 0) {
+    // Client-specified absolute expiry (milliseconds -> seconds).
+    stored_key_map[key].expiry_epoch_s_ =
+        static_cast<uint32_t>(expiry_epoch_ms / 1000);
+  } else if (result == 0 && kTombstoneGcMultiplier > 0) {
+    // Tombstone (delete = PUT of empty value): expire after gc_threshold.
+    // Only set if not already set, to avoid resetting the clock on re-gossip.
+    if (stored_key_map[key].expiry_epoch_s_ == 0) {
+      unsigned gc_threshold_s = (kGossipPeriod / 1000000) * kTombstoneGcMultiplier;
+      stored_key_map[key].expiry_epoch_s_ = now_epoch_s() + gc_threshold_s;
     }
-  } else {
-    // Key has a non-empty value — clear any tombstone timestamp.
-    stored_key_map[key].tombstone_time_ = {};
-  }
-
-  // Set TTL expiry if specified.
-  if (ttl_seconds > 0) {
-    stored_key_map[key].expiry_time_ =
-        std::chrono::system_clock::now() + std::chrono::seconds(ttl_seconds);
-    stored_key_map[key].ttl_seconds_ = ttl_seconds;
-  } else if (ttl_seconds == 0 && stored_key_map[key].ttl_seconds_ > 0) {
-    // A PUT with ttl=0 on a key that previously had a TTL clears the expiry,
-    // but only from a direct client request (not from gossip, where ttl=0
-    // means "no TTL info in this gossip message").
+  } else if (result > 0 && expiry_epoch_ms == 0) {
+    // Non-empty value with no expiry: clear any previous expiry.
+    stored_key_map[key].expiry_epoch_s_ = 0;
   }
 
   return true;

--- a/server/cpp/src/metadata.hpp
+++ b/server/cpp/src/metadata.hpp
@@ -43,6 +43,12 @@ struct KeyProperty {
   // When the key became a tombstone (size_ == 0). Only meaningful when
   // size_ == 0; used by tombstone GC to decide when to reap the key.
   std::chrono::time_point<std::chrono::system_clock> tombstone_time_;
+  // When this key expires (TTL). A default-constructed time_point (epoch)
+  // means no expiration. Set on PUT when ttl_seconds > 0.
+  std::chrono::time_point<std::chrono::system_clock> expiry_time_;
+  // The original TTL in seconds (preserved for gossip propagation).
+  // 0 means no TTL.
+  unsigned ttl_seconds_ = 0;
 };
 
 inline bool operator==(const KeyReplication &lhs, const KeyReplication &rhs) {

--- a/server/cpp/src/metadata.hpp
+++ b/server/cpp/src/metadata.hpp
@@ -40,15 +40,11 @@ struct KeyReplication {
 struct KeyProperty {
   unsigned size_;
   kvs::LatticeType type_;
-  // When the key became a tombstone (size_ == 0). Only meaningful when
-  // size_ == 0; used by tombstone GC to decide when to reap the key.
-  std::chrono::time_point<std::chrono::system_clock> tombstone_time_;
-  // When this key expires (TTL). A default-constructed time_point (epoch)
-  // means no expiration. Set on PUT when ttl_seconds > 0.
-  std::chrono::time_point<std::chrono::system_clock> expiry_time_;
-  // The original TTL in seconds (preserved for gossip propagation).
-  // 0 means no TTL.
-  unsigned ttl_seconds_ = 0;
+  // When this key should be reaped, as seconds since Unix epoch.
+  // Used for both TTL expiration (from client) and tombstone GC
+  // (computed as now + gc_threshold on delete). 0 means no expiration.
+  // uint32_t gives 1-second resolution until year 2106.
+  uint32_t expiry_epoch_s_ = 0;
 };
 
 inline bool operator==(const KeyReplication &lhs, const KeyReplication &rhs) {

--- a/server/cpp/src/metadata.hpp
+++ b/server/cpp/src/metadata.hpp
@@ -38,13 +38,22 @@ struct KeyReplication {
 };
 
 struct KeyProperty {
-  unsigned size_;
-  kvs::LatticeType type_;
-  // When this key should be reaped, as seconds since Unix epoch.
-  // Used for both TTL expiration (from client) and tombstone GC
-  // (computed as now + gc_threshold on delete). 0 means no expiration.
-  // uint32_t gives 1-second resolution until year 2106.
+  // size (24 bits, max 16MB) and type (8 bits, max 256 types) packed
+  // into a single uint32_t to avoid struct padding.
+  uint32_t size_and_type_ = 0;
   uint32_t expiry_epoch_s_ = 0;
+
+  unsigned size() const { return size_and_type_ >> 8; }
+  void set_size(unsigned s) {
+    size_and_type_ = (s << 8) | (size_and_type_ & 0xFF);
+  }
+
+  kvs::LatticeType type() const {
+    return static_cast<kvs::LatticeType>(size_and_type_ & 0xFF);
+  }
+  void set_type(kvs::LatticeType t) {
+    size_and_type_ = (size_and_type_ & 0xFFFFFF00) | (static_cast<uint8_t>(t));
+  }
 };
 
 inline bool operator==(const KeyReplication &lhs, const KeyReplication &rhs) {

--- a/server/cpp/src/monitor/monitoring.cpp
+++ b/server/cpp/src/monitor/monitoring.cpp
@@ -300,6 +300,7 @@ int main(int argc, char *argv[]) {
   unsigned rid = 0;
 
   while (!shutdown_requested.load()) {
+   try {
     kZmqUtil->poll(&pollitems, std::chrono::milliseconds{0});
 
     if (pollitems[0].revents & ZMQ_POLLIN) {
@@ -464,5 +465,11 @@ int main(int argc, char *argv[]) {
 
       report_start = std::chrono::system_clock::now();
     }
+   } catch (const zmq::error_t &e) {
+     if (e.num() == EINTR && shutdown_requested.load()) {
+       break;
+     }
+     throw;
+   }
   }
 }

--- a/server/cpp/src/route/routing.cpp
+++ b/server/cpp/src/route/routing.cpp
@@ -104,6 +104,7 @@ void run(unsigned thread_id, Address ip, vector<Address> monitoring_ips) {
       {static_cast<void *>(key_address_puller), 0, ZMQ_POLLIN, 0}};
 
   while (!shutdown_requested.load()) {
+   try {
     kZmqUtil->poll(&pollitems, std::chrono::milliseconds{100});
 
     // only relevant for the seed node
@@ -140,6 +141,12 @@ void run(unsigned thread_id, Address ip, vector<Address> monitoring_ips) {
                       local_hash_rings, key_replication_map, pending_requests,
                       seed);
     }
+   } catch (const zmq::error_t &e) {
+     if (e.num() == EINTR && shutdown_requested.load()) {
+       break;
+     }
+     throw;
+   }
   }
 }
 

--- a/server/cpp/tests/kvs/server_handler_base.hpp
+++ b/server/cpp/tests/kvs/server_handler_base.hpp
@@ -127,7 +127,7 @@ public:
   }
 
   string put_key_request(Key key, kvs::LatticeType lattice_type, string payload,
-                         string ip) {
+                         string ip, uint64_t expiry_epoch_ms = 0) {
     kvs::KeyRequest request;
     request.set_type(kvs::RequestType::PUT);
     request.set_response_address(UserThread(ip, 0).response_connect_address());
@@ -137,6 +137,9 @@ public:
     tp->set_key(std::move(key));
     tp->set_lattice_type(std::move(lattice_type));
     tp->set_payload(std::move(payload));
+    if (expiry_epoch_ms > 0) {
+      tp->set_expiry_epoch_ms(expiry_epoch_ms);
+    }
 
     string request_str;
     request.SerializeToString(&request_str);

--- a/server/cpp/tests/kvs/test_user_request_handler.hpp
+++ b/server/cpp/tests/kvs/test_user_request_handler.hpp
@@ -544,6 +544,67 @@ TEST_F(ServerHandlerTest, UserPutLatticeMismatchTest) {
   EXPECT_EQ(stored_key_map[key].type(), kvs::LatticeType::LWW);
 }
 
+// Test PUT with TTL sets expiry_epoch_s_ on the stored key.
+TEST_F(ServerHandlerTest, UserPutWithTTLSetsExpiry) {
+  Key key = "ttl_key";
+  string value = "ttl_value";
+
+  // Use an absolute expiry 300 seconds from now (in milliseconds).
+  uint64_t expiry_ms = static_cast<uint64_t>(now_epoch_s() + 300) * 1000;
+  string put_lww =
+      put_key_request(key, kvs::LatticeType::LWW, serialize(0, value), ip,
+                      expiry_ms);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  user_request_handler(access_count, seed, put_lww, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  EXPECT_EQ(stored_key_map[key].type(), kvs::LatticeType::LWW);
+  // Expiry should be set (non-zero) and approximately 300 seconds from now.
+  EXPECT_GT(stored_key_map[key].expiry_epoch_s_, 0u);
+  EXPECT_NEAR(stored_key_map[key].expiry_epoch_s_, now_epoch_s() + 300, 2);
+}
+
+// Test GET on an expired key returns KEY_DNE.
+TEST_F(ServerHandlerTest, UserGetExpiredKeyReturnsDNE) {
+  Key key = "expired_key";
+  string value = "expired_value";
+
+  // PUT with an expiry in the past (already expired).
+  uint64_t expiry_ms = static_cast<uint64_t>(now_epoch_s() - 10) * 1000;
+  string put_lww =
+      put_key_request(key, kvs::LatticeType::LWW, serialize(0, value), ip,
+                      expiry_ms);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  user_request_handler(access_count, seed, put_lww, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  // Key should exist but be expired.
+  EXPECT_GT(stored_key_map[key].expiry_epoch_s_, 0u);
+
+  // GET should return KEY_DNE.
+  string get_req = get_key_request(key, ip);
+  size_t msg_count_before = mock_zmq_util.sent_messages.size();
+  user_request_handler(access_count, seed, get_req, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  ASSERT_GT(mock_zmq_util.sent_messages.size(), msg_count_before);
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+  EXPECT_EQ(response.tuples(0).error(), kvs::AnnaError::KEY_DNE);
+}
+
 // TODO: Test key address cache invalidation
 // TODO: Test replication factor request and making the request pending
 // TODO: Test metadata operations -- does this matter?

--- a/server/cpp/tests/kvs/test_user_request_handler.hpp
+++ b/server/cpp/tests/kvs/test_user_request_handler.hpp
@@ -18,7 +18,7 @@ TEST_F(ServerHandlerTest, UserGetLWWTest) {
   Key key = "key";
   string value = "value";
   serializers[kvs::LatticeType::LWW]->put(key, serialize(0, value));
-  stored_key_map[key].type_ = kvs::LatticeType::LWW;
+  stored_key_map[key].set_type(kvs::LatticeType::LWW);
 
   string get_request = get_key_request(key, ip);
 
@@ -59,7 +59,7 @@ TEST_F(ServerHandlerTest, UserGetSetTest) {
   s.emplace("value2");
   s.emplace("value3");
   serializers[kvs::LatticeType::SET]->put(key, serialize(SetLattice<string>(s)));
-  stored_key_map[key].type_ = kvs::LatticeType::SET;
+  stored_key_map[key].set_type(kvs::LatticeType::SET);
 
   string get_request = get_key_request(key, ip);
 
@@ -101,7 +101,7 @@ TEST_F(ServerHandlerTest, UserGetOrderedSetTest) {
   s.emplace("value3");
   serializers[kvs::LatticeType::ORDERED_SET]->put(
       key, serialize(OrderedSetLattice<string>(s)));
-  stored_key_map[key].type_ = kvs::LatticeType::ORDERED_SET;
+  stored_key_map[key].set_type(kvs::LatticeType::ORDERED_SET);
 
   string get_request = get_key_request(key, ip);
 
@@ -146,7 +146,7 @@ TEST_F(ServerHandlerTest, UserGetCausalTest) {
 
   serializers[kvs::LatticeType::SINGLE_CAUSAL]->put(
       key, serialize(SingleKeyCausalLattice<SetLattice<string>>(p)));
-  stored_key_map[key].type_ = kvs::LatticeType::SINGLE_CAUSAL;
+  stored_key_map[key].set_type(kvs::LatticeType::SINGLE_CAUSAL);
 
   string get_request = get_key_request(key, ip);
 
@@ -526,7 +526,7 @@ TEST_F(ServerHandlerTest, UserPutLatticeMismatchTest) {
                        serializers, pushers);
 
   EXPECT_EQ(local_changeset.size(), 1);
-  EXPECT_EQ(stored_key_map[key].type_, kvs::LatticeType::LWW);
+  EXPECT_EQ(stored_key_map[key].type(), kvs::LatticeType::LWW);
 
   // Second PUT with SET type on the same key — lattice mismatch.
   set<string> s = {"a"};
@@ -541,7 +541,7 @@ TEST_F(ServerHandlerTest, UserPutLatticeMismatchTest) {
 
   // The mismatched PUT should be silently skipped.
   EXPECT_EQ(local_changeset.size(), 0);
-  EXPECT_EQ(stored_key_map[key].type_, kvs::LatticeType::LWW);
+  EXPECT_EQ(stored_key_map[key].type(), kvs::LatticeType::LWW);
 }
 
 // TODO: Test key address cache invalidation

--- a/server/protobuf/kvs.proto
+++ b/server/protobuf/kvs.proto
@@ -134,6 +134,10 @@ message KeyTuple {
   // A boolean set by the server if the client's address_cache_size does not
   // match the metadata stored by the server.
   bool invalidate = 6;
+
+  // Optional TTL in seconds. When set on a PUT, the key automatically expires
+  // after this many seconds. A value of 0 means no expiration (default).
+  uint32 ttl_seconds = 7;
 }
 
 // An individual GET or PUT request; each request can batch multiple keys.

--- a/server/protobuf/kvs.proto
+++ b/server/protobuf/kvs.proto
@@ -135,9 +135,11 @@ message KeyTuple {
   // match the metadata stored by the server.
   bool invalidate = 6;
 
-  // Optional TTL in seconds. When set on a PUT, the key automatically expires
-  // after this many seconds. A value of 0 means no expiration (default).
-  uint32 ttl_seconds = 7;
+  // Absolute expiry time as milliseconds since Unix epoch. When set on a PUT,
+  // the key automatically expires at this time. A value of 0 means no
+  // expiration (default). Clients compute this from their local clock:
+  // expiry_epoch_ms = now_ms + ttl_seconds * 1000.
+  uint64 expiry_epoch_ms = 7;
 }
 
 // An individual GET or PUT request; each request can batch multiple keys.


### PR DESCRIPTION
## Summary

Adds per-key TTL (time-to-live) to the Anna KVS. Any PUT can now include a TTL in seconds. After the TTL expires, GETs return KEY_DNE and the key is automatically reaped by the GC.

### How it works

1. Client sends PUT with `ttl_seconds=N`
2. Server computes `expiry_time = now + N seconds` and stores it in `KeyProperty`
3. On GET, if `now > expiry_time`, return KEY_DNE and mark for GC
4. The existing tombstone GC loop also reaps TTL-expired keys
5. TTL is propagated to replicas via gossip

### Key fix: PendingRequest TTL preservation

The initial implementation didn't work because the first PUT for a new key goes through the `pending_requests` path (the server doesn't know the replication factor yet). The `PendingRequest` struct didn't store `ttl_seconds`, so TTL was dropped when the request was replayed after the replication response. Fixed by adding `ttl_seconds_` to `PendingRequest` and passing it through all replay paths.

### Changes

| File | What |
|------|------|
| `kvs.proto` | Add `ttl_seconds` field (7) to `KeyTuple` |
| `metadata.hpp` | Add `expiry_time_`, `ttl_seconds_` to `KeyProperty` |
| `server_utils.hpp` | Add `ttl_seconds_` to `PendingRequest` |
| `user_request_handler.cpp` | Check expiry on GET, pass TTL on PUT and to pending requests |
| `replication_response_handler.cpp` | Pass TTL when replaying pending requests |
| `utils.cpp` | `process_put` sets expiry_time_ from TTL |
| `gossip_handler.cpp` | Pass TTL through gossip |
| `kvs_common.hpp` | `prepare_put_tuple` accepts TTL |
| `server.cpp` | GC loop reaps TTL-expired keys |
| `kvs_client.rs` | `put_with_ttl` method |
| `main.rs` | `PUT_TTL` CLI command |
| `lattice_types.rs` | 3 integration tests |

### Tests

- **ttl_key_expires**: PUT with 2s TTL, GET succeeds before expiry, GET returns error after expiry (fresh client bypasses read cache)
- **no_ttl_key_persists**: PUT without TTL, verify key survives beyond TTL test period
- **ttl_stress_many_keys**: PUT 50 keys with 2s TTL, verify at least half expire (uses aggressive GC config: gossip_epoch=1s, tombstone_gc_multiplier=1)

Closes #513