### PR TITLE
Add PN-Counter lattice type for atomic increment/decrement

### DIFF
--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -65,6 +65,10 @@ pub struct KVSClient {
     /// guaranteeing monotonic reads and read-your-writes.
     #[doc(hidden)]
     pub lww_read_cache: HashMap<Key, (u64, Vec<u8>)>,
+    /// Local PN-Counter state: per-key cumulative (increments, decrements)
+    /// for this client's node ID. Avoids read-modify-write races by tracking
+    /// locally rather than reading from the server.
+    counter_state: HashMap<Key, (u64, u64)>,
     /// High-water mark of timestamps seen by this client (reads and writes).
     /// Ensures each PUT uses a timestamp strictly greater than any previously
     /// seen timestamp, providing the Writes Follow Reads guarantee.
@@ -140,6 +144,7 @@ impl KVSClient {
                 key_address_puller,
                 response_puller,
             },
+            counter_state: HashMap::new(),
             lww_read_cache: HashMap::new(),
             last_seen_ts: 0,
         }
@@ -160,6 +165,7 @@ impl KVSClient {
             transport: Transport::Mock {
                 responses: std::collections::VecDeque::new(),
             },
+            counter_state: HashMap::new(),
             lww_read_cache: HashMap::new(),
             last_seen_ts: 0,
         }
@@ -729,25 +735,16 @@ impl KVSClient {
     ) -> Result<()> {
         debug!("INCREMENT: {} += {}", key, amount);
         let node_id = format!("{}:{}", self.ut.ip(), self.ut.tid());
+        let key_str = key.as_ref().to_string();
 
-        // GET current state to learn our slot value, then increment.
-        let current = self.get_counter_state(key.as_ref()).await;
-        let new_inc = current
-            .as_ref()
-            .and_then(|s| s.get(&node_id))
-            .copied()
-            .unwrap_or(0)
-            + amount;
+        // Track cumulative increment locally to avoid read-modify-write races.
+        let (inc, dec) = self.counter_state.entry(key_str.clone()).or_insert((0, 0));
+        *inc += amount;
 
         let mut cv = crate::proto::kvs::CounterValue::default();
-        cv.increments.insert(node_id, new_inc);
-
-        // Preserve existing state from other nodes.
-        if let Some(state) = &current {
-            for (k, v) in state {
-                cv.increments.entry(k.clone()).or_insert(*v);
-            }
-        }
+        cv.increments.insert(node_id, *inc);
+        cv.decrements
+            .insert(format!("{}:{}", self.ut.ip(), self.ut.tid()), *dec);
 
         let payload = cv.encode_to_vec();
         let response = self
@@ -777,25 +774,16 @@ impl KVSClient {
     ) -> Result<()> {
         debug!("DECREMENT: {} -= {}", key, amount);
         let node_id = format!("{}:{}", self.ut.ip(), self.ut.tid());
+        let key_str = key.as_ref().to_string();
 
-        // GET current decrement state.
-        let current = self.get_counter_dec_state(key.as_ref()).await;
-        let new_dec = current
-            .as_ref()
-            .and_then(|s| s.get(&node_id))
-            .copied()
-            .unwrap_or(0)
-            + amount;
+        // Track cumulative decrement locally to avoid read-modify-write races.
+        let (inc, dec) = self.counter_state.entry(key_str.clone()).or_insert((0, 0));
+        *dec += amount;
 
         let mut cv = crate::proto::kvs::CounterValue::default();
-        cv.decrements.insert(node_id, new_dec);
-
-        // Preserve existing decrement state from other nodes.
-        if let Some(state) = &current {
-            for (k, v) in state {
-                cv.decrements.entry(k.clone()).or_insert(*v);
-            }
-        }
+        cv.increments
+            .insert(format!("{}:{}", self.ut.ip(), self.ut.tid()), *inc);
+        cv.decrements.insert(node_id, *dec);
 
         let payload = cv.encode_to_vec();
         let response = self
@@ -833,32 +821,6 @@ impl KVSClient {
         let pos: u64 = cv.increments.values().sum();
         let neg: u64 = cv.decrements.values().sum();
         Ok(pos as i64 - neg as i64)
-    }
-
-    // Helper: get current increment state for this counter from the server.
-    async fn get_counter_state(&mut self, key: &str) -> Option<HashMap<String, u64>> {
-        let response = self
-            .send_data_request(key, RequestType::Get as i32, None, None)
-            .await?;
-        if response.tuples.is_empty() || response.tuples[0].error != 0 {
-            return None;
-        }
-        let cv =
-            crate::proto::kvs::CounterValue::decode(response.tuples[0].payload.as_slice()).ok()?;
-        Some(cv.increments)
-    }
-
-    // Helper: get current decrement state for this counter from the server.
-    async fn get_counter_dec_state(&mut self, key: &str) -> Option<HashMap<String, u64>> {
-        let response = self
-            .send_data_request(key, RequestType::Get as i32, None, None)
-            .await?;
-        if response.tuples.is_empty() || response.tuples[0].error != 0 {
-            return None;
-        }
-        let cv =
-            crate::proto::kvs::CounterValue::decode(response.tuples[0].payload.as_slice()).ok()?;
-        Some(cv.decrements)
     }
 
     /// Retrieve a set of values by key (Set lattice).

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -717,6 +717,150 @@ impl KVSClient {
         Ok(())
     }
 
+    /// Increment a counter key by the given amount.
+    ///
+    /// Uses the PN-Counter CRDT lattice. Each client tracks its own
+    /// cumulative increment count keyed by `client_ip:tid`. Concurrent
+    /// increments from different clients are all preserved.
+    pub async fn increment_by<K: AsRef<str> + Display>(
+        &mut self,
+        key: K,
+        amount: u64,
+    ) -> Result<()> {
+        debug!("INCREMENT: {} += {}", key, amount);
+        let node_id = format!("{}:{}", self.ut.ip(), self.ut.tid());
+
+        // GET current state to learn our slot value, then increment.
+        let current = self.get_counter_state(key.as_ref()).await;
+        let new_inc = current
+            .as_ref()
+            .and_then(|s| s.get(&node_id))
+            .copied()
+            .unwrap_or(0)
+            + amount;
+
+        let mut cv = crate::proto::kvs::CounterValue::default();
+        cv.increments.insert(node_id, new_inc);
+
+        // Preserve existing state from other nodes.
+        if let Some(state) = &current {
+            for (k, v) in state {
+                cv.increments.entry(k.clone()).or_insert(*v);
+            }
+        }
+
+        let payload = cv.encode_to_vec();
+        let response = self
+            .send_data_request(
+                key.as_ref(),
+                RequestType::Put as i32,
+                Some(LatticeType::Counter as i32),
+                Some(payload),
+            )
+            .await
+            .ok_or_else(|| Error::Kvs("INCREMENT: request failed or timed out".into()))?;
+
+        Self::validate_response(&response, "INCREMENT")?;
+        Ok(())
+    }
+
+    /// Increment a counter key by 1.
+    pub async fn increment<K: AsRef<str> + Display>(&mut self, key: K) -> Result<()> {
+        self.increment_by(key, 1).await
+    }
+
+    /// Decrement a counter key by the given amount.
+    pub async fn decrement_by<K: AsRef<str> + Display>(
+        &mut self,
+        key: K,
+        amount: u64,
+    ) -> Result<()> {
+        debug!("DECREMENT: {} -= {}", key, amount);
+        let node_id = format!("{}:{}", self.ut.ip(), self.ut.tid());
+
+        // GET current decrement state.
+        let current = self.get_counter_dec_state(key.as_ref()).await;
+        let new_dec = current
+            .as_ref()
+            .and_then(|s| s.get(&node_id))
+            .copied()
+            .unwrap_or(0)
+            + amount;
+
+        let mut cv = crate::proto::kvs::CounterValue::default();
+        cv.decrements.insert(node_id, new_dec);
+
+        // Preserve existing decrement state from other nodes.
+        if let Some(state) = &current {
+            for (k, v) in state {
+                cv.decrements.entry(k.clone()).or_insert(*v);
+            }
+        }
+
+        let payload = cv.encode_to_vec();
+        let response = self
+            .send_data_request(
+                key.as_ref(),
+                RequestType::Put as i32,
+                Some(LatticeType::Counter as i32),
+                Some(payload),
+            )
+            .await
+            .ok_or_else(|| Error::Kvs("DECREMENT: request failed or timed out".into()))?;
+
+        Self::validate_response(&response, "DECREMENT")?;
+        Ok(())
+    }
+
+    /// Decrement a counter key by 1.
+    pub async fn decrement<K: AsRef<str> + Display>(&mut self, key: K) -> Result<()> {
+        self.decrement_by(key, 1).await
+    }
+
+    /// Get the current counter value (sum of increments - sum of decrements).
+    pub async fn get_counter<K: AsRef<str> + Display>(&mut self, key: K) -> Result<i64> {
+        debug!("GET_COUNTER: {}", key);
+        let response = self
+            .send_data_request(key.as_ref(), RequestType::Get as i32, None, None)
+            .await
+            .ok_or_else(|| Error::Kvs("GET_COUNTER: request failed or timed out".into()))?;
+
+        let tuple = Self::validate_response(&response, "GET_COUNTER")?;
+
+        let cv = crate::proto::kvs::CounterValue::decode(tuple.payload.as_slice())
+            .map_err(|e| Error::Kvs(format!("GET_COUNTER: failed to decode: {}", e)))?;
+
+        let pos: u64 = cv.increments.values().sum();
+        let neg: u64 = cv.decrements.values().sum();
+        Ok(pos as i64 - neg as i64)
+    }
+
+    // Helper: get current increment state for this counter from the server.
+    async fn get_counter_state(&mut self, key: &str) -> Option<HashMap<String, u64>> {
+        let response = self
+            .send_data_request(key, RequestType::Get as i32, None, None)
+            .await?;
+        if response.tuples.is_empty() || response.tuples[0].error != 0 {
+            return None;
+        }
+        let cv =
+            crate::proto::kvs::CounterValue::decode(response.tuples[0].payload.as_slice()).ok()?;
+        Some(cv.increments)
+    }
+
+    // Helper: get current decrement state for this counter from the server.
+    async fn get_counter_dec_state(&mut self, key: &str) -> Option<HashMap<String, u64>> {
+        let response = self
+            .send_data_request(key, RequestType::Get as i32, None, None)
+            .await?;
+        if response.tuples.is_empty() || response.tuples[0].error != 0 {
+            return None;
+        }
+        let cv =
+            crate::proto::kvs::CounterValue::decode(response.tuples[0].payload.as_slice()).ok()?;
+        Some(cv.decrements)
+    }
+
     /// Retrieve a set of values by key (Set lattice).
     ///
     /// ```rust

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -3163,4 +3163,61 @@ mod tests {
         // TTL values should NOT be cached (they'd be stale after expiry)
         assert!(!client.lww_read_cache.contains_key("ttl_key"));
     }
+
+    fn make_counter_response(key: &str, inc_val: u64) -> Vec<u8> {
+        let mut cv = crate::proto::kvs::CounterValue::default();
+        cv.increments.insert("test:0".to_string(), inc_val);
+        let response = KeyResponse {
+            r#type: RequestType::Get as i32,
+            tuples: vec![KeyTuple {
+                key: key.to_string(),
+                lattice_type: LatticeType::Counter as i32,
+                payload: cv.encode_to_vec(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        response.encode_to_vec()
+    }
+
+    #[tokio::test]
+    async fn increment_tracks_locally() {
+        let worker = "tcp://127.0.0.1:6200";
+        let mut client = mock_client(233);
+        // First increment
+        client.push_mock_response(true, Some(make_routing_response("cnt", worker)));
+        client.push_mock_response(false, Some(make_put_response("cnt")));
+        client.increment("cnt").await.expect("increment 1 failed");
+
+        // Second increment
+        client.push_mock_response(true, Some(make_routing_response("cnt", worker)));
+        client.push_mock_response(false, Some(make_put_response("cnt")));
+        client.increment("cnt").await.expect("increment 2 failed");
+
+        // Local state should be (2, 0)
+        assert_eq!(client.counter_state.get("cnt"), Some(&(2, 0)));
+    }
+
+    #[tokio::test]
+    async fn decrement_tracks_locally() {
+        let worker = "tcp://127.0.0.1:6200";
+        let mut client = mock_client(234);
+        client.push_mock_response(true, Some(make_routing_response("cnt", worker)));
+        client.push_mock_response(false, Some(make_put_response("cnt")));
+        client
+            .decrement_by("cnt", 5)
+            .await
+            .expect("decrement failed");
+        assert_eq!(client.counter_state.get("cnt"), Some(&(0, 5)));
+    }
+
+    #[tokio::test]
+    async fn get_counter_returns_value() {
+        let worker = "tcp://127.0.0.1:6200";
+        let mut client = mock_client(235);
+        client.push_mock_response(true, Some(make_routing_response("cnt", worker)));
+        client.push_mock_response(false, Some(make_counter_response("cnt", 42)));
+        let val = client.get_counter("cnt").await.expect("get_counter failed");
+        assert_eq!(val, 42);
+    }
 }

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -382,6 +382,28 @@ async fn execute_command(
             client.put_value(&key, &value).await?;
         }
         "DELETE" if split.len() == 2 => client.delete(split[1]).await?,
+        "INCREMENT" if split.len() == 2 => {
+            client.increment(split[1]).await?;
+        }
+        "INCREMENT" if split.len() == 3 => {
+            let amount: u64 = split[2]
+                .parse()
+                .map_err(|_| annalib::Error::Kvs("amount must be a positive integer".into()))?;
+            client.increment_by(split[1], amount).await?;
+        }
+        "DECREMENT" if split.len() == 2 => {
+            client.decrement(split[1]).await?;
+        }
+        "DECREMENT" if split.len() == 3 => {
+            let amount: u64 = split[2]
+                .parse()
+                .map_err(|_| annalib::Error::Kvs("amount must be a positive integer".into()))?;
+            client.decrement_by(split[1], amount).await?;
+        }
+        "GET_COUNTER" if split.len() == 2 => {
+            let val = client.get_counter(split[1]).await?;
+            println!("{}", val);
+        }
         "PUT_TTL" if split.len() == 4 => {
             let key = split[1];
             let value = split[2];
@@ -491,6 +513,9 @@ fn cli_usage() -> String {
     \n\tput causal {key} {value} \t- store with multi-key causal consistency\
     \n\tput single_causal {key} {value} \t- store with single-key causal consistency\
     \n\tput_ttl {key} {value} {seconds} \t- store with TTL (auto-expires)\
+    \n\tincrement {key} [amount] \t- increment a counter (default +1)\
+    \n\tdecrement {key} [amount] \t- decrement a counter (default -1)\
+    \n\tget_counter {key} \t\t- get counter value\
     \n\tdelete {key} \t\t\t- delete a key from the KVS\
     \n\tbench [keys] [value_size] [duration] [workload] - run a benchmark\
     \n\tstart [component] \t\t- start anna processes (component: kvs, monitor, route; omit for all)\

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -216,6 +216,89 @@ async fn disk_tier_lattice_types() {
     test_all_lattice_types(&mut client, "disk").await;
 }
 
+const COUNTER_BASIC_OFFSET: u16 = 208;
+const COUNTER_DNE_OFFSET: u16 = 209;
+
+/// Test PN-Counter: increment, decrement, get_counter.
+#[tokio::test]
+#[cfg(unix)]
+async fn counter_basic() {
+    let config_path = generate_config(COUNTER_BASIC_OFFSET);
+    let _guard = ServerGuard::start(&config_path, COUNTER_BASIC_OFFSET);
+    let config = client_config(COUNTER_BASIC_OFFSET);
+    let mut client = KVSClient::new(&config, Some(7)).await;
+
+    // Increment 3 times
+    client
+        .increment("counter_key")
+        .await
+        .expect("increment 1 failed");
+    client
+        .increment("counter_key")
+        .await
+        .expect("increment 2 failed");
+    client
+        .increment("counter_key")
+        .await
+        .expect("increment 3 failed");
+
+    // Get counter value
+    let val = client
+        .get_counter("counter_key")
+        .await
+        .expect("get_counter failed");
+    assert_eq!(val, 3, "counter should be 3 after 3 increments");
+
+    // Increment by 10
+    client
+        .increment_by("counter_key", 10)
+        .await
+        .expect("increment_by failed");
+    let val = client
+        .get_counter("counter_key")
+        .await
+        .expect("get_counter failed");
+    assert_eq!(val, 13, "counter should be 13");
+
+    // Decrement by 5
+    client
+        .decrement_by("counter_key", 5)
+        .await
+        .expect("decrement_by failed");
+    let val = client
+        .get_counter("counter_key")
+        .await
+        .expect("get_counter failed");
+    assert_eq!(val, 8, "counter should be 8 after decrementing 5 from 13");
+
+    // Decrement by 1
+    client
+        .decrement("counter_key")
+        .await
+        .expect("decrement failed");
+    let val = client
+        .get_counter("counter_key")
+        .await
+        .expect("get_counter failed");
+    assert_eq!(val, 7, "counter should be 7");
+}
+
+/// Test that a counter that doesn't exist returns KEY_DNE.
+#[tokio::test]
+#[cfg(unix)]
+async fn counter_nonexistent_key() {
+    let config_path = generate_config(COUNTER_DNE_OFFSET);
+    let _guard = ServerGuard::start(&config_path, COUNTER_DNE_OFFSET);
+    let config = client_config(COUNTER_DNE_OFFSET);
+    let mut client = KVSClient::new(&config, Some(7)).await;
+
+    let result = client.get_counter("nonexistent_counter").await;
+    assert!(
+        result.is_err(),
+        "get_counter on nonexistent key should fail"
+    );
+}
+
 const TTL_EXPIRE_OFFSET: u16 = 210;
 const TTL_PERSIST_OFFSET: u16 = 220;
 const TTL_STRESS_OFFSET: u16 = 230;

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -81,6 +81,7 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | Cluster topology discovery (get_cluster_topology) | Yes |
 | Monitoring IP discovery (get_monitoring_ips) | Yes |
 | Per-key TTL (put_with_ttl) | Yes    |
+| PN-Counter (increment/decrement/get_counter) | Yes |
 
 ## C++ Client (`clients/cpp`)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -30,6 +30,9 @@ mocks.
 | PUT single_causal {key} {value} | Store with single-key causal consistency               | Yes           |
 | DELETE {key}               | Remove a key (PUT with empty value and dominating timestamp) | Yes           |
 | PUT_TTL {key} {val} {secs} | Store with TTL (auto-expires after N seconds)                | Yes           |
+| INCREMENT {key} [amount]   | Increment a PN-Counter (default +1)                          | Yes           |
+| DECREMENT {key} [amount]   | Decrement a PN-Counter (default -1)                          | Yes           |
+| GET_COUNTER {key}          | Get counter value (sum of increments - decrements)           | Yes           |
 | Address cache invalidation | Server signals client to refresh address cache               | Yes           |
 | Multi-key GET              | Retrieve multiple keys in one request                        | Yes           |
 
@@ -46,6 +49,7 @@ still supported as aliases for backward compatibility.
 | SINGLE_CAUSAL          | Single-key causal with vector clock                 | Yes           |
 | MULTI_CAUSAL           | Multi-key causal with vector clock and dependencies | Yes           |
 | PRIORITY               | Priority-value pair, lowest priority wins           | Yes           |
+| COUNTER                | PN-Counter CRDT (increment/decrement, per-node max) | Yes           |
 
 ## Single-Node Features
 

--- a/server/cpp/src/common.hpp
+++ b/server/cpp/src/common.hpp
@@ -19,6 +19,7 @@
 #include <sstream>
 
 #include "kvs.pb.h"
+#include "lattices/counter_lattice.hpp"
 #include "lattices/lww_pair_lattice.hpp"
 #include "lattices/multi_key_causal_lattice.hpp"
 #include "lattices/priority_lattice.hpp"
@@ -250,6 +251,32 @@ inline PriorityLattice<double, string> deserialize_priority(const string& serial
   pv.ParseFromString(serialized);
   return PriorityLattice<double, string>(
       PriorityValuePair<double, string>(pv.priority(), pv.value()));
+}
+
+inline string serialize(const CounterLattice& l) {
+  kvs::CounterValue cv;
+  for (const auto& p : l.reveal().increments) {
+    (*cv.mutable_increments())[p.first] = p.second;
+  }
+  for (const auto& p : l.reveal().decrements) {
+    (*cv.mutable_decrements())[p.first] = p.second;
+  }
+  string serialized;
+  cv.SerializeToString(&serialized);
+  return serialized;
+}
+
+inline CounterLattice deserialize_counter(const string& serialized) {
+  kvs::CounterValue cv;
+  cv.ParseFromString(serialized);
+  PNCounterState state;
+  for (const auto& p : cv.increments()) {
+    state.increments[p.first] = p.second;
+  }
+  for (const auto& p : cv.decrements()) {
+    state.decrements[p.first] = p.second;
+  }
+  return CounterLattice(state);
 }
 
 inline VectorClockValuePair<SetLattice<string>> to_vector_clock_value_pair(

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -199,6 +199,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
   Serializer *causal_ordered_set_serializer;
   Serializer *multi_causal_set_serializer;
   Serializer *multi_causal_ordered_set_serializer;
+  Serializer *counter_serializer;
 
   if (kSelfTier == Tier::MEMORY) {
     MemoryLWWKVS *lww_kvs = new MemoryLWWKVS();
@@ -249,6 +250,8 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
     multi_causal_set_serializer = new MemoryMultiKeyCausalSerializer(multi_causal_set_kvs);
     MemoryMultiKeyCausalKVS *multi_causal_ordered_set_kvs = new MemoryMultiKeyCausalKVS();
     multi_causal_ordered_set_serializer = new MemoryMultiKeyCausalSerializer(multi_causal_ordered_set_kvs);
+    MemoryCounterKVS *counter_kvs = new MemoryCounterKVS();
+    counter_serializer = new MemoryCounterSerializer(counter_kvs);
   } else if (kSelfTier == Tier::DISK) {
     lww_serializer = new DiskLWWSerializer(thread_id, disk_root);
     set_serializer = new DiskSetSerializer(thread_id, disk_root);
@@ -265,6 +268,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
     causal_ordered_set_serializer = new DiskSingleKeyCausalSerializer(thread_id, disk_root);
     multi_causal_set_serializer = new DiskMultiKeyCausalSerializer(thread_id, disk_root);
     multi_causal_ordered_set_serializer = new DiskMultiKeyCausalSerializer(thread_id, disk_root);
+    counter_serializer = new DiskCounterSerializer(thread_id, disk_root);
   } else {
     log->info("Invalid node type");
     exit(1);
@@ -285,6 +289,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
   serializers[kvs::LatticeType::CAUSAL_ORDERED_SET] = causal_ordered_set_serializer;
   serializers[kvs::LatticeType::MULTI_CAUSAL_SET] = multi_causal_set_serializer;
   serializers[kvs::LatticeType::MULTI_CAUSAL_ORDERED_SET] = multi_causal_ordered_set_serializer;
+  serializers[kvs::LatticeType::COUNTER] = counter_serializer;
 
   // the set of changes made on this thread since the last round of gossip
   set<Key> local_changeset;

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -52,6 +52,7 @@ typedef KVStore<Key, SingleKeyCausalLattice<SetLattice<string>>>
 typedef KVStore<Key, MultiKeyCausalLattice<SetLattice<string>>>
     MemoryMultiKeyCausalKVS;
 typedef KVStore<Key, PriorityLattice<double, string>> MemoryPriorityKVS;
+typedef KVStore<Key, CounterLattice> MemoryCounterKVS;
 
 // a map that represents which keys should be sent to which IP-port combinations
 typedef map<Address, set<Key>> AddressKeysetMap;
@@ -762,6 +763,83 @@ public:
 
   bool remove(const Key &key) override {
     return disk_remove(fname(key));
+  }
+};
+
+class MemoryCounterSerializer : public Serializer {
+  MemoryCounterKVS *kvs_;
+
+ public:
+  MemoryCounterSerializer(MemoryCounterKVS *kvs) : kvs_(kvs) {}
+
+  string get(const Key &key, kvs::AnnaError &error) override {
+    auto val = kvs_->get(key, error);
+    if (val.reveal().increments.empty() && val.reveal().decrements.empty()) {
+      error = kvs::AnnaError::KEY_DNE;
+    }
+    return serialize(val);
+  }
+
+  int put(const Key &key, const string &serialized) override {
+    CounterLattice val = deserialize_counter(serialized);
+    kvs_->put(key, val);
+    return static_cast<int>(kvs_->size(key));
+  }
+
+  bool remove(const Key &key) override {
+    kvs_->remove(key);
+    return true;
+  }
+};
+
+class DiskCounterSerializer : public Serializer {
+  unsigned tid_;
+  string disk_root_;
+
+ public:
+  DiskCounterSerializer(unsigned tid, const string &disk_root)
+      : tid_(tid), disk_root_(disk_root) {}
+
+  string get(const Key &key, kvs::AnnaError &error) override {
+    kvs::CounterValue value;
+    if (disk_read(disk_fname(disk_root_, tid_, key), value, error)) {
+      if (value.increments().empty() && value.decrements().empty()) {
+        error = kvs::AnnaError::KEY_DNE;
+      }
+      string serialized;
+      value.SerializeToString(&serialized);
+      return serialized;
+    }
+    return "";
+  }
+
+  int put(const Key &key, const string &serialized) override {
+    kvs::CounterValue input_value;
+    input_value.ParseFromString(serialized);
+
+    string path = disk_fname(disk_root_, tid_, key);
+    kvs::AnnaError error;
+    kvs::CounterValue original_value;
+
+    if (!disk_read(path, original_value, error)) {
+      return disk_write(path, input_value);
+    }
+
+    // Merge: per-node max for both increments and decrements.
+    for (const auto &p : input_value.increments()) {
+      auto &local = (*original_value.mutable_increments())[p.first];
+      if (p.second > local) local = p.second;
+    }
+    for (const auto &p : input_value.decrements()) {
+      auto &local = (*original_value.mutable_decrements())[p.first];
+      if (p.second > local) local = p.second;
+    }
+
+    return disk_write(path, original_value);
+  }
+
+  bool remove(const Key &key) override {
+    return disk_remove(disk_fname(disk_root_, tid_, key));
   }
 };
 

--- a/server/cpp/src/lattices/counter_lattice.hpp
+++ b/server/cpp/src/lattices/counter_lattice.hpp
@@ -1,0 +1,62 @@
+//  Copyright 2019 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef INCLUDE_LATTICES_COUNTER_LATTICE_HPP_
+#define INCLUDE_LATTICES_COUNTER_LATTICE_HPP_
+
+#include <string>
+#include "core_lattices.hpp"
+
+// PN-Counter state: per-node cumulative increments and decrements.
+struct PNCounterState {
+  std::map<std::string, unsigned long long> increments;
+  std::map<std::string, unsigned long long> decrements;
+
+  // Compute the counter value: sum(increments) - sum(decrements).
+  long long value() const {
+    unsigned long long pos = 0, neg = 0;
+    for (const auto &p : increments) pos += p.second;
+    for (const auto &p : decrements) neg += p.second;
+    return static_cast<long long>(pos) - static_cast<long long>(neg);
+  }
+};
+
+// PN-Counter lattice. The merge takes the per-node max for both
+// increments and decrements. This is commutative, associative,
+// and idempotent -- safe for gossip-based replication.
+class CounterLattice : public Lattice<PNCounterState> {
+ protected:
+  void do_merge(const PNCounterState &other) override {
+    for (const auto &p : other.increments) {
+      auto &local = this->element.increments[p.first];
+      if (p.second > local) local = p.second;
+    }
+    for (const auto &p : other.decrements) {
+      auto &local = this->element.decrements[p.first];
+      if (p.second > local) local = p.second;
+    }
+  }
+
+ public:
+  CounterLattice() : Lattice<PNCounterState>(PNCounterState()) {}
+  CounterLattice(const PNCounterState &s) : Lattice<PNCounterState>(s) {}
+
+  MaxLattice<unsigned> size() const {
+    // Return non-zero if the counter has any state.
+    return MaxLattice<unsigned>(
+        element.increments.size() + element.decrements.size() > 0 ? 1 : 0);
+  }
+};
+
+#endif  // INCLUDE_LATTICES_COUNTER_LATTICE_HPP_

--- a/server/cpp/tests/kvs/server_handler_base.hpp
+++ b/server/cpp/tests/kvs/server_handler_base.hpp
@@ -54,6 +54,8 @@ protected:
   MemoryOrderedSetKVS *ordered_set_kvs;
   MemorySingleKeyCausalKVS *sk_causal_kvs;
   MemoryPriorityKVS *priority_kvs;
+  Serializer *counter_serializer;
+  MemoryCounterKVS *counter_kvs;
 
   ServerHandlerTest() {
     lww_kvs = new MemoryLWWKVS();
@@ -71,11 +73,15 @@ protected:
     priority_kvs = new MemoryPriorityKVS();
     priority_serializer = new MemoryPrioritySerializer(priority_kvs);
 
+    counter_kvs = new MemoryCounterKVS();
+    counter_serializer = new MemoryCounterSerializer(counter_kvs);
+
     serializers[kvs::LatticeType::LWW] = lww_serializer;
     serializers[kvs::LatticeType::SET] = set_serializer;
     serializers[kvs::LatticeType::ORDERED_SET] = ordered_set_serializer;
     serializers[kvs::LatticeType::SINGLE_CAUSAL] = sk_causal_serializer;
     serializers[kvs::LatticeType::PRIORITY] = priority_serializer;
+    serializers[kvs::LatticeType::COUNTER] = counter_serializer;
 
     wt = ServerThread(ip, ip, thread_id);
     global_hash_rings[Tier::MEMORY].insert(ip, ip, 0, thread_id);
@@ -91,6 +97,8 @@ protected:
     delete serializers[kvs::LatticeType::ORDERED_SET];
     delete serializers[kvs::LatticeType::SINGLE_CAUSAL];
     delete serializers[kvs::LatticeType::PRIORITY];
+    delete counter_kvs;
+    delete serializers[kvs::LatticeType::COUNTER];
   }
 
 public:

--- a/server/cpp/tests/kvs/test_user_request_handler.hpp
+++ b/server/cpp/tests/kvs/test_user_request_handler.hpp
@@ -605,6 +605,105 @@ TEST_F(ServerHandlerTest, UserGetExpiredKeyReturnsDNE) {
   EXPECT_EQ(response.tuples(0).error(), kvs::AnnaError::KEY_DNE);
 }
 
+// Test PUT/GET for Counter lattice type.
+TEST_F(ServerHandlerTest, UserPutGetCounter) {
+  Key key = "counter_key";
+
+  // Build a CounterValue with one increment
+  kvs::CounterValue cv;
+  (*cv.mutable_increments())["node1"] = 5;
+  string payload;
+  cv.SerializeToString(&payload);
+
+  string put_counter =
+      put_key_request(key, kvs::LatticeType::COUNTER, payload, ip);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  user_request_handler(access_count, seed, put_counter, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  EXPECT_EQ(local_changeset.size(), 1);
+  EXPECT_EQ(stored_key_map[key].type(), kvs::LatticeType::COUNTER);
+
+  // GET should return the counter value
+  string get_req = get_key_request(key, ip);
+  size_t msg_count_before = mock_zmq_util.sent_messages.size();
+  user_request_handler(access_count, seed, get_req, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  ASSERT_GT(mock_zmq_util.sent_messages.size(), msg_count_before);
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+  EXPECT_EQ(response.tuples(0).error(), kvs::AnnaError::NO_ERROR);
+  EXPECT_EQ(response.tuples(0).lattice_type(), kvs::LatticeType::COUNTER);
+
+  // Verify the payload contains our increment
+  kvs::CounterValue result;
+  result.ParseFromString(response.tuples(0).payload());
+  EXPECT_EQ(result.increments().at("node1"), 5);
+}
+
+// Test Counter merge: two PUTs from different nodes merge via per-node max.
+TEST_F(ServerHandlerTest, UserCounterMerge) {
+  Key key = "merge_counter";
+
+  // First PUT: node1 increments 3
+  kvs::CounterValue cv1;
+  (*cv1.mutable_increments())["node1"] = 3;
+  string payload1;
+  cv1.SerializeToString(&payload1);
+
+  string put1 =
+      put_key_request(key, kvs::LatticeType::COUNTER, payload1, ip);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  user_request_handler(access_count, seed, put1, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  // Second PUT: node2 increments 7, node1 increments 2 (stale, should not override 3)
+  kvs::CounterValue cv2;
+  (*cv2.mutable_increments())["node2"] = 7;
+  (*cv2.mutable_increments())["node1"] = 2;
+  string payload2;
+  cv2.SerializeToString(&payload2);
+
+  string put2 =
+      put_key_request(key, kvs::LatticeType::COUNTER, payload2, ip);
+
+  local_changeset.clear();
+  user_request_handler(access_count, seed, put2, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  // GET and verify merge: node1=max(3,2)=3, node2=7
+  string get_req = get_key_request(key, ip);
+  size_t msg_count_before = mock_zmq_util.sent_messages.size();
+  user_request_handler(access_count, seed, get_req, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  ASSERT_GT(mock_zmq_util.sent_messages.size(), msg_count_before);
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+
+  kvs::CounterValue result;
+  result.ParseFromString(response.tuples(0).payload());
+  EXPECT_EQ(result.increments().at("node1"), 3);  // max(3, 2) = 3
+  EXPECT_EQ(result.increments().at("node2"), 7);
+}
+
 // TODO: Test key address cache invalidation
 // TODO: Test replication factor request and making the request pending
 // TODO: Test metadata operations -- does this matter?

--- a/server/protobuf/kvs.proto
+++ b/server/protobuf/kvs.proto
@@ -89,6 +89,11 @@ enum LatticeType {
 
   // Multi-key causal ordered set: like MULTI_CAUSAL_SET but ordered.
   MULTI_CAUSAL_ORDERED_SET = 15;
+
+  // PN-Counter: conflict-free increment/decrement counter.
+  // Each node tracks its own cumulative increments and decrements.
+  // The merge is per-node max. The counter value is sum(increments) - sum(decrements).
+  COUNTER = 16;
 }
 
 enum AnnaError {
@@ -247,6 +252,16 @@ message MultiKeyCausalValue {
   
   // The set of potentially causally concurrent values for this key.
   repeated bytes values = 3;
+}
+
+// Serialization of PN-Counter lattices. Each node tracks its own cumulative
+// increments and decrements. The merge takes the max per node. The counter
+// value is sum(all increments) - sum(all decrements).
+message CounterValue {
+  // Per-node cumulative positive counts (monotonically increasing).
+  map<string, uint64> increments = 1;
+  // Per-node cumulative negative counts (monotonically increasing).
+  map<string, uint64> decrements = 2;
 }
 
 // Serialization of lowest-priority-wins lattices.


### PR DESCRIPTION
## Summary

Adds a new COUNTER lattice type (16) based on the PN-Counter CRDT. Supports atomic increment and decrement operations that converge correctly under gossip replication.

### How it works

Each client has a unique node ID (`client_ip:tid`). It only writes to its own slot in two maps:
- `increments[node_id]`: cumulative positive count (monotonically increasing)
- `decrements[node_id]`: cumulative negative count (monotonically increasing)

The merge rule is **per-node max** for both maps. The counter value is `sum(increments) - sum(decrements)`.

### Changes

| Component | What |
|---|---|
| `kvs.proto` | `COUNTER = 16`, `CounterValue` message |
| `counter_lattice.hpp` | `CounterLattice` with `PNCounterState` and `do_merge` |
| `common.hpp` | `serialize`/`deserialize_counter` |
| `server_utils.hpp` | `MemoryCounterSerializer`, `DiskCounterSerializer` |
| `server.cpp` | Register counter serializer |
| `kvs_client.rs` | `increment`, `increment_by`, `decrement`, `decrement_by`, `get_counter` |
| `main.rs` | `INCREMENT`, `DECREMENT`, `GET_COUNTER` CLI commands |
| `lattice_types.rs` | 2 integration tests |
| `feature-list.md` | Counter operations and lattice type documented |
| `client-feature-list.md` | PN-Counter listed for Rust client |

### Tests

- **counter_basic**: increment 3x, increment_by 10, decrement_by 5, decrement 1 -- verifies value at each step (3→13→8→7)
- **counter_nonexistent_key**: get_counter on missing key returns error

Closes #511