### PR TITLE
Add batch PUT support (put_multi)

### DIFF
--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -1787,6 +1787,121 @@ impl KVSClient {
         Ok(results)
     }
 
+    /// Batch PUT multiple LWW key-value pairs in a single request per worker.
+    ///
+    /// Groups keys by responsible worker and sends one `KeyRequest` with
+    /// multiple tuples to each worker. This is more efficient than calling
+    /// `put()` in a loop because it reduces the number of network round-trips.
+    ///
+    /// Returns `Ok(())` if all keys were written successfully. On
+    /// `WRONG_THREAD` errors, retries up to 3 times with refreshed routing.
+    pub async fn put_multi(&mut self, keys_values: &[(&str, &str)]) -> Result<()> {
+        if keys_values.is_empty() {
+            return Ok(());
+        }
+
+        const MAX_RETRIES: usize = 3;
+        let mut pending: Vec<(String, String)> = keys_values
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        for attempt in 0..=MAX_RETRIES {
+            if pending.is_empty() {
+                break;
+            }
+
+            // Group by worker address.
+            let mut worker_kvs: HashMap<Address, Vec<(String, String)>> = HashMap::new();
+            for (key, value) in &pending {
+                if let Some(worker) = self.get_worker_address(key).await {
+                    worker_kvs
+                        .entry(worker)
+                        .or_default()
+                        .push((key.clone(), value.clone()));
+                } else {
+                    return Err(Error::Kvs(format!(
+                        "PUT_MULTI: failed to resolve address for key {}",
+                        key
+                    )));
+                }
+            }
+
+            let mut retry_keys = Vec::new();
+
+            for (worker, batch) in &worker_kvs {
+                let mut request = KeyRequest {
+                    request_id: self.get_request_id(),
+                    response_address: self.ut.response_connect_address(),
+                    r#type: RequestType::Put as i32,
+                    ..Default::default()
+                };
+
+                for (key, value) in batch {
+                    let ts = std::cmp::max(Self::generate_timestamp(), self.last_seen_ts + 1);
+                    self.last_seen_ts = ts;
+                    let lww = LwwValue {
+                        timestamp: ts,
+                        value: value.as_bytes().to_vec(),
+                    };
+                    let payload = lww.encode_to_vec();
+
+                    let mut tuple = KeyTuple {
+                        key: key.clone(),
+                        lattice_type: LatticeType::Lww as i32,
+                        payload,
+                        ..Default::default()
+                    };
+                    if let Some(cache) = self.key_address_cache.get(key) {
+                        tuple.address_cache_size = cache.len() as u32;
+                    }
+                    request.tuples.push(tuple);
+
+                    // Cache for read-your-writes.
+                    self.lww_read_cache
+                        .insert(key.clone(), (lww.timestamp, lww.value.clone()));
+                }
+
+                let encoded = request.encode_to_vec();
+                self.send_request(&encoded, worker).await?;
+
+                match self.recv_response(false).await {
+                    Some(data) => {
+                        let response = KeyResponse::decode(data.as_slice())
+                            .map_err(|e| Error::Kvs(format!("PUT_MULTI: decode error: {}", e)))?;
+
+                        for tuple in &response.tuples {
+                            if tuple.invalidate {
+                                self.key_address_cache.remove(&tuple.key);
+                            }
+                            if tuple.error == AnnaError::WrongThread as i32 {
+                                self.key_address_cache.remove(&tuple.key);
+                                if attempt < MAX_RETRIES {
+                                    // Find the original value to retry.
+                                    if let Some((_, v)) =
+                                        batch.iter().find(|(k, _)| k == &tuple.key)
+                                    {
+                                        retry_keys.push((tuple.key.clone(), v.clone()));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    None => {
+                        for (key, _) in batch {
+                            self.key_address_cache.remove(key);
+                        }
+                        return Err(Error::Kvs("PUT_MULTI: request timed out".into()));
+                    }
+                }
+            }
+
+            pending = retry_keys;
+        }
+
+        Ok(())
+    }
+
     /// Set the per-key replication factor by writing to the metadata key.
     ///
     /// The replication metadata is stored as an LWW value containing a
@@ -3162,6 +3277,44 @@ mod tests {
             .expect("put_with_ttl failed");
         // TTL values should NOT be cached (they'd be stale after expiry)
         assert!(!client.lww_read_cache.contains_key("ttl_key"));
+    }
+
+    #[tokio::test]
+    async fn put_multi_batches_keys() {
+        let worker = "tcp://127.0.0.1:6200";
+        let mut client = mock_client(236);
+        // Two keys routed to the same worker -> one batched request.
+        client.push_mock_response(true, Some(make_routing_response("mk1", worker)));
+        client.push_mock_response(true, Some(make_routing_response("mk2", worker)));
+        // One response for the batch.
+        let batch_response = KeyResponse {
+            r#type: RequestType::Put as i32,
+            tuples: vec![
+                KeyTuple {
+                    key: "mk1".into(),
+                    ..Default::default()
+                },
+                KeyTuple {
+                    key: "mk2".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        client.push_mock_response(false, Some(batch_response.encode_to_vec()));
+        client
+            .put_multi(&[("mk1", "v1"), ("mk2", "v2")])
+            .await
+            .expect("put_multi failed");
+        // Both should be in read cache.
+        assert!(client.lww_read_cache.contains_key("mk1"));
+        assert!(client.lww_read_cache.contains_key("mk2"));
+    }
+
+    #[tokio::test]
+    async fn put_multi_empty_is_ok() {
+        let mut client = mock_client(237);
+        client.put_multi(&[]).await.expect("empty put_multi failed");
     }
 
     fn make_counter_response(key: &str, inc_val: u64) -> Vec<u8> {

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -382,6 +382,10 @@ async fn execute_command(
             client.put_value(&key, &value).await?;
         }
         "DELETE" if split.len() == 2 => client.delete(split[1]).await?,
+        "PUT_MULTI" if split.len() >= 3 && (split.len() - 1) % 2 == 0 => {
+            let pairs: Vec<(&str, &str)> = split[1..].chunks(2).map(|c| (c[0], c[1])).collect();
+            client.put_multi(&pairs).await?;
+        }
         "INCREMENT" if split.len() == 2 => {
             client.increment(split[1]).await?;
         }
@@ -512,6 +516,7 @@ fn cli_usage() -> String {
     \n\tput priority {key} {pri} {val} \t- store with priority (lowest wins)\
     \n\tput causal {key} {value} \t- store with multi-key causal consistency\
     \n\tput single_causal {key} {value} \t- store with single-key causal consistency\
+    \n\tput_multi {k1} {v1} {k2} {v2} ... \t- batch PUT multiple keys\
     \n\tput_ttl {key} {value} {seconds} \t- store with TTL (auto-expires)\
     \n\tincrement {key} [amount] \t- increment a counter (default +1)\
     \n\tdecrement {key} [amount] \t- decrement a counter (default -1)\

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -216,6 +216,38 @@ async fn disk_tier_lattice_types() {
     test_all_lattice_types(&mut client, "disk").await;
 }
 
+const BATCH_PUT_OFFSET: u16 = 207;
+
+/// Test put_multi: batch PUT multiple keys, verify all readable.
+#[tokio::test]
+#[cfg(unix)]
+async fn batch_put_and_get() {
+    let config_path = generate_config(BATCH_PUT_OFFSET);
+    let _guard = ServerGuard::start(&config_path, BATCH_PUT_OFFSET);
+    let config = client_config(BATCH_PUT_OFFSET);
+    let mut client = KVSClient::new(&config, Some(7)).await;
+
+    let pairs: Vec<(&str, &str)> = (0..10)
+        .map(|i| {
+            // Leak strings to get &str with 'static lifetime for the vec
+            let k: &str = Box::leak(format!("batch_key_{}", i).into_boxed_str());
+            let v: &str = Box::leak(format!("batch_val_{}", i).into_boxed_str());
+            (k, v)
+        })
+        .collect();
+
+    client.put_multi(&pairs).await.expect("put_multi failed");
+
+    // Verify all keys are readable.
+    for i in 0..10 {
+        let val = client
+            .get(&format!("batch_key_{}", i))
+            .await
+            .unwrap_or_else(|e| panic!("GET batch_key_{} failed: {}", i, e));
+        assert_eq!(val, format!("batch_val_{}", i));
+    }
+}
+
 const COUNTER_BASIC_OFFSET: u16 = 208;
 const COUNTER_DNE_OFFSET: u16 = 209;
 

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -82,6 +82,7 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | Monitoring IP discovery (get_monitoring_ips) | Yes |
 | Per-key TTL (put_with_ttl) | Yes    |
 | PN-Counter (increment/decrement/get_counter) | Yes |
+| Batch PUT (put_multi)    | Yes    |
 
 ## C++ Client (`clients/cpp`)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -35,6 +35,7 @@ mocks.
 | GET_COUNTER {key}          | Get counter value (sum of increments - decrements)           | Yes           |
 | Address cache invalidation | Server signals client to refresh address cache               | Yes           |
 | Multi-key GET              | Retrieve multiple keys in one request                        | Yes           |
+| Multi-key PUT (put_multi)  | Batch PUT multiple keys in one request per worker            | Yes           |
 
 Legacy commands (`GET_SET`, `PUT_SET`, `GET_CAUSAL`, `PUT_CAUSAL`, etc.) are
 still supported as aliases for backward compatibility.


### PR DESCRIPTION
## Summary

Client-only change. The server already processes multiple tuples per `KeyRequest` -- `put_multi` groups keys by responsible worker and sends one batched request per worker.

### Client API

```rust
client.put_multi(&[("key1", "val1"), ("key2", "val2"), ("key3", "val3")]).await?;
```

Groups keys by worker address (like `get_multi`), builds one `KeyRequest` with multiple `KeyTuple` entries per worker, handles `WRONG_THREAD` retries, and caches writes for read-your-writes consistency.

### CLI

```
PUT_MULTI k1 v1 k2 v2 k3 v3
```

### Tests

- **put_multi_batches_keys**: unit test with mock, verifies both keys cached
- **put_multi_empty_is_ok**: unit test for empty input
- **batch_put_and_get**: integration test, 10 keys PUT then all GET verified

### No server changes

`user_request_handler.cpp` already iterates `request.tuples()` in a loop -- batch PUT works out of the box.

Closes #515