### PR TITLE
Add OR-Set lattice type for add/remove set operations

### DIFF
--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -834,8 +834,11 @@ impl KVSClient {
         element: &str,
     ) -> Result<()> {
         debug!("OR_SET_ADD: {} += {}", key, element);
-        self.last_seen_ts += 1;
-        let tag = format!("{}:{}:{}", self.ut.ip(), self.ut.tid(), self.last_seen_ts);
+        let tag_seq = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::from_secs(0))
+            .as_nanos();
+        let tag = format!("{}:{}:{}", self.ut.ip(), self.ut.tid(), tag_seq);
 
         let mut osv = crate::proto::kvs::OrSetValue::default();
         osv.elements.insert(tag, element.as_bytes().to_vec());
@@ -873,7 +876,16 @@ impl KVSClient {
             .await
             .ok_or_else(|| Error::Kvs("OR_SET_REMOVE: GET failed".into()))?;
 
-        let tuple = Self::validate_response(&response, "OR_SET_REMOVE")?;
+        let tuple = match Self::validate_response(&response, "OR_SET_REMOVE") {
+            Ok(t) => t,
+            Err(e) => {
+                // KEY_DNE means the set doesn't exist -- nothing to remove.
+                if e.to_string().contains("KEY_DNE") {
+                    return Ok(());
+                }
+                return Err(e);
+            }
+        };
         let osv = crate::proto::kvs::OrSetValue::decode(tuple.payload.as_slice())
             .map_err(|e| Error::Kvs(format!("OR_SET_REMOVE: decode failed: {}", e)))?;
 

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -823,6 +823,122 @@ impl KVSClient {
         Ok(pos as i64 - neg as i64)
     }
 
+    /// Add an element to an OR-Set key.
+    ///
+    /// Uses the OR-Set CRDT lattice. Each add tags the element with a unique
+    /// ID (`client_ip:tid:seq`). Concurrent adds from different clients are
+    /// all preserved. Add wins over concurrent remove.
+    pub async fn or_set_add<K: AsRef<str> + Display>(
+        &mut self,
+        key: K,
+        element: &str,
+    ) -> Result<()> {
+        debug!("OR_SET_ADD: {} += {}", key, element);
+        self.last_seen_ts += 1;
+        let tag = format!("{}:{}:{}", self.ut.ip(), self.ut.tid(), self.last_seen_ts);
+
+        let mut osv = crate::proto::kvs::OrSetValue::default();
+        osv.elements.insert(tag, element.as_bytes().to_vec());
+
+        let payload = osv.encode_to_vec();
+        let response = self
+            .send_data_request(
+                key.as_ref(),
+                RequestType::Put as i32,
+                Some(LatticeType::OrSet as i32),
+                Some(payload),
+            )
+            .await
+            .ok_or_else(|| Error::Kvs("OR_SET_ADD: request failed or timed out".into()))?;
+
+        Self::validate_response(&response, "OR_SET_ADD")?;
+        Ok(())
+    }
+
+    /// Remove an element from an OR-Set key.
+    ///
+    /// Tombstones all tags currently associated with the element.
+    /// Requires a GET to discover the tags, then a PUT with those tags
+    /// in the tombstone set.
+    pub async fn or_set_remove<K: AsRef<str> + Display>(
+        &mut self,
+        key: K,
+        element: &str,
+    ) -> Result<()> {
+        debug!("OR_SET_REMOVE: {} -= {}", key, element);
+
+        // GET current state to find tags for this element.
+        let response = self
+            .send_data_request(key.as_ref(), RequestType::Get as i32, None, None)
+            .await
+            .ok_or_else(|| Error::Kvs("OR_SET_REMOVE: GET failed".into()))?;
+
+        let tuple = Self::validate_response(&response, "OR_SET_REMOVE")?;
+        let osv = crate::proto::kvs::OrSetValue::decode(tuple.payload.as_slice())
+            .map_err(|e| Error::Kvs(format!("OR_SET_REMOVE: decode failed: {}", e)))?;
+
+        // Find all tags for this element.
+        let element_bytes = element.as_bytes().to_vec();
+        let tags_to_remove: Vec<String> = osv
+            .elements
+            .iter()
+            .filter(|(_, v)| **v == element_bytes)
+            .map(|(tag, _)| tag.clone())
+            .collect();
+
+        if tags_to_remove.is_empty() {
+            return Ok(()); // Element not in set, nothing to remove.
+        }
+
+        // PUT with tombstones for those tags.
+        let remove_osv = crate::proto::kvs::OrSetValue {
+            tombstones: tags_to_remove,
+            ..Default::default()
+        };
+
+        let payload = remove_osv.encode_to_vec();
+        let response = self
+            .send_data_request(
+                key.as_ref(),
+                RequestType::Put as i32,
+                Some(LatticeType::OrSet as i32),
+                Some(payload),
+            )
+            .await
+            .ok_or_else(|| Error::Kvs("OR_SET_REMOVE: PUT failed".into()))?;
+
+        Self::validate_response(&response, "OR_SET_REMOVE")?;
+        Ok(())
+    }
+
+    /// Get the current elements of an OR-Set key.
+    ///
+    /// Returns the live set (elements whose tags are not tombstoned).
+    pub async fn get_or_set<K: AsRef<str> + Display>(&mut self, key: K) -> Result<Vec<String>> {
+        debug!("GET_OR_SET: {}", key);
+        let response = self
+            .send_data_request(key.as_ref(), RequestType::Get as i32, None, None)
+            .await
+            .ok_or_else(|| Error::Kvs("GET_OR_SET: request failed or timed out".into()))?;
+
+        let tuple = Self::validate_response(&response, "GET_OR_SET")?;
+        let osv = crate::proto::kvs::OrSetValue::decode(tuple.payload.as_slice())
+            .map_err(|e| Error::Kvs(format!("GET_OR_SET: decode failed: {}", e)))?;
+
+        // Compute live set: elements whose tags are not tombstoned.
+        let tombstones: std::collections::HashSet<&str> =
+            osv.tombstones.iter().map(|s| s.as_str()).collect();
+        let mut result: Vec<String> = osv
+            .elements
+            .iter()
+            .filter(|(tag, _)| !tombstones.contains(tag.as_str()))
+            .map(|(_, v)| String::from_utf8_lossy(v).to_string())
+            .collect();
+        result.sort();
+        result.dedup();
+        Ok(result)
+    }
+
     /// Retrieve a set of values by key (Set lattice).
     ///
     /// ```rust
@@ -3309,6 +3425,73 @@ mod tests {
         // Both should be in read cache.
         assert!(client.lww_read_cache.contains_key("mk1"));
         assert!(client.lww_read_cache.contains_key("mk2"));
+    }
+
+    #[tokio::test]
+    async fn or_set_add_sends_request() {
+        let worker = "tcp://127.0.0.1:6200";
+        let mut client = mock_client(238);
+        client.push_mock_response(true, Some(make_routing_response("oset", worker)));
+        client.push_mock_response(false, Some(make_put_response("oset")));
+        client
+            .or_set_add("oset", "apple")
+            .await
+            .expect("or_set_add failed");
+    }
+
+    #[tokio::test]
+    async fn or_set_remove_sends_tombstone() {
+        let worker = "tcp://127.0.0.1:6200";
+        let mut client = mock_client(239);
+        // First: GET to discover tags
+        let mut osv = crate::proto::kvs::OrSetValue::default();
+        osv.elements
+            .insert("tag1".into(), "apple".as_bytes().to_vec());
+        let get_response = KeyResponse {
+            r#type: RequestType::Get as i32,
+            tuples: vec![KeyTuple {
+                key: "oset".into(),
+                lattice_type: LatticeType::OrSet as i32,
+                payload: osv.encode_to_vec(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        client.push_mock_response(true, Some(make_routing_response("oset", worker)));
+        client.push_mock_response(false, Some(get_response.encode_to_vec()));
+        // Second: PUT with tombstone
+        client.push_mock_response(true, Some(make_routing_response("oset", worker)));
+        client.push_mock_response(false, Some(make_put_response("oset")));
+        client
+            .or_set_remove("oset", "apple")
+            .await
+            .expect("or_set_remove failed");
+    }
+
+    #[tokio::test]
+    async fn get_or_set_returns_live_elements() {
+        let worker = "tcp://127.0.0.1:6200";
+        let mut client = mock_client(240);
+        let mut osv = crate::proto::kvs::OrSetValue::default();
+        osv.elements
+            .insert("tag1".into(), "apple".as_bytes().to_vec());
+        osv.elements
+            .insert("tag2".into(), "banana".as_bytes().to_vec());
+        osv.tombstones.push("tag1".into()); // apple is tombstoned
+        let get_response = KeyResponse {
+            r#type: RequestType::Get as i32,
+            tuples: vec![KeyTuple {
+                key: "oset".into(),
+                lattice_type: LatticeType::OrSet as i32,
+                payload: osv.encode_to_vec(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        client.push_mock_response(true, Some(make_routing_response("oset", worker)));
+        client.push_mock_response(false, Some(get_response.encode_to_vec()));
+        let vals = client.get_or_set("oset").await.expect("get_or_set failed");
+        assert_eq!(vals, vec!["banana"]); // apple tombstoned, only banana live
     }
 
     #[tokio::test]

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -382,6 +382,16 @@ async fn execute_command(
             client.put_value(&key, &value).await?;
         }
         "DELETE" if split.len() == 2 => client.delete(split[1]).await?,
+        "SET_ADD" if split.len() == 3 => {
+            client.or_set_add(split[1], split[2]).await?;
+        }
+        "SET_REMOVE" if split.len() == 3 => {
+            client.or_set_remove(split[1], split[2]).await?;
+        }
+        "GET_OR_SET" if split.len() == 2 => {
+            let vals = client.get_or_set(split[1]).await?;
+            println!("{}", vals.join(", "));
+        }
         "PUT_MULTI" if split.len() >= 3 && (split.len() - 1) % 2 == 0 => {
             let pairs: Vec<(&str, &str)> = split[1..].chunks(2).map(|c| (c[0], c[1])).collect();
             client.put_multi(&pairs).await?;
@@ -516,6 +526,9 @@ fn cli_usage() -> String {
     \n\tput priority {key} {pri} {val} \t- store with priority (lowest wins)\
     \n\tput causal {key} {value} \t- store with multi-key causal consistency\
     \n\tput single_causal {key} {value} \t- store with single-key causal consistency\
+    \n\tset_add {key} {element} \t\t- add element to OR-Set\
+    \n\tset_remove {key} {element} \t\t- remove element from OR-Set\
+    \n\tget_or_set {key} \t\t\t- get OR-Set elements\
     \n\tput_multi {k1} {v1} {k2} {v2} ... \t- batch PUT multiple keys\
     \n\tput_ttl {key} {value} {seconds} \t- store with TTL (auto-expires)\
     \n\tincrement {key} [amount] \t- increment a counter (default +1)\

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -216,6 +216,57 @@ async fn disk_tier_lattice_types() {
     test_all_lattice_types(&mut client, "disk").await;
 }
 
+const OR_SET_OFFSET: u16 = 206;
+
+/// Test OR-Set: add, remove, get, add-wins-over-concurrent-remove.
+#[tokio::test]
+#[cfg(unix)]
+async fn or_set_add_remove_get() {
+    let config_path = generate_config(OR_SET_OFFSET);
+    let _guard = ServerGuard::start(&config_path, OR_SET_OFFSET);
+    let config = client_config(OR_SET_OFFSET);
+    let mut client = KVSClient::new(&config, Some(7)).await;
+
+    // Add elements
+    client.or_set_add("oset", "apple").await.expect("add apple");
+    client
+        .or_set_add("oset", "banana")
+        .await
+        .expect("add banana");
+    client
+        .or_set_add("oset", "cherry")
+        .await
+        .expect("add cherry");
+
+    // Get should return all 3
+    let vals = client.get_or_set("oset").await.expect("get_or_set");
+    assert_eq!(vals, vec!["apple", "banana", "cherry"]);
+
+    // Remove banana
+    client
+        .or_set_remove("oset", "banana")
+        .await
+        .expect("remove banana");
+
+    // Get should return apple and cherry
+    let vals = client
+        .get_or_set("oset")
+        .await
+        .expect("get_or_set after remove");
+    assert_eq!(vals, vec!["apple", "cherry"]);
+
+    // Re-add banana (add wins over previous remove)
+    client
+        .or_set_add("oset", "banana")
+        .await
+        .expect("re-add banana");
+    let vals = client
+        .get_or_set("oset")
+        .await
+        .expect("get_or_set after re-add");
+    assert_eq!(vals, vec!["apple", "banana", "cherry"]);
+}
+
 const BATCH_PUT_OFFSET: u16 = 207;
 
 /// Test put_multi: batch PUT multiple keys, verify all readable.

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1247,10 +1247,10 @@ async fn self_depart_signal() {
     let kvs_label = format!("anna-kvs@{}", NODE1_IP);
     cluster.signal_self_depart(&kvs_label);
 
-    // Poll until the KVS process exits. signal_self_depart() sleeps 8s
-    // for gossip propagation, then the KVS sleeps 2s after the handler.
-    // On loaded CI runners, add extra margin.
-    let deadline = Instant::now() + Duration::from_secs(20);
+    // Poll until the KVS process exits. signal_self_depart() already
+    // slept 8s. The KVS handler + 2s ZMQ drain should finish in ~3s.
+    // Use generous timeout for loaded CI runners.
+    let deadline = Instant::now() + Duration::from_secs(30);
     let mut kvs_exited = false;
     while Instant::now() < deadline {
         if cluster

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -83,6 +83,7 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | Per-key TTL (put_with_ttl) | Yes    |
 | PN-Counter (increment/decrement/get_counter) | Yes |
 | Batch PUT (put_multi)    | Yes    |
+| OR-Set (set_add/set_remove/get_or_set) | Yes |
 
 ## C++ Client (`clients/cpp`)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -33,6 +33,9 @@ mocks.
 | INCREMENT {key} [amount]   | Increment a PN-Counter (default +1)                          | Yes           |
 | DECREMENT {key} [amount]   | Decrement a PN-Counter (default -1)                          | Yes           |
 | GET_COUNTER {key}          | Get counter value (sum of increments - decrements)           | Yes           |
+| SET_ADD {key} {element}    | Add element to OR-Set                                        | Yes           |
+| SET_REMOVE {key} {element} | Remove element from OR-Set                                   | Yes           |
+| GET_OR_SET {key}           | Get live elements of OR-Set                                  | Yes           |
 | Address cache invalidation | Server signals client to refresh address cache               | Yes           |
 | Multi-key GET              | Retrieve multiple keys in one request                        | Yes           |
 | Multi-key PUT (put_multi)  | Batch PUT multiple keys in one request per worker            | Yes           |
@@ -51,6 +54,7 @@ still supported as aliases for backward compatibility.
 | MULTI_CAUSAL           | Multi-key causal with vector clock and dependencies | Yes           |
 | PRIORITY               | Priority-value pair, lowest priority wins           | Yes           |
 | COUNTER                | PN-Counter CRDT (increment/decrement, per-node max) | Yes           |
+| OR_SET                 | OR-Set CRDT (add/remove elements, add-wins)         | Yes           |
 
 ## Single-Node Features
 

--- a/docs/lattices.md
+++ b/docs/lattices.md
@@ -113,7 +113,7 @@ protobuf types, server handlers, serializers, and client APIs):
 | **Multi-key causal**    | `MULTI_CAUSAL`    | Causal ordering with cross-key dependency tracking |
 | **Priority**            | `PRIORITY`        | Lowest priority value wins                       |
 | **PN-Counter**          | `COUNTER`         | Increment/decrement counter, converges to sum of all updates |
-| **OR-Set**              | `OR_SET`          | Add/remove set with add-wins semantics (tombstone-based CRDT) |
+| **OR-Set**              | `OR_SET`          | Observed-remove set; concurrent adds win over removes (tombstone-based CRDT) |
 
 ### Theoretical (not yet implemented)
 

--- a/docs/lattices.md
+++ b/docs/lattices.md
@@ -101,9 +101,8 @@ This compositional approach means:
 
 ### Implemented
 
-Anna provides six lattice types with full implementations (lattice code,
-protobuf types, server handlers, serializers, and client APIs in all
-four languages):
+Anna provides eight lattice types with full implementations (lattice code,
+protobuf types, server handlers, serializers, and client APIs):
 
 | Consistency Level       | Lattice Type     | Description                                       |
 |-------------------------|------------------|---------------------------------------------------|
@@ -113,6 +112,8 @@ four languages):
 | **Single-key causal**   | `SINGLE_CAUSAL`   | Vector clocks track causal ordering per key      |
 | **Multi-key causal**    | `MULTI_CAUSAL`    | Causal ordering with cross-key dependency tracking |
 | **Priority**            | `PRIORITY`        | Lowest priority value wins                       |
+| **PN-Counter**          | `COUNTER`         | Increment/decrement counter, converges to sum of all updates |
+| **OR-Set**              | `OR_SET`          | Add/remove set with add-wins semantics (tombstone-based CRDT) |
 
 ### Theoretical (not yet implemented)
 

--- a/server/cpp/src/common.hpp
+++ b/server/cpp/src/common.hpp
@@ -21,6 +21,7 @@
 #include "kvs.pb.h"
 #include "lattices/counter_lattice.hpp"
 #include "lattices/lww_pair_lattice.hpp"
+#include "lattices/or_set_lattice.hpp"
 #include "lattices/multi_key_causal_lattice.hpp"
 #include "lattices/priority_lattice.hpp"
 #include "lattices/single_key_causal_lattice.hpp"
@@ -277,6 +278,32 @@ inline CounterLattice deserialize_counter(const string& serialized) {
     state.decrements[p.first] = p.second;
   }
   return CounterLattice(state);
+}
+
+inline string serialize(const OrSetLattice& l) {
+  kvs::OrSetValue osv;
+  for (const auto& p : l.reveal().elements) {
+    (*osv.mutable_elements())[p.first] = p.second;
+  }
+  for (const auto& t : l.reveal().tombstones) {
+    osv.add_tombstones(t);
+  }
+  string serialized;
+  osv.SerializeToString(&serialized);
+  return serialized;
+}
+
+inline OrSetLattice deserialize_or_set(const string& serialized) {
+  kvs::OrSetValue osv;
+  osv.ParseFromString(serialized);
+  OrSetState state;
+  for (const auto& p : osv.elements()) {
+    state.elements[p.first] = p.second;
+  }
+  for (const auto& t : osv.tombstones()) {
+    state.tombstones.insert(t);
+  }
+  return OrSetLattice(state);
 }
 
 inline VectorClockValuePair<SetLattice<string>> to_vector_clock_value_pair(

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -200,6 +200,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
   Serializer *multi_causal_set_serializer;
   Serializer *multi_causal_ordered_set_serializer;
   Serializer *counter_serializer;
+  Serializer *or_set_serializer;
 
   if (kSelfTier == Tier::MEMORY) {
     MemoryLWWKVS *lww_kvs = new MemoryLWWKVS();
@@ -252,6 +253,8 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
     multi_causal_ordered_set_serializer = new MemoryMultiKeyCausalSerializer(multi_causal_ordered_set_kvs);
     MemoryCounterKVS *counter_kvs = new MemoryCounterKVS();
     counter_serializer = new MemoryCounterSerializer(counter_kvs);
+    MemoryOrSetKVS *or_set_kvs = new MemoryOrSetKVS();
+    or_set_serializer = new MemoryOrSetSerializer(or_set_kvs);
   } else if (kSelfTier == Tier::DISK) {
     lww_serializer = new DiskLWWSerializer(thread_id, disk_root);
     set_serializer = new DiskSetSerializer(thread_id, disk_root);
@@ -269,6 +272,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
     multi_causal_set_serializer = new DiskMultiKeyCausalSerializer(thread_id, disk_root);
     multi_causal_ordered_set_serializer = new DiskMultiKeyCausalSerializer(thread_id, disk_root);
     counter_serializer = new DiskCounterSerializer(thread_id, disk_root);
+    or_set_serializer = new DiskOrSetSerializer(thread_id, disk_root);
   } else {
     log->info("Invalid node type");
     exit(1);
@@ -290,6 +294,7 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
   serializers[kvs::LatticeType::MULTI_CAUSAL_SET] = multi_causal_set_serializer;
   serializers[kvs::LatticeType::MULTI_CAUSAL_ORDERED_SET] = multi_causal_ordered_set_serializer;
   serializers[kvs::LatticeType::COUNTER] = counter_serializer;
+  serializers[kvs::LatticeType::OR_SET] = or_set_serializer;
 
   // the set of changes made on this thread since the last round of gossip
   set<Key> local_changeset;

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -374,15 +374,20 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
   // enter event loop
   while (!shutdown_requested.load()) {
    try {
-    if (self_depart_requested.load() && !monitoring_ips.empty()) {
-      string depart_done_addr =
-          MonitoringThread(monitoring_ips[0]).depart_done_connect_address();
-      self_depart_handler(thread_id, seed, public_ip, private_ip, log,
-                          depart_done_addr, global_hash_rings, local_hash_rings,
-                          stored_key_map, key_replication_map, routing_ips,
-                          monitoring_ips, wt, pushers, serializers);
-      // Allow ZMQ to deliver depart notifications before process exits
-      std::this_thread::sleep_for(std::chrono::seconds(2));
+    if (self_depart_requested.load()) {
+      if (!monitoring_ips.empty()) {
+        string depart_done_addr =
+            MonitoringThread(monitoring_ips[0]).depart_done_connect_address();
+        self_depart_handler(thread_id, seed, public_ip, private_ip, log,
+                            depart_done_addr, global_hash_rings, local_hash_rings,
+                            stored_key_map, key_replication_map, routing_ips,
+                            monitoring_ips, wt, pushers, serializers);
+        // Allow ZMQ to deliver depart notifications before process exits
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+      } else {
+        log->info("Self-depart requested but no monitoring IPs configured; "
+                   "exiting without depart handshake.");
+      }
       return;
     }
 

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -868,9 +868,12 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
       }
     }
    } catch (const zmq::error_t &e) {
-     if (e.num() == EINTR && shutdown_requested.load()) {
-       // ZMQ interrupted by SIGTERM — exit cleanly so gcov data is flushed.
-       break;
+     if (e.num() == EINTR &&
+         (shutdown_requested.load() || self_depart_requested.load())) {
+       // ZMQ interrupted by signal — continue the loop so the signal
+       // handler at the top of the loop can process the request.
+       if (shutdown_requested.load()) break;
+       continue;  // Let self_depart_requested be handled at top of loop.
      }
      throw;  // Re-throw unexpected ZMQ errors.
    }

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -53,6 +53,7 @@ typedef KVStore<Key, MultiKeyCausalLattice<SetLattice<string>>>
     MemoryMultiKeyCausalKVS;
 typedef KVStore<Key, PriorityLattice<double, string>> MemoryPriorityKVS;
 typedef KVStore<Key, CounterLattice> MemoryCounterKVS;
+typedef KVStore<Key, OrSetLattice> MemoryOrSetKVS;
 
 // a map that represents which keys should be sent to which IP-port combinations
 typedef map<Address, set<Key>> AddressKeysetMap;
@@ -833,6 +834,81 @@ class DiskCounterSerializer : public Serializer {
     for (const auto &p : input_value.decrements()) {
       auto &local = (*original_value.mutable_decrements())[p.first];
       if (p.second > local) local = p.second;
+    }
+
+    return disk_write(path, original_value);
+  }
+
+  bool remove(const Key &key) override {
+    return disk_remove(disk_fname(disk_root_, tid_, key));
+  }
+};
+
+class MemoryOrSetSerializer : public Serializer {
+  MemoryOrSetKVS *kvs_;
+
+ public:
+  MemoryOrSetSerializer(MemoryOrSetKVS *kvs) : kvs_(kvs) {}
+
+  string get(const Key &key, kvs::AnnaError &error) override {
+    auto val = kvs_->get(key, error);
+    if (val.reveal().elements.empty() && val.reveal().tombstones.empty()) {
+      error = kvs::AnnaError::KEY_DNE;
+    }
+    return serialize(val);
+  }
+
+  int put(const Key &key, const string &serialized) override {
+    OrSetLattice val = deserialize_or_set(serialized);
+    kvs_->put(key, val);
+    return static_cast<int>(kvs_->size(key));
+  }
+
+  bool remove(const Key &key) override {
+    kvs_->remove(key);
+    return true;
+  }
+};
+
+class DiskOrSetSerializer : public Serializer {
+  unsigned tid_;
+  string disk_root_;
+
+ public:
+  DiskOrSetSerializer(unsigned tid, const string &disk_root)
+      : tid_(tid), disk_root_(disk_root) {}
+
+  string get(const Key &key, kvs::AnnaError &error) override {
+    kvs::OrSetValue value;
+    if (disk_read(disk_fname(disk_root_, tid_, key), value, error)) {
+      if (value.elements().empty() && value.tombstones().empty()) {
+        error = kvs::AnnaError::KEY_DNE;
+      }
+      string serialized;
+      value.SerializeToString(&serialized);
+      return serialized;
+    }
+    return "";
+  }
+
+  int put(const Key &key, const string &serialized) override {
+    kvs::OrSetValue input_value;
+    input_value.ParseFromString(serialized);
+
+    string path = disk_fname(disk_root_, tid_, key);
+    kvs::AnnaError error;
+    kvs::OrSetValue original_value;
+
+    if (!disk_read(path, original_value, error)) {
+      return disk_write(path, input_value);
+    }
+
+    // Merge: union of elements and tombstones.
+    for (const auto &p : input_value.elements()) {
+      (*original_value.mutable_elements())[p.first] = p.second;
+    }
+    for (const auto &t : input_value.tombstones()) {
+      original_value.add_tombstones(t);
     }
 
     return disk_write(path, original_value);

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -912,7 +912,7 @@ class DiskOrSetSerializer : public Serializer {
         original_value.tombstones().begin(),
         original_value.tombstones().end());
     for (const auto &t : input_value.tombstones()) {
-      if (existing_tombstones.find(t) == existing_tombstones.end()) {
+      if (existing_tombstones.insert(t).second) {
         original_value.add_tombstones(t);
       }
     }

--- a/server/cpp/src/kvs/server_utils.hpp
+++ b/server/cpp/src/kvs/server_utils.hpp
@@ -907,8 +907,14 @@ class DiskOrSetSerializer : public Serializer {
     for (const auto &p : input_value.elements()) {
       (*original_value.mutable_elements())[p.first] = p.second;
     }
+    // Deduplicate tombstones during merge.
+    std::set<std::string> existing_tombstones(
+        original_value.tombstones().begin(),
+        original_value.tombstones().end());
     for (const auto &t : input_value.tombstones()) {
-      original_value.add_tombstones(t);
+      if (existing_tombstones.find(t) == existing_tombstones.end()) {
+        original_value.add_tombstones(t);
+      }
     }
 
     return disk_write(path, original_value);

--- a/server/cpp/src/lattices/or_set_lattice.hpp
+++ b/server/cpp/src/lattices/or_set_lattice.hpp
@@ -1,0 +1,68 @@
+//  Copyright 2019 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef INCLUDE_LATTICES_OR_SET_LATTICE_HPP_
+#define INCLUDE_LATTICES_OR_SET_LATTICE_HPP_
+
+#include <string>
+#include <set>
+#include "core_lattices.hpp"
+
+// OR-Set state: tagged elements and tombstones.
+struct OrSetState {
+  // tag -> element value
+  std::map<std::string, std::string> elements;
+  // tombstoned tags
+  std::set<std::string> tombstones;
+
+  // Compute the live set: elements whose tags are not tombstoned.
+  std::set<std::string> value() const {
+    std::set<std::string> result;
+    for (const auto &p : elements) {
+      if (tombstones.find(p.first) == tombstones.end()) {
+        result.insert(p.second);
+      }
+    }
+    return result;
+  }
+};
+
+// OR-Set (Observed-Remove Set) lattice. The merge takes the union of
+// both elements and tombstones. This is commutative, associative,
+// and idempotent -- safe for gossip-based replication.
+// Add wins over concurrent remove (new tags are not in the tombstone set).
+class OrSetLattice : public Lattice<OrSetState> {
+ protected:
+  void do_merge(const OrSetState &other) override {
+    // Union of elements.
+    for (const auto &p : other.elements) {
+      this->element.elements.insert(p);
+    }
+    // Union of tombstones.
+    for (const auto &t : other.tombstones) {
+      this->element.tombstones.insert(t);
+    }
+  }
+
+ public:
+  OrSetLattice() : Lattice<OrSetState>(OrSetState()) {}
+  OrSetLattice(const OrSetState &s) : Lattice<OrSetState>(s) {}
+
+  MaxLattice<unsigned> size() const {
+    auto live = element.value();
+    return MaxLattice<unsigned>(live.empty() ? 0 : 1);
+  }
+};
+
+#endif  // INCLUDE_LATTICES_OR_SET_LATTICE_HPP_

--- a/server/cpp/tests/kvs/server_handler_base.hpp
+++ b/server/cpp/tests/kvs/server_handler_base.hpp
@@ -56,6 +56,8 @@ protected:
   MemoryPriorityKVS *priority_kvs;
   Serializer *counter_serializer;
   MemoryCounterKVS *counter_kvs;
+  Serializer *or_set_serializer;
+  MemoryOrSetKVS *or_set_kvs;
 
   ServerHandlerTest() {
     lww_kvs = new MemoryLWWKVS();
@@ -83,6 +85,10 @@ protected:
     serializers[kvs::LatticeType::PRIORITY] = priority_serializer;
     serializers[kvs::LatticeType::COUNTER] = counter_serializer;
 
+    or_set_kvs = new MemoryOrSetKVS();
+    or_set_serializer = new MemoryOrSetSerializer(or_set_kvs);
+    serializers[kvs::LatticeType::OR_SET] = or_set_serializer;
+
     wt = ServerThread(ip, ip, thread_id);
     global_hash_rings[Tier::MEMORY].insert(ip, ip, 0, thread_id);
   }
@@ -99,6 +105,8 @@ protected:
     delete serializers[kvs::LatticeType::PRIORITY];
     delete counter_kvs;
     delete serializers[kvs::LatticeType::COUNTER];
+    delete or_set_kvs;
+    delete serializers[kvs::LatticeType::OR_SET];
   }
 
 public:

--- a/server/cpp/tests/kvs/test_user_request_handler.hpp
+++ b/server/cpp/tests/kvs/test_user_request_handler.hpp
@@ -704,6 +704,103 @@ TEST_F(ServerHandlerTest, UserCounterMerge) {
   EXPECT_EQ(result.increments().at("node2"), 7);
 }
 
+// Test PUT/GET for OR-Set lattice type.
+TEST_F(ServerHandlerTest, UserPutGetOrSet) {
+  Key key = "or_set_key";
+
+  // Build an OrSetValue with one element
+  kvs::OrSetValue osv;
+  (*osv.mutable_elements())["tag1"] = "apple";
+  string payload;
+  osv.SerializeToString(&payload);
+
+  string put_or_set =
+      put_key_request(key, kvs::LatticeType::OR_SET, payload, ip);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  user_request_handler(access_count, seed, put_or_set, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  EXPECT_EQ(stored_key_map[key].type(), kvs::LatticeType::OR_SET);
+
+  // GET should return the element
+  string get_req = get_key_request(key, ip);
+  size_t msg_count_before = mock_zmq_util.sent_messages.size();
+  user_request_handler(access_count, seed, get_req, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  ASSERT_GT(mock_zmq_util.sent_messages.size(), msg_count_before);
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+  EXPECT_EQ(response.tuples(0).error(), kvs::AnnaError::NO_ERROR);
+
+  kvs::OrSetValue result;
+  result.ParseFromString(response.tuples(0).payload());
+  EXPECT_EQ(result.elements().at("tag1"), "apple");
+}
+
+// Test OR-Set merge: add + tombstone merge correctly.
+TEST_F(ServerHandlerTest, UserOrSetMergeWithTombstone) {
+  Key key = "or_set_merge";
+
+  // First PUT: add two elements
+  kvs::OrSetValue osv1;
+  (*osv1.mutable_elements())["tag1"] = "apple";
+  (*osv1.mutable_elements())["tag2"] = "banana";
+  string payload1;
+  osv1.SerializeToString(&payload1);
+
+  string put1 = put_key_request(key, kvs::LatticeType::OR_SET, payload1, ip);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  user_request_handler(access_count, seed, put1, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  // Second PUT: tombstone tag1 (remove apple)
+  kvs::OrSetValue osv2;
+  osv2.add_tombstones("tag1");
+  string payload2;
+  osv2.SerializeToString(&payload2);
+
+  string put2 = put_key_request(key, kvs::LatticeType::OR_SET, payload2, ip);
+
+  local_changeset.clear();
+  user_request_handler(access_count, seed, put2, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  // GET and verify: tag1 should be tombstoned, only tag2 (banana) live
+  string get_req = get_key_request(key, ip);
+  size_t msg_count_before = mock_zmq_util.sent_messages.size();
+  user_request_handler(access_count, seed, get_req, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  ASSERT_GT(mock_zmq_util.sent_messages.size(), msg_count_before);
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+
+  kvs::OrSetValue result;
+  result.ParseFromString(response.tuples(0).payload());
+  // Both elements should be in the payload (server stores all)
+  EXPECT_EQ(result.elements().size(), 2);
+  // But tag1 should be tombstoned
+  EXPECT_EQ(result.tombstones_size(), 1);
+  EXPECT_EQ(result.tombstones(0), "tag1");
+}
+
 // TODO: Test key address cache invalidation
 // TODO: Test replication factor request and making the request pending
 // TODO: Test metadata operations -- does this matter?

--- a/server/protobuf/kvs.proto
+++ b/server/protobuf/kvs.proto
@@ -94,6 +94,12 @@ enum LatticeType {
   // Each node tracks its own cumulative increments and decrements.
   // The merge is per-node max. The counter value is sum(increments) - sum(decrements).
   COUNTER = 16;
+
+  // OR-Set (Observed-Remove Set): supports both add and remove of elements.
+  // Each element is tagged with a unique ID on add. Remove records the tags
+  // as tombstones. Merge is union of both elements and tombstones.
+  // Add wins over concurrent remove (new tag not in tombstone set).
+  OR_SET = 17;
 }
 
 enum AnnaError {
@@ -262,6 +268,17 @@ message CounterValue {
   map<string, uint64> increments = 1;
   // Per-node cumulative negative counts (monotonically increasing).
   map<string, uint64> decrements = 2;
+}
+
+// Serialization of OR-Set (Observed-Remove Set) lattices. Each element is
+// tagged with a unique ID on add. Remove tombstones specific tags. The value
+// is elements whose tags are NOT tombstoned.
+message OrSetValue {
+  // Elements with their unique tags: tag -> element_bytes.
+  // Tag format: "node_id:sequence_number".
+  map<string, bytes> elements = 1;
+  // Tombstoned tags (removed elements).
+  repeated string tombstones = 2;
 }
 
 // Serialization of lowest-priority-wins lattices.


### PR DESCRIPTION
## Summary

New OR_SET lattice type (17) based on the Observed-Remove Set CRDT. Supports adding and removing elements from a set while preserving convergence under gossip replication.

### How it works

Each `add(element)` tags the element with a unique ID (`node_id:tid:seq`). `remove(element)` GETs the current state, finds all tags for that element, and PUTs them as tombstones. The merge is union of both elements and tombstones. Add wins over concurrent remove (a new add generates a fresh tag not in the tombstone set).

### Client API

| Method | Description |
|---|---|
| `or_set_add(key, element)` | Add element with unique tag |
| `or_set_remove(key, element)` | Tombstone all tags for element |
| `get_or_set(key)` | Get live elements (not tombstoned) |

### Tests

- **or_set_add_remove_get**: add 3 elements, remove 1, verify 2 remain, re-add removed element, verify 3 again
- **UserPutGetOrSet**: C++ unit test for PUT/GET
- **UserOrSetMergeWithTombstone**: C++ unit test for merge with tombstone

Closes #512