### PR TITLE
Add key scanning API (#516)

### DIFF
--- a/clients/rust/src/lib/completer.rs
+++ b/clients/rust/src/lib/completer.rs
@@ -9,7 +9,7 @@ use rustyline::{Context, Helper};
 
 /// Commands available in the anna interactive CLI.
 pub const ANNA_COMMANDS: &[&str] = &[
-    "GET", "PUT", "DELETE", "BENCH", "START", "STOP", "STATUS", "HELP", "EXIT",
+    "GET", "PUT", "DELETE", "SCAN", "BENCH", "START", "STOP", "STATUS", "HELP", "EXIT",
 ];
 
 /// Commands that accept an optional component name argument.

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -2161,6 +2161,7 @@ impl KVSClient {
         let base = self.base_offset();
         let mut all_entries = Vec::new();
         let mut seen_keys = HashSet::new();
+        let mut failed_threads = 0usize;
 
         for tid in 0..thread_count {
             let port = tid + crate::threads::K_KEY_REQUEST_PORT + base;
@@ -2205,19 +2206,26 @@ impl KVSClient {
                         }
                         Err(e) => {
                             warn!("SCAN: failed to decode response from {}: {}", addr, e);
+                            failed_threads += 1;
                             break;
                         }
                     },
                     Ok(Err(e)) => {
                         warn!("SCAN: request to {} failed: {}", addr, e);
+                        failed_threads += 1;
                         break;
                     }
                     Err(_) => {
                         warn!("SCAN: request to {} timed out", addr);
+                        failed_threads += 1;
                         break;
                     }
                 }
             }
+        }
+
+        if failed_threads == thread_count {
+            return Err(Error::Kvs("SCAN: all threads failed".into()));
         }
 
         Ok(all_entries)

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -2128,6 +2128,100 @@ impl KVSClient {
     pub fn set_timeout(&mut self, timeout: Duration) {
         self.timeout = timeout;
     }
+
+    // ── Scan / key listing ──────────────────────────────────────────
+
+    /// Scan keys across all KVS threads, returning entries matching `prefix`.
+    ///
+    /// Discovers the cluster topology, constructs addresses for every KVS
+    /// memory thread, and issues paginated SCAN requests to each. Results
+    /// are merged and deduplicated (keys may be replicated across threads).
+    ///
+    /// Pass an empty string for `prefix` to list all keys.
+    pub async fn scan(&mut self, prefix: &str) -> Result<Vec<crate::proto::kvs::ScanEntry>> {
+        use std::collections::HashSet;
+
+        let thread_count = match self.get_cluster_topology().await {
+            Some(t) if t.memory_thread_count > 0 => t.memory_thread_count as usize,
+            _ => 1, // Default to 1 thread if topology not yet published.
+        };
+
+        // Derive KVS IP from routing address (same host in typical deployments).
+        let kvs_ip = self
+            .routing_threads
+            .first()
+            .and_then(|rt| {
+                let addr = rt.key_address_connect_address();
+                addr.split("://")
+                    .nth(1)
+                    .and_then(|hp| hp.rsplit_once(':').map(|(h, _)| h.to_string()))
+            })
+            .ok_or_else(|| Error::Kvs("SCAN: no routing address configured".into()))?;
+
+        let base = self.base_offset();
+        let mut all_entries = Vec::new();
+        let mut seen_keys = HashSet::new();
+
+        for tid in 0..thread_count {
+            let port = tid + crate::threads::K_KEY_REQUEST_PORT + base;
+            let addr = format!("tcp://{}:{}", kvs_ip, port);
+
+            let mut cursor: u64 = 0;
+            loop {
+                let request = KeyRequest {
+                    request_id: self.get_request_id(),
+                    response_address: self.ut.response_connect_address(),
+                    r#type: RequestType::Scan as i32,
+                    scan_prefix: prefix.to_string(),
+                    scan_cursor: cursor,
+                    scan_count: 100,
+                    ..Default::default()
+                };
+
+                let encoded = request.encode_to_vec();
+
+                let result = tokio::time::timeout(self.timeout, async {
+                    self.send_request(&encoded, &addr).await?;
+                    match self.recv_response(false).await {
+                        Some(data) => Ok(data),
+                        None => Err(Error::Kvs("SCAN: recv timed out".into())),
+                    }
+                })
+                .await;
+
+                match result {
+                    Ok(Ok(data)) => match KeyResponse::decode(data.as_slice()) {
+                        Ok(response) => {
+                            for entry in &response.scan_keys {
+                                if seen_keys.insert(entry.key.clone()) {
+                                    all_entries.push(entry.clone());
+                                }
+                            }
+                            let next = response.scan_next_cursor;
+                            if next == 0 || response.scan_keys.is_empty() {
+                                break; // Done with this thread.
+                            }
+                            cursor = next;
+                        }
+                        Err(e) => {
+                            warn!("SCAN: failed to decode response from {}: {}", addr, e);
+                            break;
+                        }
+                    },
+                    Ok(Err(e)) => {
+                        warn!("SCAN: request to {} failed: {}", addr, e);
+                        break;
+                    }
+                    Err(_) => {
+                        warn!("SCAN: request to {} timed out", addr);
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(all_entries)
+    }
 }
 
 #[cfg(test)]

--- a/clients/rust/src/lib/threads.rs
+++ b/clients/rust/src/lib/threads.rs
@@ -15,6 +15,9 @@ const K_CACHE_UPDATE_PORT: usize = 6850;
 // The port on which KVS servers listen for direct cache registration messages.
 const K_CACHE_REGISTRATION_PORT: usize = 6900;
 
+// The port on which KVS servers listen for data requests (GET/PUT/SCAN).
+pub(crate) const K_KEY_REQUEST_PORT: usize = 6200;
+
 /// `Thread` is a base type for a number of other thread types
 pub struct Thread {
     ip: Address,

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -556,6 +556,7 @@ fn cli_usage() -> String {
     \n\tincrement {key} [amount] \t- increment a counter (default +1)\
     \n\tdecrement {key} [amount] \t- decrement a counter (default -1)\
     \n\tget_counter {key} \t\t- get counter value\
+    \n\tscan [prefix] \t\t\t- list keys matching prefix (all keys if omitted)\
     \n\tdelete {key} \t\t\t- delete a key from the KVS\
     \n\tbench [keys] [value_size] [duration] [workload] - run a benchmark\
     \n\tstart [component] \t\t- start anna processes (component: kvs, monitor, route; omit for all)\

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -418,6 +418,28 @@ async fn execute_command(
             let val = client.get_counter(split[1]).await?;
             println!("{}", val);
         }
+        "SCAN" => {
+            let prefix = if split.len() >= 2 { split[1] } else { "" };
+            let entries = client.scan(prefix).await?;
+            if entries.is_empty() {
+                println!("(no keys found)");
+            } else {
+                for entry in &entries {
+                    let type_name = annalib::proto::kvs::LatticeType::try_from(entry.lattice_type)
+                        .map(|t| format!("{:?}", t))
+                        .unwrap_or_else(|_| format!("?{}", entry.lattice_type));
+                    if entry.expiry_epoch_s > 0 {
+                        println!(
+                            "  {} [type={}, size={}, expiry={}]",
+                            entry.key, type_name, entry.size, entry.expiry_epoch_s
+                        );
+                    } else {
+                        println!("  {} [type={}, size={}]", entry.key, type_name, entry.size);
+                    }
+                }
+                println!("({} keys)", entries.len());
+            }
+        }
         "PUT_TTL" if split.len() == 4 => {
             let key = split[1];
             let value = split[2];

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -571,3 +571,44 @@ async fn ttl_stress_many_keys() {
         expired_count, key_count
     );
 }
+
+/// SCAN: list keys matching a prefix across all KVS threads.
+#[tokio::test]
+async fn scan_keys() {
+    let config_path = generate_config(221);
+    let _guard = ServerGuard::start(&config_path, 221);
+    let config = client_config(221);
+    let mut client = KVSClient::new(&config, Some(15)).await;
+
+    // Insert some keys with different prefixes.
+    client.put("scan_a1", "v1").await.expect("PUT failed");
+    client.put("scan_a2", "v2").await.expect("PUT failed");
+    client.put("scan_b1", "v3").await.expect("PUT failed");
+    client.put("other_x", "v4").await.expect("PUT failed");
+
+    // Scan all keys.
+    let all = client.scan("").await.expect("SCAN all failed");
+    assert!(
+        all.len() >= 4,
+        "expected at least 4 keys, got {}",
+        all.len()
+    );
+
+    // Scan with prefix filter.
+    let scan_a = client.scan("scan_a").await.expect("SCAN prefix failed");
+    assert_eq!(scan_a.len(), 2, "expected 2 keys with prefix 'scan_a'");
+    for entry in &scan_a {
+        assert!(
+            entry.key.starts_with("scan_a"),
+            "key '{}' should start with 'scan_a'",
+            entry.key
+        );
+    }
+
+    // Scan with non-existent prefix.
+    let none = client
+        .scan("nonexistent_prefix_")
+        .await
+        .expect("SCAN empty failed");
+    assert!(none.is_empty(), "expected 0 keys for non-existent prefix");
+}

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -574,6 +574,7 @@ async fn ttl_stress_many_keys() {
 
 /// SCAN: list keys matching a prefix across all KVS threads.
 #[tokio::test]
+#[cfg(unix)]
 async fn scan_keys() {
     let config_path = generate_config(221);
     let _guard = ServerGuard::start(&config_path, 221);

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -84,6 +84,7 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | PN-Counter (increment/decrement/get_counter) | Yes |
 | Batch PUT (put_multi)    | Yes    |
 | OR-Set (set_add/set_remove/get_or_set) | Yes |
+| Key scanning (scan)      | Yes    |
 
 ## C++ Client (`clients/cpp`)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -39,6 +39,7 @@ mocks.
 | Address cache invalidation | Server signals client to refresh address cache               | Yes           |
 | Multi-key GET              | Retrieve multiple keys in one request                        | Yes           |
 | Multi-key PUT (put_multi)  | Batch PUT multiple keys in one request per worker            | Yes           |
+| SCAN [prefix]              | List keys matching prefix (fans out to all threads)          | Yes           |
 
 Legacy commands (`GET_SET`, `PUT_SET`, `GET_CAUSAL`, `PUT_CAUSAL`, etc.) are
 still supported as aliases for backward compatibility.

--- a/server/cpp/src/kvs/CMakeLists.txt
+++ b/server/cpp/src/kvs/CMakeLists.txt
@@ -26,6 +26,7 @@ SET(KVS_SOURCE
   cache_ip_response_handler.cpp
   cache_registration_handler.cpp
   management_node_response_handler.cpp
+  scan_handler.cpp
   utils.cpp)
 
 ADD_EXECUTABLE(anna-kvs ${KVS_SOURCE})

--- a/server/cpp/src/kvs/kvs_handlers.hpp
+++ b/server/cpp/src/kvs/kvs_handlers.hpp
@@ -102,6 +102,10 @@ void management_node_response_handler(string &serialized,
                                       SocketCache &pushers, ServerThread &wt,
                                       unsigned &rid);
 
+void scan_handler(string &serialized, logger log,
+                  map<Key, KeyProperty> &stored_key_map,
+                  SocketCache &pushers);
+
 void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
                  SerializerMap &serializers,
                  map<Key, KeyProperty> &stored_key_map);

--- a/server/cpp/src/kvs/scan_handler.cpp
+++ b/server/cpp/src/kvs/scan_handler.cpp
@@ -1,0 +1,81 @@
+//  Copyright 2019 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "kvs/kvs_handlers.hpp"
+
+static const unsigned kDefaultScanCount = 100;
+
+void scan_handler(string &serialized, logger log,
+                  map<Key, KeyProperty> &stored_key_map,
+                  SocketCache &pushers) {
+  kvs::KeyRequest request;
+  request.ParseFromString(serialized);
+
+  kvs::KeyResponse response;
+  response.set_response_id(request.request_id());
+  response.set_type(kvs::RequestType::SCAN);
+
+  string prefix = request.scan_prefix();
+  uint64_t cursor = request.scan_cursor();
+  unsigned count = request.scan_count();
+  if (count == 0) count = kDefaultScanCount;
+
+  response.set_scan_total_keys(stored_key_map.size());
+
+  // Iterate from begin(), skip `cursor` entries, collect up to `count`
+  // keys matching the prefix.
+  uint64_t index = 0;
+  unsigned collected = 0;
+  auto it = stored_key_map.begin();
+
+  // Skip to cursor position.
+  while (it != stored_key_map.end() && index < cursor) {
+    ++it;
+    ++index;
+  }
+
+  // Collect matching keys.
+  while (it != stored_key_map.end() && collected < count) {
+    const Key &key = it->first;
+    const KeyProperty &prop = it->second;
+
+    // Skip metadata keys — they are internal and should not be exposed
+    // to client scans.
+    if (!is_metadata(key)) {
+      if (prefix.empty() || key.substr(0, prefix.size()) == prefix) {
+        auto *entry = response.add_scan_keys();
+        entry->set_key(key);
+        entry->set_lattice_type(prop.type());
+        entry->set_size(prop.size());
+        entry->set_expiry_epoch_s(prop.expiry_epoch_s_);
+        collected++;
+      }
+    }
+
+    ++it;
+    ++index;
+  }
+
+  // Set next cursor: 0 means done, otherwise the index to resume from.
+  if (it == stored_key_map.end()) {
+    response.set_scan_next_cursor(0);
+  } else {
+    response.set_scan_next_cursor(index);
+  }
+
+  string serialized_response;
+  response.SerializeToString(&serialized_response);
+  kZmqUtil->send_string(serialized_response,
+                        &pushers[request.response_address()]);
+}

--- a/server/cpp/src/kvs/scan_handler.cpp
+++ b/server/cpp/src/kvs/scan_handler.cpp
@@ -15,6 +15,7 @@
 #include "kvs/kvs_handlers.hpp"
 
 static const unsigned kDefaultScanCount = 100;
+static const unsigned kMaxScanCount = 10000;
 
 void scan_handler(string &serialized, logger log,
                   map<Key, KeyProperty> &stored_key_map,
@@ -30,6 +31,7 @@ void scan_handler(string &serialized, logger log,
   uint64_t cursor = request.scan_cursor();
   unsigned count = request.scan_count();
   if (count == 0) count = kDefaultScanCount;
+  if (count > kMaxScanCount) count = kMaxScanCount;
 
   response.set_scan_total_keys(stored_key_map.size());
 

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -438,11 +438,20 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
       auto work_start = std::chrono::system_clock::now();
 
       string serialized = kZmqUtil->recv_string(&request_puller);
-      user_request_handler(access_count, seed, serialized, log,
-                           global_hash_rings, local_hash_rings,
-                           pending_requests, key_access_tracker, stored_key_map,
-                           key_replication_map, local_changeset, wt,
-                           serializers, pushers);
+
+      // Peek at the request type to dispatch SCAN separately.
+      kvs::KeyRequest peek;
+      peek.ParseFromString(serialized);
+
+      if (peek.type() == kvs::RequestType::SCAN) {
+        scan_handler(serialized, log, stored_key_map, pushers);
+      } else {
+        user_request_handler(access_count, seed, serialized, log,
+                             global_hash_rings, local_hash_rings,
+                             pending_requests, key_access_tracker,
+                             stored_key_map, key_replication_map,
+                             local_changeset, wt, serializers, pushers);
+      }
 
       auto time_elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
                               std::chrono::system_clock::now() - work_start)

--- a/server/cpp/tests/kvs/server_handler_base.hpp
+++ b/server/cpp/tests/kvs/server_handler_base.hpp
@@ -162,4 +162,20 @@ public:
 
     return request_str;
   }
+
+  string scan_key_request(string prefix, uint64_t cursor, uint32_t count,
+                          string ip) {
+    kvs::KeyRequest request;
+    request.set_type(kvs::RequestType::SCAN);
+    request.set_response_address(UserThread(ip, 0).response_connect_address());
+    request.set_request_id(kRequestId);
+    request.set_scan_prefix(std::move(prefix));
+    request.set_scan_cursor(cursor);
+    request.set_scan_count(count);
+
+    string request_str;
+    request.SerializeToString(&request_str);
+
+    return request_str;
+  }
 };

--- a/server/cpp/tests/kvs/test_user_request_handler.hpp
+++ b/server/cpp/tests/kvs/test_user_request_handler.hpp
@@ -944,6 +944,32 @@ TEST_F(ServerHandlerTest, ScanSkipsMetadata) {
   EXPECT_EQ(response.scan_keys(0).key(), "user_key");
 }
 
+TEST_F(ServerHandlerTest, ScanCountClamped) {
+  // Insert more keys than kDefaultScanCount to verify count=0 default
+  // and that very large counts are clamped.
+  for (int i = 0; i < 3; i++) {
+    string key = "clamp" + std::to_string(i);
+    serializers[kvs::LatticeType::LWW]->put(key, serialize(i, string("v")));
+    stored_key_map[key].set_type(kvs::LatticeType::LWW);
+    stored_key_map[key].set_size(1);
+  }
+
+  // count=0 should use default (100), returning all 3 keys.
+  string scan_req = scan_key_request("", 0, 0, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  kvs::KeyResponse resp;
+  resp.ParseFromString(mock_zmq_util.sent_messages.back());
+  EXPECT_EQ(resp.scan_keys_size(), 3);
+
+  // Very large count should be clamped but still work.
+  scan_req = scan_key_request("", 0, 999999999, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  resp.ParseFromString(mock_zmq_util.sent_messages.back());
+  EXPECT_EQ(resp.scan_keys_size(), 3);  // Only 3 keys exist.
+}
+
 // TODO: Test key address cache invalidation
 // TODO: Test replication factor request and making the request pending
 // TODO: Test metadata operations -- does this matter?

--- a/server/cpp/tests/kvs/test_user_request_handler.hpp
+++ b/server/cpp/tests/kvs/test_user_request_handler.hpp
@@ -801,6 +801,149 @@ TEST_F(ServerHandlerTest, UserOrSetMergeWithTombstone) {
   EXPECT_EQ(result.tombstones(0), "tag1");
 }
 
+// ── SCAN tests ──────────────────────────────────────────────────────────
+
+TEST_F(ServerHandlerTest, ScanAllKeys) {
+  // Insert several keys.
+  serializers[kvs::LatticeType::LWW]->put("alpha", serialize(1, string("v1")));
+  stored_key_map["alpha"].set_type(kvs::LatticeType::LWW);
+  stored_key_map["alpha"].set_size(2);
+
+  serializers[kvs::LatticeType::LWW]->put("beta", serialize(2, string("v2")));
+  stored_key_map["beta"].set_type(kvs::LatticeType::LWW);
+  stored_key_map["beta"].set_size(2);
+
+  serializers[kvs::LatticeType::LWW]->put("gamma", serialize(3, string("v3")));
+  stored_key_map["gamma"].set_type(kvs::LatticeType::LWW);
+  stored_key_map["gamma"].set_size(2);
+
+  string scan_req = scan_key_request("", 0, 100, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  ASSERT_GT(mock_zmq_util.sent_messages.size(), 0);
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+
+  EXPECT_EQ(response.type(), kvs::RequestType::SCAN);
+  EXPECT_EQ(response.scan_keys_size(), 3);
+  EXPECT_EQ(response.scan_total_keys(), 3);
+  EXPECT_EQ(response.scan_next_cursor(), 0);  // All keys returned.
+
+  // Verify all key names are present.
+  std::set<string> keys;
+  for (const auto &entry : response.scan_keys()) {
+    keys.insert(entry.key());
+    EXPECT_EQ(entry.lattice_type(), kvs::LatticeType::LWW);
+    EXPECT_EQ(entry.size(), 2);
+  }
+  EXPECT_TRUE(keys.count("alpha"));
+  EXPECT_TRUE(keys.count("beta"));
+  EXPECT_TRUE(keys.count("gamma"));
+}
+
+TEST_F(ServerHandlerTest, ScanWithPrefix) {
+  serializers[kvs::LatticeType::LWW]->put("app:user1", serialize(1, string("u1")));
+  stored_key_map["app:user1"].set_type(kvs::LatticeType::LWW);
+  stored_key_map["app:user1"].set_size(2);
+
+  serializers[kvs::LatticeType::LWW]->put("app:user2", serialize(2, string("u2")));
+  stored_key_map["app:user2"].set_type(kvs::LatticeType::LWW);
+  stored_key_map["app:user2"].set_size(2);
+
+  serializers[kvs::LatticeType::LWW]->put("other:key", serialize(3, string("o")));
+  stored_key_map["other:key"].set_type(kvs::LatticeType::LWW);
+  stored_key_map["other:key"].set_size(1);
+
+  string scan_req = scan_key_request("app:", 0, 100, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+
+  EXPECT_EQ(response.scan_keys_size(), 2);
+  for (const auto &entry : response.scan_keys()) {
+    EXPECT_TRUE(entry.key().substr(0, 4) == "app:");
+  }
+}
+
+TEST_F(ServerHandlerTest, ScanPagination) {
+  // Insert 5 keys.
+  for (int i = 0; i < 5; i++) {
+    string key = "k" + std::to_string(i);
+    serializers[kvs::LatticeType::LWW]->put(key, serialize(i, string("v")));
+    stored_key_map[key].set_type(kvs::LatticeType::LWW);
+    stored_key_map[key].set_size(1);
+  }
+
+  // Page 1: get first 2 keys.
+  string scan_req = scan_key_request("", 0, 2, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  kvs::KeyResponse page1;
+  page1.ParseFromString(mock_zmq_util.sent_messages.back());
+  EXPECT_EQ(page1.scan_keys_size(), 2);
+  EXPECT_GT(page1.scan_next_cursor(), 0);
+
+  // Page 2: get next 2 keys from cursor.
+  scan_req = scan_key_request("", page1.scan_next_cursor(), 2, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  kvs::KeyResponse page2;
+  page2.ParseFromString(mock_zmq_util.sent_messages.back());
+  EXPECT_EQ(page2.scan_keys_size(), 2);
+  EXPECT_GT(page2.scan_next_cursor(), 0);
+
+  // Page 3: get remaining key.
+  scan_req = scan_key_request("", page2.scan_next_cursor(), 2, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  kvs::KeyResponse page3;
+  page3.ParseFromString(mock_zmq_util.sent_messages.back());
+  EXPECT_EQ(page3.scan_keys_size(), 1);
+  EXPECT_EQ(page3.scan_next_cursor(), 0);  // Done.
+
+  // Verify total = 5 unique keys across all pages.
+  std::set<string> all_keys;
+  for (const auto &e : page1.scan_keys()) all_keys.insert(e.key());
+  for (const auto &e : page2.scan_keys()) all_keys.insert(e.key());
+  for (const auto &e : page3.scan_keys()) all_keys.insert(e.key());
+  EXPECT_EQ(all_keys.size(), 5);
+}
+
+TEST_F(ServerHandlerTest, ScanEmptyStore) {
+  string scan_req = scan_key_request("", 0, 100, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+
+  EXPECT_EQ(response.scan_keys_size(), 0);
+  EXPECT_EQ(response.scan_next_cursor(), 0);
+  EXPECT_EQ(response.scan_total_keys(), 0);
+}
+
+TEST_F(ServerHandlerTest, ScanSkipsMetadata) {
+  // Insert a metadata key and a regular key.
+  string meta_key = "ANNA_METADATA|replication|mykey";
+  serializers[kvs::LatticeType::LWW]->put(meta_key, serialize(1, string("rep")));
+  stored_key_map[meta_key].set_type(kvs::LatticeType::LWW);
+  stored_key_map[meta_key].set_size(3);
+
+  serializers[kvs::LatticeType::LWW]->put("user_key", serialize(2, string("v")));
+  stored_key_map["user_key"].set_type(kvs::LatticeType::LWW);
+  stored_key_map["user_key"].set_size(1);
+
+  string scan_req = scan_key_request("", 0, 100, ip);
+  scan_handler(scan_req, log_, stored_key_map, pushers);
+
+  kvs::KeyResponse response;
+  response.ParseFromString(mock_zmq_util.sent_messages.back());
+
+  // Only the user key should be returned; metadata is excluded.
+  EXPECT_EQ(response.scan_keys_size(), 1);
+  EXPECT_EQ(response.scan_keys(0).key(), "user_key");
+}
+
 // TODO: Test key address cache invalidation
 // TODO: Test replication factor request and making the request pending
 // TODO: Test metadata operations -- does this matter?

--- a/server/protobuf/kvs.proto
+++ b/server/protobuf/kvs.proto
@@ -28,6 +28,9 @@ enum RequestType {
 
   // A request to put data into the KVS.
   PUT = 2;
+
+  // A request to scan/list keys on this thread.
+  SCAN = 3;
 }
 
 enum LatticeType { 
@@ -166,6 +169,19 @@ message KeyRequest {
 
   // A client-specific ID used to match asynchronous requests with responses.
   string request_id = 4;
+
+  // --- SCAN-specific fields (only used when type = SCAN) ---
+
+  // Key prefix filter. Empty string matches all keys.
+  string scan_prefix = 5;
+
+  // Offset cursor: start returning keys from this index.
+  // 0 for the first page.
+  uint64 scan_cursor = 6;
+
+  // Maximum number of keys to return per page.
+  // 0 means server default (100).
+  uint32 scan_count = 7;
 }
 
 // A response to a KeyRequest. 
@@ -184,6 +200,32 @@ message KeyResponse {
   // captured in the corresponding KeyTuple. This will only be set if the whole
   // request times out.
   AnnaError error = 4;
+
+  // --- SCAN-specific response fields (only set when type = SCAN) ---
+
+  // Keys matching the scan request.
+  repeated ScanEntry scan_keys = 5;
+
+  // Next cursor offset. 0 means scan is complete for this thread.
+  uint64 scan_next_cursor = 6;
+
+  // Total number of keys on this thread (for progress reporting).
+  uint64 scan_total_keys = 7;
+}
+
+// A single key entry returned by a SCAN request.
+message ScanEntry {
+  // The key name.
+  string key = 1;
+
+  // The lattice type of the stored value.
+  LatticeType lattice_type = 2;
+
+  // The size of the stored value in bytes.
+  uint32 size = 3;
+
+  // Absolute expiry time as epoch seconds. 0 = no expiry.
+  uint32 expiry_epoch_s = 4;
 }
 
 // A request to the routing tier to retrieve server addresses corresponding to


### PR DESCRIPTION
## Summary

Adds a  request type that lets clients list keys stored in the KVS, with optional prefix filtering and cursor-based pagination.

### Design

- **Server**: Each KVS thread handles SCAN requests on its own `stored_key_map`. The cursor is a simple integer offset — iterate from `begin()`, skip `cursor` entries, return up to `count` matching keys. Metadata keys (`ANNA_METADATA|*`) are excluded.
- **Client**: The `scan()` method fans out to all KVS memory threads (addresses derived from routing IP + base_offset + thread count from `get_cluster_topology()`). Results are merged and deduplicated across threads.
- **Consistency**: Best-effort, same as Redis SCAN. If the map is mutated between pages, some keys may be missed or returned twice.

### Changes

**Protobuf** (`kvs.proto`):
- `SCAN = 3` added to `RequestType`
- `scan_prefix`, `scan_cursor`, `scan_count` fields on `KeyRequest`
- `scan_keys`, `scan_next_cursor`, `scan_total_keys` fields on `KeyResponse`
- New `ScanEntry` message (key, lattice_type, size, expiry_epoch_s)

**Server** (C++):
- `scan_handler.cpp`: iterates `stored_key_map` with offset cursor + prefix filter
- `server.cpp`: dispatches SCAN requests from `request_puller`
- `CMakeLists.txt`: includes `scan_handler.cpp`

**Client** (Rust):
- `scan(prefix)`: fans out to all threads, paginates, deduplicates
- CLI: `SCAN [prefix]` command with metadata display

**Tests**:
- 5 C++ unit tests: all keys, prefix filter, pagination, empty store, metadata exclusion
- 1 Rust integration test: PUT keys with different prefixes, scan all, scan filtered, scan non-existent prefix

Closes #516