### PR TITLE
Align CLI commands with Redis naming conventions

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Autoscaling and Policy Engine](docs/autoscaling.md)
 - [Feature List](docs/feature-list.md)
   - [Client Feature List](docs/client-feature-list.md)
+- [API Comparison vs. Other KV Stores](docs/api-comparison.md)
 
 # Building and Running
 - [Building anna](docs/building-anna.md)

--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -130,7 +130,15 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
     if (v.size() < 2) {
       std::cerr << "Usage: GET <key>" << std::endl;
     } else {
-      std::cout << annalib::get_any(client, v[1]) << std::endl;
+      try {
+        std::cout << annalib::get_any(client, v[1]) << std::endl;
+      } catch (const std::runtime_error &e) {
+        if (string(e.what()).find("KEY_DNE") != string::npos) {
+          std::cout << "(nil)" << std::endl;
+        } else {
+          throw;
+        }
+      }
     }
   } else if (command == "DEL" || command == "DELETE") {
     if (v.size() < 2) {

--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -92,7 +92,7 @@ string cli_usage() {
          "  SADD {key} {member} [member...] - add members to an OR-Set (not yet implemented)\n"
          "  SREM {key} {member} [member...] - remove members from an OR-Set (not yet implemented)\n"
          "  SMEMBERS {key}                  - list members of an OR-Set (not yet implemented)\n"
-         "  SUBSCRIBE {key1} [key2...]      - subscribe to value changes on keys\n"
+         "  SUBSCRIBE {key1} [key2...]      - subscribe to value changes on keys (not available in C++ CLI, use Rust CLI or library API)\n"
          "  BENCH [keys] [value_size] [duration] [workload] - run a benchmark\n"
          "  START, STOP, STATUS, HELP, EXIT";
 }
@@ -158,21 +158,21 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
     if (v.size() < 3) {
       std::cerr << "Usage: SADD <key> <member> [member ...]" << std::endl;
     } else {
-      std::cerr << "Error: SADD is not yet implemented (requires OR-Set add support in C++ client library)" << std::endl;
+      std::cerr << "Error: SADD is not yet implemented (requires OR-Set add support in C++ client library). Use the Rust CLI (anna) for this command." << std::endl;
     }
   } else if (command == "SREM") {
     // TODO: requires or_set_remove in C++ client library
     if (v.size() < 3) {
       std::cerr << "Usage: SREM <key> <member> [member ...]" << std::endl;
     } else {
-      std::cerr << "Error: SREM is not yet implemented (requires OR-Set remove support in C++ client library)" << std::endl;
+      std::cerr << "Error: SREM is not yet implemented (requires OR-Set remove support in C++ client library). Use the Rust CLI (anna) for this command." << std::endl;
     }
   } else if (command == "SMEMBERS") {
     // TODO: requires or_set_get / get_set in C++ client library
     if (v.size() < 2) {
       std::cerr << "Usage: SMEMBERS <key>" << std::endl;
     } else {
-      std::cerr << "Error: SMEMBERS is not yet implemented (requires OR-Set get support in C++ client library)" << std::endl;
+      std::cerr << "Error: SMEMBERS is not yet implemented (requires OR-Set get support in C++ client library). Use the Rust CLI (anna) for this command." << std::endl;
     }
   } else if (command == "SUBSCRIBE") {
     if (v.size() < 2) {

--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -72,6 +72,7 @@ void print_priority_value(const annalib::PriorityResult& result) {
 string cli_usage() {
   return "Valid commands are:\n"
          "  GET {key}                       - get the value of any key (auto-detects type)\n"
+         "  MGET {key1} {key2} ...          - get multiple keys at once\n"
          "  PUT {key} {value}               - store a value (LWW, default)\n"
          "  PUT set {key} {vals...}         - store a set (union merge)\n"
          "  PUT ordered_set {key} {vals...} - store an ordered set\n"
@@ -87,7 +88,11 @@ string cli_usage() {
          "  PUT causal_ordered_set {key} {vals...} - store an ordered set with single-key causal\n"
          "  PUT multi_causal_set {key} {vals...} - store a set with multi-key causal consistency\n"
          "  PUT multi_causal_ordered_set {key} {vals...} - store an ordered set with multi-key causal\n"
-         "  DELETE {key}                    - delete a key\n"
+         "  DEL {key}                       - delete a key (alias: DELETE)\n"
+         "  SADD {key} {member} [member...] - add members to an OR-Set (not yet implemented)\n"
+         "  SREM {key} {member} [member...] - remove members from an OR-Set (not yet implemented)\n"
+         "  SMEMBERS {key}                  - list members of an OR-Set (not yet implemented)\n"
+         "  SUBSCRIBE {key1} [key2...]      - subscribe to value changes on keys\n"
          "  BENCH [keys] [value_size] [duration] [workload] - run a benchmark\n"
          "  START, STOP, STATUS, HELP, EXIT";
 }
@@ -127,11 +132,54 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
     } else {
       std::cout << annalib::get_any(client, v[1]) << std::endl;
     }
-  } else if (command == "DELETE") {
+  } else if (command == "DEL" || command == "DELETE") {
     if (v.size() < 2) {
-      std::cerr << "Usage: DELETE <key>" << std::endl;
+      std::cerr << "Usage: DEL <key>" << std::endl;
     } else if (!annalib::del(client, v[1]).succeeded()) {
-      std::cerr << "Error: DELETE failed" << std::endl;
+      std::cerr << "Error: DEL failed" << std::endl;
+    }
+  } else if (command == "MGET") {
+    if (v.size() < 2) {
+      std::cerr << "Usage: MGET <key1> [key2 ...]" << std::endl;
+    } else {
+      vector<string> keys(v.begin() + 1, v.end());
+      auto results = annalib::get_multi(client, keys);
+      for (const auto& key : keys) {
+        auto it = results.find(key);
+        if (it != results.end()) {
+          std::cout << key << ": " << it->second << std::endl;
+        } else {
+          std::cout << key << ": (not found)" << std::endl;
+        }
+      }
+    }
+  } else if (command == "SADD") {
+    // TODO: requires or_set_add in C++ client library
+    if (v.size() < 3) {
+      std::cerr << "Usage: SADD <key> <member> [member ...]" << std::endl;
+    } else {
+      std::cerr << "Error: SADD is not yet implemented (requires OR-Set add support in C++ client library)" << std::endl;
+    }
+  } else if (command == "SREM") {
+    // TODO: requires or_set_remove in C++ client library
+    if (v.size() < 3) {
+      std::cerr << "Usage: SREM <key> <member> [member ...]" << std::endl;
+    } else {
+      std::cerr << "Error: SREM is not yet implemented (requires OR-Set remove support in C++ client library)" << std::endl;
+    }
+  } else if (command == "SMEMBERS") {
+    // TODO: requires or_set_get / get_set in C++ client library
+    if (v.size() < 2) {
+      std::cerr << "Usage: SMEMBERS <key>" << std::endl;
+    } else {
+      std::cerr << "Error: SMEMBERS is not yet implemented (requires OR-Set get support in C++ client library)" << std::endl;
+    }
+  } else if (command == "SUBSCRIBE") {
+    if (v.size() < 2) {
+      std::cerr << "Usage: SUBSCRIBE <key1> [key2 ...]" << std::endl;
+    } else {
+      std::cerr << "Error: SUBSCRIBE requires server IP and cache IP configuration "
+                << "(use ValueChangeSubscriber directly from the C++ client library)" << std::endl;
     }
   } else if (command == "PUT" || command == "PUT_SET" ||
              command == "PUT_ORDERED_SET" || command == "PUT_CAUSAL" ||

--- a/clients/cpp/tests/cli/test_cli_invocation.cpp
+++ b/clients/cpp/tests/cli/test_cli_invocation.cpp
@@ -240,6 +240,42 @@ TEST_F(CliInvocationTest, BenchHelpIncludesBenchCommand) {
   EXPECT_NE(r.stdout_str.find("bench"), std::string::npos);
 }
 
+TEST_F(CliInvocationTest, CliFileWithSaddStub) {
+  std::string cmd_file = "cli_test_sadd.txt";
+  {
+    std::ofstream f(cmd_file);
+    f << "SADD myset elem\n";
+  }
+  auto r = run_command(cli_binary + " --routing 127.0.0.1 --client-ip 127.0.0.1 cli " + cmd_file);
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_NE(r.stderr_str.find("not yet implemented"), std::string::npos);
+  std::remove(cmd_file.c_str());
+}
+
+TEST_F(CliInvocationTest, CliFileWithSremStub) {
+  std::string cmd_file = "cli_test_srem.txt";
+  {
+    std::ofstream f(cmd_file);
+    f << "SREM myset elem\n";
+  }
+  auto r = run_command(cli_binary + " --routing 127.0.0.1 --client-ip 127.0.0.1 cli " + cmd_file);
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_NE(r.stderr_str.find("not yet implemented"), std::string::npos);
+  std::remove(cmd_file.c_str());
+}
+
+TEST_F(CliInvocationTest, CliFileWithSmembersStub) {
+  std::string cmd_file = "cli_test_smembers.txt";
+  {
+    std::ofstream f(cmd_file);
+    f << "SMEMBERS myset\n";
+  }
+  auto r = run_command(cli_binary + " --routing 127.0.0.1 --client-ip 127.0.0.1 cli " + cmd_file);
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_NE(r.stderr_str.find("not yet implemented"), std::string::npos);
+  std::remove(cmd_file.c_str());
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/clients/go/cmd/anna-go/main.go
+++ b/clients/go/cmd/anna-go/main.go
@@ -468,13 +468,57 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 		}
 		runBench(client, numKeys, valSize, dur, 2, wlArg)
 
-	case "DELETE":
+	case "DEL", "DELETE":
 		if len(parts) != 2 {
-			return false, fmt.Errorf("usage: DELETE <key>")
+			return false, fmt.Errorf("usage: DEL <key>")
 		}
 		if err := client.Delete(parts[1]); err != nil {
 			return false, err
 		}
+
+	case "MGET":
+		if len(parts) < 2 {
+			return false, fmt.Errorf("usage: MGET <key1> [key2 ...]")
+		}
+		keys := parts[1:]
+		results, err := client.GetMulti(keys)
+		if err != nil {
+			return false, err
+		}
+		for _, key := range keys {
+			if val, ok := results[key]; ok {
+				fmt.Printf("%s: %s\n", key, val)
+			} else {
+				fmt.Printf("%s: (not found)\n", key)
+			}
+		}
+
+	case "SADD":
+		// TODO: requires or_set_add in Go client library
+		if len(parts) < 3 {
+			return false, fmt.Errorf("usage: SADD <key> <member> [member ...]")
+		}
+		fmt.Fprintln(os.Stderr, "Error: SADD is not yet implemented (requires OR-Set add support in Go client library)")
+
+	case "SREM":
+		// TODO: requires or_set_remove in Go client library
+		if len(parts) < 3 {
+			return false, fmt.Errorf("usage: SREM <key> <member> [member ...]")
+		}
+		fmt.Fprintln(os.Stderr, "Error: SREM is not yet implemented (requires OR-Set remove support in Go client library)")
+
+	case "SMEMBERS":
+		// TODO: requires or_set_get in Go client library
+		if len(parts) < 2 {
+			return false, fmt.Errorf("usage: SMEMBERS <key>")
+		}
+		fmt.Fprintln(os.Stderr, "Error: SMEMBERS is not yet implemented (requires OR-Set get support in Go client library)")
+
+	case "SUBSCRIBE":
+		if len(parts) < 2 {
+			return false, fmt.Errorf("usage: SUBSCRIBE <key1> [key2 ...]")
+		}
+		fmt.Fprintln(os.Stderr, "Error: SUBSCRIBE requires server IP and cache IP configuration (use ValueChangeSubscriber directly from the Go client library)")
 
 	case "START":
 		if configFilePath == "" {
@@ -512,6 +556,7 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 func cliUsage() string {
 	return `Valid commands are:
 	get {key}                                    - get the value of any key (auto-detects type)
+	mget {key1} {key2} ...                       - get multiple keys at once
 	put {key} {value}                            - store a value (LWW, default)
 	put set {key} {vals...}                      - store a set (union merge)
 	put ordered_set {key} {vals...}              - store an ordered set
@@ -527,7 +572,11 @@ func cliUsage() string {
 	put causal_ordered_set {key} {vals...}       - store an ordered set with single-key causal
 	put multi_causal_set {key} {vals...}         - store a set with multi-key causal consistency
 	put multi_causal_ordered_set {key} {vals...} - store an ordered set with multi-key causal
-	delete {key}                                 - delete a key from the KVS
+	del {key}                                    - delete a key from the KVS (alias: delete)
+	sadd {key} {member} [member...]              - add members to an OR-Set (not yet implemented)
+	srem {key} {member} [member...]              - remove members from an OR-Set (not yet implemented)
+	smembers {key}                               - list members of an OR-Set (not yet implemented)
+	subscribe {key1} [key2...]                   - subscribe to value changes on keys
 	bench [keys] [value_size] [duration] [workload] - run a benchmark
 	start                                        - start anna processes
 	stop                                         - stop running anna processes

--- a/clients/go/cmd/anna-go/main.go
+++ b/clients/go/cmd/anna-go/main.go
@@ -498,21 +498,21 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 		if len(parts) < 3 {
 			return false, fmt.Errorf("usage: SADD <key> <member> [member ...]")
 		}
-		fmt.Fprintln(os.Stderr, "Error: SADD is not yet implemented (requires OR-Set add support in Go client library)")
+		fmt.Fprintln(os.Stderr, "Error: SADD is not yet implemented (requires OR-Set add support in Go client library). Use the Rust CLI (anna) for this command.")
 
 	case "SREM":
 		// TODO: requires or_set_remove in Go client library
 		if len(parts) < 3 {
 			return false, fmt.Errorf("usage: SREM <key> <member> [member ...]")
 		}
-		fmt.Fprintln(os.Stderr, "Error: SREM is not yet implemented (requires OR-Set remove support in Go client library)")
+		fmt.Fprintln(os.Stderr, "Error: SREM is not yet implemented (requires OR-Set remove support in Go client library). Use the Rust CLI (anna) for this command.")
 
 	case "SMEMBERS":
 		// TODO: requires or_set_get in Go client library
 		if len(parts) < 2 {
 			return false, fmt.Errorf("usage: SMEMBERS <key>")
 		}
-		fmt.Fprintln(os.Stderr, "Error: SMEMBERS is not yet implemented (requires OR-Set get support in Go client library)")
+		fmt.Fprintln(os.Stderr, "Error: SMEMBERS is not yet implemented (requires OR-Set get support in Go client library). Use the Rust CLI (anna) for this command.")
 
 	case "SUBSCRIBE":
 		if len(parts) < 2 {
@@ -576,7 +576,7 @@ func cliUsage() string {
 	sadd {key} {member} [member...]              - add members to an OR-Set (not yet implemented)
 	srem {key} {member} [member...]              - remove members from an OR-Set (not yet implemented)
 	smembers {key}                               - list members of an OR-Set (not yet implemented)
-	subscribe {key1} [key2...]                   - subscribe to value changes on keys
+	subscribe {key1} [key2...]                   - subscribe to value changes on keys (not available in Go CLI, use Rust CLI or library API)
 	bench [keys] [value_size] [duration] [workload] - run a benchmark
 	start                                        - start anna processes
 	stop                                         - stop running anna processes

--- a/clients/go/cmd/anna-go/main.go
+++ b/clients/go/cmd/anna-go/main.go
@@ -284,9 +284,14 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 		default: // "GET"
 			val, err := client.Get(parts[1])
 			if err != nil {
-				return false, err
+				if strings.Contains(err.Error(), "KEY_DNE") {
+					fmt.Println("(nil)")
+				} else {
+					return false, err
+				}
+			} else {
+				fmt.Println(val)
 			}
-			fmt.Println(val)
 		}
 
 	// Unified PUT: optional type prefix.

--- a/clients/python/anna/cli.py
+++ b/clients/python/anna/cli.py
@@ -14,6 +14,7 @@ _TYPE_NAMES = {"lww", "set", "ordered_set", "lww_set", "lww_ordered_set",
 def cli_usage():
     return ("Valid commands are:\n"
             "  GET {key}                       - get the value of any key (auto-detects type)\n"
+            "  MGET {key1} {key2} ...          - get multiple keys at once\n"
             "  PUT {key} {value}               - store a value (LWW, default)\n"
             "  PUT set {key} {vals...}         - store a set (union merge)\n"
             "  PUT ordered_set {key} {vals...} - store an ordered set\n"
@@ -29,7 +30,11 @@ def cli_usage():
             "  PUT priority {key} {pri} {val}  - store with priority (lowest wins)\n"
             "  PUT causal {key} {value}        - store with multi-key causal consistency\n"
             "  PUT single_causal {key} {value} - store with single-key causal consistency\n"
-            "  DELETE {key}                    - delete a key\n"
+            "  DEL {key}                       - delete a key (alias: DELETE)\n"
+            "  SADD {key} {member} [member...] - add members to an OR-Set (not yet implemented)\n"
+            "  SREM {key} {member} [member...] - remove members from an OR-Set (not yet implemented)\n"
+            "  SMEMBERS {key}                  - list members of an OR-Set (not yet implemented)\n"
+            "  SUBSCRIBE {key1} [key2...]      - subscribe to value changes on keys\n"
             "  BENCH [keys] [value_size] [duration] [workload] - run a benchmark\n"
             "  START, STOP, STATUS, HELP, EXIT")
 
@@ -356,13 +361,61 @@ def execute_command(client, config_path, line):
             result = client.put(parts[1], val)
             if not result.get(parts[1], False):
                 print("Failure!")
-    elif cmd == "DELETE":
+    elif cmd in ("DEL", "DELETE"):
         if len(parts) < 2:
-            print("Usage: DELETE <key>")
+            print("Usage: DEL <key>")
             return True
         result = client.delete(parts[1])
         if not result.get(parts[1], False):
             print("Failure!")
+    elif cmd == "MGET":
+        if len(parts) < 2:
+            print("Usage: MGET <key1> [key2 ...]")
+            return True
+        keys = parts[1:]
+        results = client.get_all(keys)
+        for key in keys:
+            val = results.get(key)
+            if val is not None:
+                revealed = val.reveal()
+                if isinstance(revealed, bytes):
+                    print(f"{key}: {revealed.decode('utf-8', errors='replace')}")
+                elif isinstance(revealed, (set, frozenset)):
+                    items = sorted(v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
+                                   for v in revealed)
+                    print(f"{key}: {{ {' '.join(items)} }}")
+                elif isinstance(revealed, list):
+                    items = [v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
+                             for v in revealed]
+                    print(f"{key}: [ {' '.join(items)} ]")
+                else:
+                    print(f"{key}: {revealed}")
+            else:
+                print(f"{key}: (not found)")
+    elif cmd == "SADD":
+        # TODO: requires or_set_add in Python client library
+        if len(parts) < 3:
+            print("Usage: SADD <key> <member> [member ...]")
+        else:
+            print("Error: SADD is not yet implemented (requires OR-Set add support in Python client library)")
+    elif cmd == "SREM":
+        # TODO: requires or_set_remove in Python client library
+        if len(parts) < 3:
+            print("Usage: SREM <key> <member> [member ...]")
+        else:
+            print("Error: SREM is not yet implemented (requires OR-Set remove support in Python client library)")
+    elif cmd == "SMEMBERS":
+        # TODO: requires or_set_get in Python client library
+        if len(parts) < 2:
+            print("Usage: SMEMBERS <key>")
+        else:
+            print("Error: SMEMBERS is not yet implemented (requires OR-Set get support in Python client library)")
+    elif cmd == "SUBSCRIBE":
+        if len(parts) < 2:
+            print("Usage: SUBSCRIBE <key1> [key2 ...]")
+        else:
+            print("Error: SUBSCRIBE requires server IP and cache IP configuration "
+                  "(use ValueChangeSubscriber directly from the Python client library)")
     elif cmd in ("PUT_SET", "PUT_ORDERED_SET", "PUT_CAUSAL",
                  "PUT_SINGLE_CAUSAL", "PUT_PRIORITY"):
         # Legacy PUT_* aliases: remap to the unified PUT handler.

--- a/clients/python/anna/cli.py
+++ b/clients/python/anna/cli.py
@@ -72,7 +72,7 @@ def execute_command(client, config_path, line):
                 for v in values:
                     print(v.decode("utf-8") if isinstance(v, bytes) else str(v))
             else:
-                print("Key not found")
+                print("(nil)")
         elif cmd == "GET_SINGLE_CAUSAL":
             val = client.get_single_causal(key)
             if val is not None:
@@ -82,7 +82,7 @@ def execute_command(client, config_path, line):
                 for v in values:
                     print(v.decode("utf-8") if isinstance(v, bytes) else str(v))
             else:
-                print("Key not found")
+                print("(nil)")
         elif cmd == "GET_PRIORITY":
             val = client.get_priority(key)
             if val is not None:
@@ -90,7 +90,7 @@ def execute_command(client, config_path, line):
                 value = val.value
                 print(value.decode("utf-8") if isinstance(value, bytes) else str(value))
             else:
-                print("Key not found")
+                print("(nil)")
         elif cmd == "GET_ORDERED_SET":
             val = client.get_ordered_set(key)
             if val is not None:
@@ -98,7 +98,7 @@ def execute_command(client, config_path, line):
                          for v in val.reveal()]
                 print("[ " + " ".join(items) + " ]")
             else:
-                print("Key not found")
+                print("(nil)")
         elif cmd == "GET_SET":
             result = client.get(key)
             val = result.get(key)
@@ -107,7 +107,7 @@ def execute_command(client, config_path, line):
                                for v in val.reveal())
                 print("{ " + " ".join(items) + " }")
             else:
-                print("Key not found")
+                print("(nil)")
         else:
             # Unified GET: uses client.get() which returns LWW or Set
             # lattice objects. For other types (causal, priority, etc.),
@@ -129,7 +129,7 @@ def execute_command(client, config_path, line):
                 else:
                     print(revealed)
             else:
-                print("Key not found")
+                print("(nil)")
     elif cmd == "PUT":
         if len(parts) < 3:
             print("Usage: PUT [type] <key> <value(s)>")

--- a/clients/python/anna/cli.py
+++ b/clients/python/anna/cli.py
@@ -34,7 +34,7 @@ def cli_usage():
             "  SADD {key} {member} [member...] - add members to an OR-Set (not yet implemented)\n"
             "  SREM {key} {member} [member...] - remove members from an OR-Set (not yet implemented)\n"
             "  SMEMBERS {key}                  - list members of an OR-Set (not yet implemented)\n"
-            "  SUBSCRIBE {key1} [key2...]      - subscribe to value changes on keys\n"
+            "  SUBSCRIBE {key1} [key2...]      - subscribe to value changes on keys (not available in Python CLI, use Rust CLI or library API)\n"
             "  BENCH [keys] [value_size] [duration] [workload] - run a benchmark\n"
             "  START, STOP, STATUS, HELP, EXIT")
 
@@ -397,19 +397,19 @@ def execute_command(client, config_path, line):
         if len(parts) < 3:
             print("Usage: SADD <key> <member> [member ...]")
         else:
-            print("Error: SADD is not yet implemented (requires OR-Set add support in Python client library)")
+            print("Error: SADD is not yet implemented (requires OR-Set add support in Python client library). Use the Rust CLI (anna) for this command.")
     elif cmd == "SREM":
         # TODO: requires or_set_remove in Python client library
         if len(parts) < 3:
             print("Usage: SREM <key> <member> [member ...]")
         else:
-            print("Error: SREM is not yet implemented (requires OR-Set remove support in Python client library)")
+            print("Error: SREM is not yet implemented (requires OR-Set remove support in Python client library). Use the Rust CLI (anna) for this command.")
     elif cmd == "SMEMBERS":
         # TODO: requires or_set_get in Python client library
         if len(parts) < 2:
             print("Usage: SMEMBERS <key>")
         else:
-            print("Error: SMEMBERS is not yet implemented (requires OR-Set get support in Python client library)")
+            print("Error: SMEMBERS is not yet implemented (requires OR-Set get support in Python client library). Use the Rust CLI (anna) for this command.")
     elif cmd == "SUBSCRIBE":
         if len(parts) < 2:
             print("Usage: SUBSCRIBE <key1> [key2 ...]")

--- a/clients/python/anna/client.py
+++ b/clients/python/anna/client.py
@@ -285,12 +285,12 @@ class AnnaTcpClient(BaseAnnaClient):
         for key in keys:
             kv_pairs[key] = None
 
+        req_ids = []
         for key in keys:
             if worker_addresses[key]:
                 req, _ = self._prepare_data_request(key)
                 req.type = GET
 
-                req_ids = []
                 for address in worker_addresses[key]:
                     req.request_id = self._get_request_id()
 

--- a/clients/python/tests/test_cli.py
+++ b/clients/python/tests/test_cli.py
@@ -884,6 +884,82 @@ class TestUnifiedPutSyntax:
         client.put.assert_called_once()
 
 
+class TestMgetCommand:
+    def test_mget_returns_values(self, capsys):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        from anna.lattices import LWWPairLattice
+
+        client = MagicMock()
+        client.get_all.return_value = {
+            "key1": LWWPairLattice(1, b"val1"),
+            "key2": LWWPairLattice(2, b"val2"),
+        }
+
+        result = execute_command(client, None, "MGET key1 key2")
+        assert result is True
+        out = capsys.readouterr().out
+        assert "key1: val1" in out
+        assert "key2: val2" in out
+
+    def test_mget_missing_args(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "MGET")
+        assert result is True
+        assert "Usage" in capsys.readouterr().out
+
+
+class TestDelAlias:
+    def test_del_calls_delete(self):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+
+        client = MagicMock()
+        client.delete.return_value = {"mykey": True}
+
+        result = execute_command(client, None, "DEL mykey")
+        assert result is True
+        client.delete.assert_called_once_with("mykey")
+
+
+class TestGetNil:
+    def test_get_returns_nil(self, capsys):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+
+        client = MagicMock()
+        client.get.return_value = {"nonexistent": None}
+
+        execute_command(client, None, "GET nonexistent")
+        assert "(nil)" in capsys.readouterr().out
+
+
+class TestSetCommandStubs:
+    def test_sadd_stub(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "SADD myset elem")
+        assert result is True
+        out = capsys.readouterr().out
+        assert "not yet implemented" in out
+        assert "Rust CLI" in out
+
+    def test_srem_stub(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "SREM myset elem")
+        assert result is True
+        out = capsys.readouterr().out
+        assert "not yet implemented" in out
+        assert "Rust CLI" in out
+
+    def test_smembers_stub(self, capsys):
+        from anna.cli import execute_command
+        result = execute_command(None, None, "SMEMBERS myset")
+        assert result is True
+        out = capsys.readouterr().out
+        assert "not yet implemented" in out
+        assert "Rust CLI" in out
+
+
 class TestArityValidation:
     """Tests for argument count validation."""
 

--- a/clients/python/tests/test_cli.py
+++ b/clients/python/tests/test_cli.py
@@ -237,7 +237,7 @@ class TestExecuteCommand:
         client.get.return_value = {"mykey": None}
 
         execute_command(client, None, "GET mykey")
-        assert "Key not found" in capsys.readouterr().out
+        assert "(nil)" in capsys.readouterr().out
 
     def test_put_with_mock_client(self, capsys):
         from unittest.mock import MagicMock
@@ -321,7 +321,7 @@ class TestOrderedSetFormatting:
         client.get_ordered_set.return_value = None
 
         execute_command(client, "/dev/null", "GET_ORDERED_SET mykey")
-        assert "Key not found" in capsys.readouterr().out
+        assert "(nil)" in capsys.readouterr().out
 
     def test_put_ordered_set(self):
         from unittest.mock import MagicMock
@@ -380,7 +380,7 @@ class TestSingleCausalFormatting:
         client.get_single_causal.return_value = None
 
         execute_command(client, "/dev/null", "GET_SINGLE_CAUSAL mykey")
-        assert "Key not found" in capsys.readouterr().out
+        assert "(nil)" in capsys.readouterr().out
 
     def test_put_single_causal(self):
         from unittest.mock import MagicMock
@@ -437,7 +437,7 @@ class TestPriorityFormatting:
         client.get_priority.return_value = None
 
         execute_command(client, "/dev/null", "GET_PRIORITY mykey")
-        assert "Key not found" in capsys.readouterr().out
+        assert "(nil)" in capsys.readouterr().out
 
     def test_put_priority(self):
         from unittest.mock import MagicMock
@@ -518,7 +518,7 @@ class TestCausalFormatting:
         client.get_causal.return_value = None
 
         execute_command(client, "/dev/null", "GET_CAUSAL mykey")
-        assert "Key not found" in capsys.readouterr().out
+        assert "(nil)" in capsys.readouterr().out
 
     def test_put_causal_failure(self, capsys):
         from unittest.mock import MagicMock
@@ -563,7 +563,7 @@ class TestGetSetNotFound:
         client.get.return_value = {"myset": None}
 
         execute_command(client, None, "GET_SET myset")
-        assert "Key not found" in capsys.readouterr().out
+        assert "(nil)" in capsys.readouterr().out
 
 
 class TestPutSetFailure:

--- a/clients/rust/src/lib/completer.rs
+++ b/clients/rust/src/lib/completer.rs
@@ -220,4 +220,26 @@ mod tests {
         let results = complete("PUT set ");
         assert!(results.is_empty());
     }
+
+    #[test]
+    fn new_commands_present_in_anna_commands() {
+        let expected = [
+            "DEL",
+            "MGET",
+            "MSET",
+            "SADD",
+            "SREM",
+            "SMEMBERS",
+            "INCR",
+            "DECR",
+            "EXPIRE",
+            "SUBSCRIBE",
+        ];
+        for cmd in &expected {
+            assert!(
+                ANNA_COMMANDS.contains(cmd),
+                "{cmd} should be in ANNA_COMMANDS"
+            );
+        }
+    }
 }

--- a/clients/rust/src/lib/completer.rs
+++ b/clients/rust/src/lib/completer.rs
@@ -9,7 +9,26 @@ use rustyline::{Context, Helper};
 
 /// Commands available in the anna interactive CLI.
 pub const ANNA_COMMANDS: &[&str] = &[
-    "GET", "PUT", "DELETE", "SCAN", "BENCH", "START", "STOP", "STATUS", "HELP", "EXIT",
+    "GET",
+    "PUT",
+    "DEL",
+    "MGET",
+    "MSET",
+    "SADD",
+    "SREM",
+    "SMEMBERS",
+    "INCR",
+    "DECR",
+    "GET_COUNTER",
+    "EXPIRE",
+    "SCAN",
+    "SUBSCRIBE",
+    "BENCH",
+    "START",
+    "STOP",
+    "STATUS",
+    "HELP",
+    "EXIT",
 ];
 
 /// Commands that accept an optional component name argument.

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -402,8 +402,12 @@ async fn execute_command(
         "MGET" if split.len() >= 2 => {
             let keys: Vec<&str> = split[1..].to_vec();
             let results = client.get_multi(&keys).await?;
-            for (key, val) in results {
-                println!("{}: {}", key, val);
+            for key in &keys {
+                if let Some(val) = results.get(*key) {
+                    println!("{}: {}", key, val);
+                } else {
+                    println!("{}: (not found)", key);
+                }
             }
         }
         "MSET" if split.len() >= 3 && (split.len() - 1) % 2 == 0 => {

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -171,8 +171,10 @@ async fn run() -> Result<String> {
                 .get_one::<String>("command_file")
                 .map(|s| s.as_str())
             {
-                None => cli_loop_interactive(client, server_config_path).await?,
-                Some(filename) => cli_loop_file(client, filename, server_config_path).await?,
+                None => cli_loop_interactive(client, config, server_config_path).await?,
+                Some(filename) => {
+                    cli_loop_file(client, filename, config, server_config_path).await?
+                }
             }
             .into())
         }
@@ -368,6 +370,7 @@ fn parse_put_args(split: &[&str]) -> Result<(String, annalib::value::Value)> {
 async fn execute_command(
     client: &mut KVSClient,
     line: &str,
+    client_config: &ClientConfig,
     config_file_path: &Path,
 ) -> Result<bool> {
     let split = line.trim().split(' ').collect::<Vec<&str>>();
@@ -381,7 +384,80 @@ async fn execute_command(
             let (key, value) = parse_put_args(&split)?;
             client.put_value(&key, &value).await?;
         }
-        "DELETE" if split.len() == 2 => client.delete(split[1]).await?,
+        "DEL" | "DELETE" if split.len() == 2 => client.delete(split[1]).await?,
+        "SADD" if split.len() >= 3 => {
+            for element in &split[2..] {
+                client.or_set_add(split[1], element).await?;
+            }
+        }
+        "SREM" if split.len() >= 3 => {
+            for element in &split[2..] {
+                client.or_set_remove(split[1], element).await?;
+            }
+        }
+        "SMEMBERS" if split.len() == 2 => {
+            let vals = client.get_or_set(split[1]).await?;
+            println!("{}", vals.join(", "));
+        }
+        "MGET" if split.len() >= 2 => {
+            let keys: Vec<&str> = split[1..].to_vec();
+            let results = client.get_multi(&keys).await?;
+            for (key, val) in results {
+                println!("{}: {}", key, val);
+            }
+        }
+        "MSET" if split.len() >= 3 && (split.len() - 1) % 2 == 0 => {
+            let pairs: Vec<(&str, &str)> = split[1..].chunks(2).map(|c| (c[0], c[1])).collect();
+            client.put_multi(&pairs).await?;
+        }
+        "INCR" if split.len() == 2 => {
+            client.increment(split[1]).await?;
+        }
+        "INCR" if split.len() == 3 => {
+            let amount: u64 = split[2]
+                .parse()
+                .map_err(|_| annalib::Error::Kvs("amount must be a positive integer".into()))?;
+            client.increment_by(split[1], amount).await?;
+        }
+        "DECR" if split.len() == 2 => {
+            client.decrement(split[1]).await?;
+        }
+        "DECR" if split.len() == 3 => {
+            let amount: u64 = split[2]
+                .parse()
+                .map_err(|_| annalib::Error::Kvs("amount must be a positive integer".into()))?;
+            client.decrement_by(split[1], amount).await?;
+        }
+        "GET_COUNTER" if split.len() == 2 => {
+            let val = client.get_counter(split[1]).await?;
+            println!("{}", val);
+        }
+        "SUBSCRIBE" if split.len() >= 2 => {
+            use annalib::value_change_subscriber::ValueChangeSubscriber;
+            let keys: Vec<String> = split[1..].iter().map(|s| s.to_string()).collect();
+            let mut sub = ValueChangeSubscriber::new(client_config, None).await?;
+            sub.watch(&keys).await?;
+            println!("Subscribed to: {}", keys.join(", "));
+            println!("Waiting for updates (Ctrl+C to stop)...");
+            loop {
+                match sub.recv_update(std::time::Duration::from_secs(1)).await {
+                    Ok(Some((key, payload))) => {
+                        let display = match ValueChangeSubscriber::decode_lww_value(&payload) {
+                            Ok(bytes) => String::from_utf8(bytes)
+                                .unwrap_or_else(|_| format!("({} raw bytes)", payload.len())),
+                            Err(_) => format!("({} raw bytes)", payload.len()),
+                        };
+                        println!("{}: {}", key, display);
+                    }
+                    Ok(None) => continue,
+                    Err(e) => {
+                        error!("SUBSCRIBE error: {}", e);
+                        break;
+                    }
+                }
+            }
+        }
+        // Legacy aliases for renamed commands.
         "SET_ADD" if split.len() == 3 => {
             client.or_set_add(split[1], split[2]).await?;
         }
@@ -414,10 +490,6 @@ async fn execute_command(
                 .map_err(|_| annalib::Error::Kvs("amount must be a positive integer".into()))?;
             client.decrement_by(split[1], amount).await?;
         }
-        "GET_COUNTER" if split.len() == 2 => {
-            let val = client.get_counter(split[1]).await?;
-            println!("{}", val);
-        }
         "SCAN" => {
             let prefix = if split.len() >= 2 { split[1] } else { "" };
             let entries = client.scan(prefix).await?;
@@ -440,7 +512,7 @@ async fn execute_command(
                 println!("({} keys)", entries.len());
             }
         }
-        "PUT_TTL" if split.len() == 4 => {
+        "EXPIRE" | "PUT_TTL" if split.len() == 4 => {
             let key = split[1];
             let value = split[2];
             let ttl: u32 = split[3]
@@ -531,9 +603,22 @@ async fn execute_command(
 }
 
 fn cli_usage() -> String {
-    "Valid commands are:\
+    "Redis-style commands:\
     \n\tget {key} \t\t\t- get the value of any key (auto-detects type)\
     \n\tput {key} {value} \t\t- store a value (LWW, default)\
+    \n\tdel {key} \t\t\t- delete a key from the KVS\
+    \n\tmget {key1} {key2} ... \t\t- get multiple keys at once\
+    \n\tmset {k1} {v1} {k2} {v2} ... \t- batch PUT multiple keys\
+    \n\tsadd {key} {m1} [m2 ...] \t- add member(s) to an OR-Set\
+    \n\tsrem {key} {m1} [m2 ...] \t- remove member(s) from an OR-Set\
+    \n\tsmembers {key} \t\t\t- get all members of an OR-Set\
+    \n\tincr {key} [amount] \t\t- increment a counter (default +1)\
+    \n\tdecr {key} [amount] \t\t- decrement a counter (default -1)\
+    \n\tget_counter {key} \t\t- get counter value\
+    \n\texpire {key} {value} {seconds} \t- store with TTL (auto-expires)\
+    \n\tscan [prefix] \t\t\t- list keys matching prefix (all keys if omitted)\
+    \n\tsubscribe {key1} [key2 ...] \t- watch keys for changes (Ctrl+C to stop)\
+    \n\nAnna-specific PUT variants:\
     \n\tput set {key} {vals...} \t\t- store a set (union merge)\
     \n\tput ordered_set {key} {vals...} \t- store an ordered set\
     \n\tput lww_set {key} {vals...} \t- store a set (LWW, replaces on write)\
@@ -548,16 +633,7 @@ fn cli_usage() -> String {
     \n\tput priority {key} {pri} {val} \t- store with priority (lowest wins)\
     \n\tput causal {key} {value} \t- store with multi-key causal consistency\
     \n\tput single_causal {key} {value} \t- store with single-key causal consistency\
-    \n\tset_add {key} {element} \t\t- add element to OR-Set\
-    \n\tset_remove {key} {element} \t\t- remove element from OR-Set\
-    \n\tget_or_set {key} \t\t\t- get OR-Set elements\
-    \n\tput_multi {k1} {v1} {k2} {v2} ... \t- batch PUT multiple keys\
-    \n\tput_ttl {key} {value} {seconds} \t- store with TTL (auto-expires)\
-    \n\tincrement {key} [amount] \t- increment a counter (default +1)\
-    \n\tdecrement {key} [amount] \t- decrement a counter (default -1)\
-    \n\tget_counter {key} \t\t- get counter value\
-    \n\tscan [prefix] \t\t\t- list keys matching prefix (all keys if omitted)\
-    \n\tdelete {key} \t\t\t- delete a key from the KVS\
+    \n\nOther:\
     \n\tbench [keys] [value_size] [duration] [workload] - run a benchmark\
     \n\tstart [component] \t\t- start anna processes (component: kvs, monitor, route; omit for all)\
     \n\tstop [component] \t\t- stop running anna processes\
@@ -569,6 +645,7 @@ fn cli_usage() -> String {
 
 async fn cli_loop_interactive(
     mut client: KVSClient,
+    client_config: ClientConfig,
     config_file_path: PathBuf,
 ) -> Result<&'static str> {
     let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(1);
@@ -594,7 +671,7 @@ async fn cli_loop_interactive(
     });
 
     while let Some(line) = rx.recv().await {
-        match execute_command(&mut client, &line, &config_file_path).await {
+        match execute_command(&mut client, &line, &client_config, &config_file_path).await {
             Ok(true) => break,
             Err(e) => error!("{}", e),
             _ => {}
@@ -607,6 +684,7 @@ async fn cli_loop_interactive(
 async fn cli_loop_file(
     mut client: KVSClient,
     filename: &str,
+    client_config: ClientConfig,
     config_file_path: PathBuf,
 ) -> Result<&'static str> {
     let file = File::open(filename).map_err(|e| {
@@ -615,7 +693,7 @@ async fn cli_loop_file(
     let reader = BufReader::new(file);
 
     for line in reader.lines().map_while(|l| l.ok()) {
-        match execute_command(&mut client, &line, &config_file_path).await {
+        match execute_command(&mut client, &line, &client_config, &config_file_path).await {
             Ok(true) => break,
             Err(e) => error!("Error while executing command line: '{}'\n{}", line, e),
             _ => {}

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -376,10 +376,11 @@ async fn execute_command(
     let split = line.trim().split(' ').collect::<Vec<&str>>();
 
     match split[0].to_ascii_uppercase().as_str() {
-        "GET" if split.len() == 2 => {
-            let value = client.get_value(split[1]).await?;
-            println!("{}", value);
-        }
+        "GET" if split.len() == 2 => match client.get_value(split[1]).await {
+            Ok(value) => println!("{}", value),
+            Err(e) if e.to_string().contains("KEY_DNE") => println!("(nil)"),
+            Err(e) => return Err(e.into()),
+        },
         "PUT" if split.len() >= 3 => {
             let (key, value) = parse_put_args(&split)?;
             client.put_value(&key, &value).await?;

--- a/docs/api-comparison.md
+++ b/docs/api-comparison.md
@@ -1,6 +1,6 @@
 # API Comparison: Anna vs. Major KV Stores
 
-### What Anna has that's unique
+## What Anna has that's unique
 
 Anna's lattice type system (17 types with CRDT-style merge semantics) is genuinely distinctive. No other major KV store offers built-in conflict-free replicated data types at the storage layer:
 
@@ -8,13 +8,13 @@ Anna's lattice type system (17 types with CRDT-style merge semantics) is genuine
 - **Gossip-based replication with automatic conflict resolution** -- no other store in this list does this natively
 - **Per-key replication factor control** -- DynamoDB has table-level, Cassandra has keyspace-level, but per-key is rare
 
-### Feature comparison vs. competitors
+## Feature comparison vs. competitors
 
 | Capability | Anna | Redis | etcd | TiKV | DynamoDB | Cassandra | FoundationDB |
 |---|---|---|---|---|---|---|---|
 | **TTL/Expiration** | EXPIRE (per-key, server-enforced) | Per-key | Per-lease | RawKV only | Per-item | Per-value | No |
 | **Key scan/list** | SCAN (prefix filter, paginated) | SCAN/KEYS | Range | scan() | Scan/Query | SELECT | get_range() |
-| **Watch/subscribe** | SUBSCRIBE (gossip-based, all 4 clients) | Pub/Sub + Streams | Watch API | CDC | Streams | CDC | watch(key) |
+| **Watch/subscribe** | SUBSCRIBE (gossip-based; CLI: Rust only, library: all 4) | Pub/Sub + Streams | Watch API | CDC | Streams | CDC | watch(key) |
 | **Atomic CAS** | No | WATCH+MULTI | Txn if/then | CAS (RawKV) | ConditionExpression | LWT (IF) | Native (all txns) |
 | **Batch read/write** | MGET + MSET | MGET/MSET, pipeline | Range + Txn | batch_get/batch_put/scan | BatchGetItem/BatchWriteItem | SELECT IN + BATCH | get_range + Txn |
 | **Counters/Incr** | INCR/DECR (PN-Counter CRDT) | INCR/DECR | No | No | Atomic counters | Counter type | add() atomic |
@@ -22,7 +22,7 @@ Anna's lattice type system (17 types with CRDT-style merge semantics) is genuine
 | **Secondary indexes** | No | Sorted sets | No | No | GSI/LSI | Secondary indexes | Layer (manual) |
 | **Range queries** | No | ZRANGEBYSCORE | Range | scan(start,end) | Query (sort key) | Clustering cols | get_range() |
 
-### Anna's current API surface (4 clients: Rust, C++, Python, Go)
+## Anna's current API surface (4 clients: Rust, C++, Python, Go)
 
 | Category | Operations |
 |---|---|
@@ -30,7 +30,7 @@ Anna's lattice type system (17 types with CRDT-style merge semantics) is genuine
 | **Batch** | MGET, MSET — get_multi, put_multi (groups by worker for efficiency) |
 | **17 lattice types** | LWW, Set, OrderedSet, SingleCausal, MultiCausal, Priority, LwwSet, LwwOrderedSet, UnionScalar, PrioritySet, PriorityOrderedSet, CausalSet, CausalOrderedSet, MultiCausalSet, MultiCausalOrderedSet, Counter, OrSet |
 | **Transactions** | begin/put/get/commit/rollback (client-side buffering, read-committed + repeatable-read isolation) |
-| **Watch/subscribe** | SUBSCRIBE — ValueChangeSubscriber: watch(keys), recv_update(timeout), get_cached(key) -- all 4 clients |
+| **Watch/subscribe** | SUBSCRIBE — ValueChangeSubscriber: watch(keys), recv_update(timeout), get_cached(key) — library: all 4 clients; CLI: Rust only |
 | **TTL/Expiration** | EXPIRE — put_with_ttl(key, value, ttl_seconds); per-key, server-enforced |
 | **Counter** | INCR, DECR, GET_COUNTER — increment(key, amount), decrement(key, amount), get_counter(key) |
 | **OR-Set** | SADD, SREM, SMEMBERS — or_set_add(key, element), or_set_remove(key, element), get_or_set(key) |
@@ -39,17 +39,17 @@ Anna's lattice type system (17 types with CRDT-style merge semantics) is genuine
 | **Stats/monitoring** | get_storage_stats, get_key_access_stats, get_key_size_stats, LatencyReporter |
 | **Key scan/list** | SCAN — scan(prefix), fans out to all threads, cursor-paginated, returns key + type + size + expiry |
 
-### Remaining gaps to close
+## Remaining gaps to close
 
 No actionable gaps remain. All items from the original comparison have been implemented or classified as architecture mismatches (below).
 
-### Hardest to emulate (architecture mismatch)
+## Hardest to emulate (architecture mismatch)
 
 - **Conditional writes / CAS**: Anna's eventual consistency model conflicts with strong CAS. The causal lattice types provide partial ordering but not compare-and-swap semantics.
 - **Range queries**: Anna uses hash-based key distribution (consistent hashing). Range queries require sequential key layout, which would need a fundamentally different routing strategy.
 - **Secondary indexes**: Would require a server-side index maintenance layer that doesn't exist.
 
-### Which store's API is closest to Anna?
+## Which store's API is closest to Anna?
 
 **Redis** is the closest match in spirit -- both are in-memory, both support multiple data types (sets, sorted sets), both have pub/sub. If Anna wanted to emulate one API, a subset of the Redis command protocol (RESP) would be the most natural fit:
 
@@ -67,7 +67,7 @@ No actionable gaps remain. All items from the original comparison have been impl
 | `DECR`/`DECRBY` | `DECR key` / `DECRBY key decrement` | `DECR {key} [amount]` | `decrement(key)` / `decrement_by(key, n)` | PN-Counter CRDT |
 | (no equivalent) | — | `GET_COUNTER {key}` | `get_counter(key)` | Returns net counter value (incr - decr) |
 | `SETEX` | `SETEX key seconds value` | `EXPIRE {key} {value} {seconds}` | `put_with_ttl(key, value, ttl)` | Server-enforced per-key TTL |
-| `SUBSCRIBE` | `SUBSCRIBE channel [channel...]` | `SUBSCRIBE {key1} [key2 ...]` | `ValueChangeSubscriber::watch(keys)` | Gossip-based, receives on value change |
+| `SUBSCRIBE` | `SUBSCRIBE channel [channel...]` | `SUBSCRIBE {key1} [key2 ...]` | `ValueChangeSubscriber::watch(keys)` | Gossip-based; CLI: Rust only, library: all 4 |
 | `SCAN` | `SCAN cursor [MATCH pattern] [COUNT count]` | `SCAN [prefix]` | `scan(prefix)` | Fans out to all KVS threads |
 
 **Differences from Redis**: Anna's `SADD`/`SREM` use OR-Set (tombstone-based CRDT) rather than Redis's simple in-memory set. Anna's `INCR`/`DECR` use a PN-Counter CRDT that converges across replicas. Anna's `SUBSCRIBE` is gossip-based (eventual delivery) rather than Redis's synchronous pub/sub. Anna's `SCAN` fans out to all KVS threads since keys are hash-distributed, while Redis scans a single hash table.

--- a/docs/api-comparison.md
+++ b/docs/api-comparison.md
@@ -1,0 +1,73 @@
+# API Comparison: Anna vs. Major KV Stores
+
+### What Anna has that's unique
+
+Anna's lattice type system (17 types with CRDT-style merge semantics) is genuinely distinctive. No other major KV store offers built-in conflict-free replicated data types at the storage layer:
+
+- **LWW, Set, OrderedSet, Priority, Causal variants, Counter, OR-Set** -- merge-able without coordination
+- **Gossip-based replication with automatic conflict resolution** -- no other store in this list does this natively
+- **Per-key replication factor control** -- DynamoDB has table-level, Cassandra has keyspace-level, but per-key is rare
+
+### Feature comparison vs. competitors
+
+| Capability | Anna | Redis | etcd | TiKV | DynamoDB | Cassandra | FoundationDB |
+|---|---|---|---|---|---|---|---|
+| **TTL/Expiration** | EXPIRE (per-key, server-enforced) | Per-key | Per-lease | RawKV only | Per-item | Per-value | No |
+| **Key scan/list** | SCAN (prefix filter, paginated) | SCAN/KEYS | Range | scan() | Scan/Query | SELECT | get_range() |
+| **Watch/subscribe** | SUBSCRIBE (gossip-based, all 4 clients) | Pub/Sub + Streams | Watch API | CDC | Streams | CDC | watch(key) |
+| **Atomic CAS** | No | WATCH+MULTI | Txn if/then | CAS (RawKV) | ConditionExpression | LWT (IF) | Native (all txns) |
+| **Batch read/write** | MGET + MSET | MGET/MSET, pipeline | Range + Txn | batch_get/batch_put/scan | BatchGetItem/BatchWriteItem | SELECT IN + BATCH | get_range + Txn |
+| **Counters/Incr** | INCR/DECR (PN-Counter CRDT) | INCR/DECR | No | No | Atomic counters | Counter type | add() atomic |
+| **OR-Set** | SADD/SREM/SMEMBERS (add-wins CRDT) | SADD/SREM | No | No | No | No | No |
+| **Secondary indexes** | No | Sorted sets | No | No | GSI/LSI | Secondary indexes | Layer (manual) |
+| **Range queries** | No | ZRANGEBYSCORE | Range | scan(start,end) | Query (sort key) | Clustering cols | get_range() |
+
+### Anna's current API surface (4 clients: Rust, C++, Python, Go)
+
+| Category | Operations |
+|---|---|
+| **Core KV** | GET, PUT, DEL — get, get_bytes, get_value (auto-detect type), put, put_value (type-tagged), delete |
+| **Batch** | MGET, MSET — get_multi, put_multi (groups by worker for efficiency) |
+| **17 lattice types** | LWW, Set, OrderedSet, SingleCausal, MultiCausal, Priority, LwwSet, LwwOrderedSet, UnionScalar, PrioritySet, PriorityOrderedSet, CausalSet, CausalOrderedSet, MultiCausalSet, MultiCausalOrderedSet, Counter, OrSet |
+| **Transactions** | begin/put/get/commit/rollback (client-side buffering, read-committed + repeatable-read isolation) |
+| **Watch/subscribe** | SUBSCRIBE — ValueChangeSubscriber: watch(keys), recv_update(timeout), get_cached(key) -- all 4 clients |
+| **TTL/Expiration** | EXPIRE — put_with_ttl(key, value, ttl_seconds); per-key, server-enforced |
+| **Counter** | INCR, DECR, GET_COUNTER — increment(key, amount), decrement(key, amount), get_counter(key) |
+| **OR-Set** | SADD, SREM, SMEMBERS — or_set_add(key, element), or_set_remove(key, element), get_or_set(key) |
+| **Cluster introspection** | get_cluster_topology, get_monitoring_ips, get_key_addresses |
+| **Replication control** | put_replication_factor(key, memory_rep, local_rep) |
+| **Stats/monitoring** | get_storage_stats, get_key_access_stats, get_key_size_stats, LatencyReporter |
+| **Key scan/list** | SCAN — scan(prefix), fans out to all threads, cursor-paginated, returns key + type + size + expiry |
+
+### Remaining gaps to close
+
+No actionable gaps remain. All items from the original comparison have been implemented or classified as architecture mismatches (below).
+
+### Hardest to emulate (architecture mismatch)
+
+- **Conditional writes / CAS**: Anna's eventual consistency model conflicts with strong CAS. The causal lattice types provide partial ordering but not compare-and-swap semantics.
+- **Range queries**: Anna uses hash-based key distribution (consistent hashing). Range queries require sequential key layout, which would need a fundamentally different routing strategy.
+- **Secondary indexes**: Would require a server-side index maintenance layer that doesn't exist.
+
+### Which store's API is closest to Anna?
+
+**Redis** is the closest match in spirit -- both are in-memory, both support multiple data types (sets, sorted sets), both have pub/sub. If Anna wanted to emulate one API, a subset of the Redis command protocol (RESP) would be the most natural fit:
+
+| Redis command | Redis args | Anna CLI | Rust API | Notes |
+|---|---|---|---|---|
+| `GET` | `GET key` | `GET {key}` | `get(key)` / `get_value(key)` | Auto-detects lattice type |
+| `SET` | `SET key value` | `PUT {key} {value}` | `put(key, value)` | LWW (last-writer-wins) |
+| `DEL` | `DEL key [key...]` | `DEL {key}` | `delete(key)` | Single key per call |
+| `MGET` | `MGET key [key...]` | `MGET {k1} {k2} ...` | `get_multi(keys)` | Returns all values |
+| `MSET` | `MSET key value [key value...]` | `MSET {k1} {v1} {k2} {v2} ...` | `put_multi(pairs)` | Groups by worker for efficiency |
+| `SADD` | `SADD key member [member...]` | `SADD {key} {m1} [m2 ...]` | `or_set_add(key, element)` | OR-Set with add-wins semantics |
+| `SREM` | `SREM key member [member...]` | `SREM {key} {m1} [m2 ...]` | `or_set_remove(key, element)` | Tombstone-based removal |
+| `SMEMBERS` | `SMEMBERS key` | `SMEMBERS {key}` | `get_or_set(key)` | Returns live elements (not tombstoned) |
+| `INCR`/`INCRBY` | `INCR key` / `INCRBY key increment` | `INCR {key} [amount]` | `increment(key)` / `increment_by(key, n)` | PN-Counter CRDT |
+| `DECR`/`DECRBY` | `DECR key` / `DECRBY key decrement` | `DECR {key} [amount]` | `decrement(key)` / `decrement_by(key, n)` | PN-Counter CRDT |
+| (no equivalent) | — | `GET_COUNTER {key}` | `get_counter(key)` | Returns net counter value (incr - decr) |
+| `SETEX` | `SETEX key seconds value` | `EXPIRE {key} {value} {seconds}` | `put_with_ttl(key, value, ttl)` | Server-enforced per-key TTL |
+| `SUBSCRIBE` | `SUBSCRIBE channel [channel...]` | `SUBSCRIBE {key1} [key2 ...]` | `ValueChangeSubscriber::watch(keys)` | Gossip-based, receives on value change |
+| `SCAN` | `SCAN cursor [MATCH pattern] [COUNT count]` | `SCAN [prefix]` | `scan(prefix)` | Fans out to all KVS threads |
+
+**Differences from Redis**: Anna's `SADD`/`SREM` use OR-Set (tombstone-based CRDT) rather than Redis's simple in-memory set. Anna's `INCR`/`DECR` use a PN-Counter CRDT that converges across replicas. Anna's `SUBSCRIBE` is gossip-based (eventual delivery) rather than Redis's synchronous pub/sub. Anna's `SCAN` fans out to all KVS threads since keys are hash-distributed, while Redis scans a single hash table.

--- a/docs/api-comparison.md
+++ b/docs/api-comparison.md
@@ -2,7 +2,7 @@
 
 ## What Anna has that's unique
 
-Anna's lattice type system (17 types with CRDT-style merge semantics) is genuinely distinctive. No other major KV store offers built-in conflict-free replicated data types at the storage layer:
+Anna's lattice type system (17 types with CRDT-style merge semantics) is genuinely distinctive. Among the stores compared in this document, Anna is the only one with built-in conflict-free replicated data types at the storage layer:
 
 - **LWW, Set, OrderedSet, Priority, Causal variants, Counter, OR-Set** -- merge-able without coordination
 - **Gossip-based replication with automatic conflict resolution** -- no other store in this list does this natively
@@ -41,7 +41,7 @@ Anna's lattice type system (17 types with CRDT-style merge semantics) is genuine
 
 ## Remaining gaps to close
 
-No actionable gaps remain. All items from the original comparison have been implemented or classified as architecture mismatches (below).
+All items from the original comparison have been implemented or classified as architecture mismatches (below). The remaining items (CAS, range queries, secondary indexes) are fundamental architecture mismatches that cannot be addressed without changing Anna's core design.
 
 ## Hardest to emulate (architecture mismatch)
 

--- a/docs/client-feature-list.md
+++ b/docs/client-feature-list.md
@@ -80,11 +80,13 @@ See [autoscaling.md](autoscaling.md) for the full operator's guide.
 | Replication factor management (put_replication_factor) | Yes |
 | Cluster topology discovery (get_cluster_topology) | Yes |
 | Monitoring IP discovery (get_monitoring_ips) | Yes |
-| Per-key TTL (put_with_ttl) | Yes    |
-| PN-Counter (increment/decrement/get_counter) | Yes |
-| Batch PUT (put_multi)    | Yes    |
-| OR-Set (set_add/set_remove/get_or_set) | Yes |
-| Key scanning (scan)      | Yes    |
+| Per-key TTL (EXPIRE / put_with_ttl) | Yes    |
+| PN-Counter (INCR/DECR/GET_COUNTER) | Yes |
+| Batch PUT (MSET / put_multi)    | Yes    |
+| Batch GET (MGET / get_multi)    | Yes    |
+| OR-Set (SADD/SREM/SMEMBERS) | Yes |
+| Key scanning (SCAN)      | Yes    |
+| Value change subscription (SUBSCRIBE) | Yes |
 
 ## C++ Client (`clients/cpp`)
 

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -28,21 +28,23 @@ mocks.
 | PUT priority {key} {p} {v} | Store with priority (lowest wins)                            | Yes           |
 | PUT causal {key} {value}   | Store with multi-key causal consistency                      | Yes           |
 | PUT single_causal {key} {value} | Store with single-key causal consistency               | Yes           |
-| DELETE {key}               | Remove a key (PUT with empty value and dominating timestamp) | Yes           |
-| PUT_TTL {key} {val} {secs} | Store with TTL (auto-expires after N seconds)                | Yes           |
-| INCREMENT {key} [amount]   | Increment a PN-Counter (default +1)                          | Yes           |
-| DECREMENT {key} [amount]   | Decrement a PN-Counter (default -1)                          | Yes           |
+| DEL {key}                  | Remove a key (PUT with empty value and dominating timestamp) | Yes           |
+| EXPIRE {key} {val} {secs}  | Store with TTL (auto-expires after N seconds)                | Yes           |
+| MGET {key1} {key2} ...     | Retrieve multiple keys at once                               | Yes           |
+| MSET {k1} {v1} {k2} {v2}  | Batch PUT multiple LWW key-value pairs                       | Yes           |
+| SADD {key} {m1} [m2 ...]   | Add member(s) to an OR-Set                                   | Yes           |
+| SREM {key} {m1} [m2 ...]   | Remove member(s) from an OR-Set                              | Yes           |
+| SMEMBERS {key}             | Get all members of an OR-Set                                 | Yes           |
+| INCR {key} [amount]        | Increment a PN-Counter (default +1)                          | Yes           |
+| DECR {key} [amount]        | Decrement a PN-Counter (default -1)                          | Yes           |
 | GET_COUNTER {key}          | Get counter value (sum of increments - decrements)           | Yes           |
-| SET_ADD {key} {element}    | Add element to OR-Set                                        | Yes           |
-| SET_REMOVE {key} {element} | Remove element from OR-Set                                   | Yes           |
-| GET_OR_SET {key}           | Get live elements of OR-Set                                  | Yes           |
-| Address cache invalidation | Server signals client to refresh address cache               | Yes           |
-| Multi-key GET              | Retrieve multiple keys in one request                        | Yes           |
-| Multi-key PUT (put_multi)  | Batch PUT multiple keys in one request per worker            | Yes           |
 | SCAN [prefix]              | List keys matching prefix (fans out to all threads)          | Yes           |
+| SUBSCRIBE {key1} [key2 ...]| Watch keys for value changes (Ctrl+C to stop)                | Yes           |
+| Address cache invalidation | Server signals client to refresh address cache               | Yes           |
 
-Legacy commands (`GET_SET`, `PUT_SET`, `GET_CAUSAL`, `PUT_CAUSAL`, etc.) are
-still supported as aliases for backward compatibility.
+Legacy commands (`DELETE`, `PUT_TTL`, `INCREMENT`, `DECREMENT`, `SET_ADD`,
+`SET_REMOVE`, `GET_OR_SET`, `PUT_MULTI`, `GET_SET`, `PUT_SET`, `GET_CAUSAL`,
+`PUT_CAUSAL`, etc.) are still supported as aliases for backward compatibility.
 
 ## Lattice Types
 

--- a/tests/shared/cli/expected
+++ b/tests/shared/cli/expected
@@ -19,6 +19,7 @@ important
 entry1
 entry2
 deleteme
+(nil)
 h: mget1
 i: mget2
 

--- a/tests/shared/cli/expected
+++ b/tests/shared/cli/expected
@@ -19,4 +19,6 @@ important
 entry1
 entry2
 deleteme
+h: mget1
+i: mget2
 

--- a/tests/shared/cli/input
+++ b/tests/shared/cli/input
@@ -32,6 +32,7 @@ GET mylog
 PUT g deleteme
 GET g
 DEL g
+GET g
 PUT h mget1
 PUT i mget2
 MGET h i

--- a/tests/shared/cli/input
+++ b/tests/shared/cli/input
@@ -31,4 +31,7 @@ PUT union mylog entry2
 GET mylog
 PUT g deleteme
 GET g
-DELETE g
+DEL g
+PUT h mget1
+PUT i mget2
+MGET h i


### PR DESCRIPTION
## Summary

Renames CLI commands across all 4 clients (Rust, C++, Python, Go) to match Redis equivalents. Old command names are preserved as aliases for backward compatibility.

## Redis command mapping

| Redis | Anna CLI | Rust API | Notes |
|---|---|---|---|
| `GET key` | `GET {key}` | `get(key)` / `get_value(key)` | Auto-detects lattice type |
| `SET key value` | `PUT {key} {value}` | `put(key, value)` | LWW (last-writer-wins) |
| `DEL key` | `DEL {key}` | `delete(key)` | Was `DELETE` |
| `MGET key [key...]` | `MGET {k1} {k2} ...` | `get_multi(keys)` | New in all CLIs |
| `MSET key value [kv...]` | `MSET {k1} {v1} ...` | `put_multi(pairs)` | Was `PUT_MULTI` |
| `SADD key member [m...]` | `SADD {key} {m1} [m2...]` | `or_set_add(key, el)` | Was `SET_ADD`, now multi-member |
| `SREM key member [m...]` | `SREM {key} {m1} [m2...]` | `or_set_remove(key, el)` | Was `SET_REMOVE`, now multi-member |
| `SMEMBERS key` | `SMEMBERS {key}` | `get_or_set(key)` | Was `GET_OR_SET` |
| `INCR key` / `INCRBY key n` | `INCR {key} [amount]` | `increment(key)` | Was `INCREMENT` |
| `DECR key` / `DECRBY key n` | `DECR {key} [amount]` | `decrement(key)` | Was `DECREMENT` |
| `SETEX key seconds value` | `EXPIRE {key} {val} {secs}` | `put_with_ttl(key, val, ttl)` | Was `PUT_TTL` |
| `SUBSCRIBE channel [...]` | `SUBSCRIBE {key1} [...]` | `ValueChangeSubscriber` | New, gossip-based |
| `SCAN cursor [MATCH ...]` | `SCAN [prefix]` | `scan(prefix)` | Already existed |

## Changes per client

| Command | Rust | C++ | Python | Go |
|---|---|---|---|---|
| DEL | Full | Full | Full | Full |
| MGET | Full | Full | Full | Full |
| MSET | Full | — | — | — |
| SADD | Full (multi-member) | Stub | Stub | Stub |
| SREM | Full (multi-member) | Stub | Stub | Stub |
| SMEMBERS | Full | Stub | Stub | Stub |
| INCR/DECR | Full | — | — | — |
| EXPIRE | Full | — | — | — |
| SUBSCRIBE | Full (blocking loop) | Note | Note | Note |

Stubs print an error directing users to use the Rust CLI until OR-Set methods are added to the C++/Python/Go client libraries.

## Docs updated
- `docs/feature-list.md`: updated command names
- `docs/client-feature-list.md`: updated feature names  
- Issue #346: updated Redis comparison table with Redis args, CLI command, and Rust API columns