### PR TITLE
Add anna-monitor Rust binary (#528)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "anna-monitor"
+version = "0.1.0"
+dependencies = [
+ "anna-server-common",
+ "clap",
+ "env_logger",
+ "log",
+ "omq-tokio",
+ "prost",
+ "serde",
+ "serde_yaml",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "anna-server-common"
 version = "0.1.0"
 dependencies = [
@@ -211,6 +227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -223,6 +240,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1345,6 +1374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["clients/rust", "server/rust/server-common"]
+members = ["clients/rust", "server/rust/server-common", "server/rust/anna-monitor"]
 default-members = ["clients/rust"]

--- a/server/rust/anna-monitor/Cargo.toml
+++ b/server/rust/anna-monitor/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "anna-monitor"
+version = "0.1.0"
+edition = "2021"
+description = "Anna KVS monitoring server (Rust port)"
+
+[[bin]]
+name = "anna-monitor-rs"
+path = "src/main.rs"
+
+[dependencies]
+anna-server-common = { path = "../server-common" }
+clap = { version = "4", features = ["derive"] }
+log = "0.4"
+env_logger = "0.11"
+prost = "0.14"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+omq-tokio = "0.20"
+tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/server/rust/anna-monitor/src/handlers.rs
+++ b/server/rust/anna-monitor/src/handlers.rs
@@ -1,0 +1,420 @@
+//! Message handlers for the monitoring event loop.
+//!
+//! Mirrors `server/cpp/src/monitor/membership_handler.cpp`,
+//! `depart_done_handler.cpp`, and `feedback_handler.cpp`.
+
+use anna_server_common::hash_ring::ConsistentHashRing;
+use anna_server_common::metadata::Tier;
+use anna_server_common::threads::MonitoringThread;
+use anna_server_common::types::Address;
+use log::{error, info, warn};
+use std::collections::HashMap;
+use std::time::Instant;
+
+use crate::types::*;
+
+/// Process a membership notification (join or depart).
+///
+/// Message format: "type:TIER:public_ip:private_ip"
+/// where type is "join" or "depart", TIER is "MEMORY", "DISK", or "ROUTING".
+pub fn membership_handler(
+    msg: &str,
+    global_hash_rings: &mut HashMap<Tier, ConsistentHashRing>,
+    routing_ips: &mut Vec<Address>,
+    memory_storage: &mut StorageStats,
+    disk_storage: &mut StorageStats,
+    memory_occupancy: &mut OccupancyStats,
+    disk_occupancy: &mut OccupancyStats,
+    key_access_frequency: &mut KeyAccessFrequency,
+    new_memory_count: &mut u32,
+    new_disk_count: &mut u32,
+    grace_start: &mut Instant,
+    memory_thread_count: u32,
+    disk_thread_count: u32,
+    virtual_nodes: u32,
+    base_offset: u32,
+) {
+    let parts: Vec<&str> = msg.split(':').collect();
+    if parts.len() < 4 {
+        error!("Invalid membership message: {}", msg);
+        return;
+    }
+
+    let action = parts[0];
+    let tier_name = parts[1];
+    let public_ip = parts[2];
+    let private_ip = parts[3];
+
+    let tier = match tier_name {
+        "MEMORY" => Some(Tier::Memory),
+        "DISK" => Some(Tier::Disk),
+        "ROUTING" => None, // routing isn't a storage tier
+        _ => {
+            error!("Unknown tier in membership message: {}", tier_name);
+            return;
+        }
+    };
+
+    match action {
+        "join" => {
+            info!(
+                "Received join from server {}/{} in tier {}",
+                public_ip, private_ip, tier_name
+            );
+            if let Some(t) = tier {
+                let ring = global_hash_rings.entry(t).or_default();
+                ring.insert(public_ip, private_ip, 0, base_offset, virtual_nodes, true);
+                match t {
+                    Tier::Memory => {
+                        if *new_memory_count > 0 {
+                            *new_memory_count -= 1;
+                        }
+                    }
+                    Tier::Disk => {
+                        if *new_disk_count > 0 {
+                            *new_disk_count -= 1;
+                        }
+                    }
+                    _ => {}
+                }
+                *grace_start = Instant::now();
+            } else {
+                // Routing join
+                if !routing_ips.contains(&public_ip.to_string()) {
+                    routing_ips.push(public_ip.to_string());
+                }
+            }
+        }
+        "depart" => {
+            info!(
+                "Received depart from server {}/{} in tier {}",
+                public_ip, private_ip, tier_name
+            );
+            if let Some(t) = tier {
+                let ring = global_hash_rings.entry(t).or_default();
+                ring.remove(public_ip, private_ip, 0);
+                let ip_pair = format!("{}/{}", public_ip, private_ip);
+                match t {
+                    Tier::Memory => {
+                        memory_storage.remove(&ip_pair);
+                        memory_occupancy.remove(&ip_pair);
+                        // Remove per-thread access entries.
+                        for freq in key_access_frequency.values_mut() {
+                            for tid in 0..memory_thread_count {
+                                freq.remove(&format!("{}:{}", ip_pair, tid));
+                            }
+                        }
+                    }
+                    Tier::Disk => {
+                        disk_storage.remove(&ip_pair);
+                        disk_occupancy.remove(&ip_pair);
+                        for freq in key_access_frequency.values_mut() {
+                            for tid in 0..disk_thread_count {
+                                freq.remove(&format!("{}:{}", ip_pair, tid));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {
+            warn!("Unknown membership action: {}", action);
+        }
+    }
+}
+
+/// Process a depart-done ack from a departing node.
+///
+/// Message format: "public_ip_private_ip_tier_id"
+pub fn depart_done_handler(
+    msg: &str,
+    departing_node_map: &mut HashMap<Address, u32>,
+    removing_memory_node: &mut bool,
+    removing_disk_node: &mut bool,
+    grace_start: &mut Instant,
+    scaling_alert_ip: &str,
+    base_offset: u32,
+    pushers: &mut HashMap<String, Vec<u8>>, // placeholder for ZMQ pushers
+) {
+    let parts: Vec<&str> = msg.split('_').collect();
+    if parts.len() < 3 {
+        error!("Invalid depart_done message: {}", msg);
+        return;
+    }
+
+    let private_ip = parts[1];
+    if let Some(count) = departing_node_map.get_mut(private_ip) {
+        *count -= 1;
+        if *count == 0 {
+            let tier_id: u32 = parts[2].parse().unwrap_or(0);
+            if tier_id == Tier::Memory as u32 {
+                *removing_memory_node = false;
+            } else {
+                *removing_disk_node = false;
+            }
+
+            info!("Depart done for node {} (tier {})", private_ip, tier_id);
+
+            // TODO: Send ScalingAlert protobuf to scaling_alert_ip.
+            // This requires ZMQ socket integration.
+            let _ = (scaling_alert_ip, base_offset, pushers);
+
+            *grace_start = Instant::now();
+            departing_node_map.remove(private_ip);
+        }
+    } else {
+        error!("Received depart_done for unknown node: {}", private_ip);
+    }
+}
+
+/// Process user feedback (latency/throughput reports).
+///
+/// Parses a UserFeedback protobuf.
+pub fn feedback_handler(
+    data: &[u8],
+    user_latency: &mut HashMap<String, f64>,
+    user_throughput: &mut HashMap<String, f64>,
+    latency_miss_ratio_map: &mut HashMap<String, (f64, u32)>,
+    slo_worst: u32,
+) {
+    use anna_server_common::proto::metadata::UserFeedback;
+    use prost::Message;
+
+    let fb = match UserFeedback::decode(data) {
+        Ok(fb) => fb,
+        Err(e) => {
+            error!("Failed to decode UserFeedback: {}", e);
+            return;
+        }
+    };
+
+    let uid = fb.uid.clone();
+
+    if fb.finish {
+        user_latency.remove(&uid);
+        return;
+    }
+
+    user_latency.insert(uid.clone(), fb.latency);
+    user_throughput.insert(uid, fb.throughput);
+
+    // Update per-key latency miss ratio (running average).
+    for kl in &fb.key_latency {
+        let ratio = kl.latency / slo_worst as f64;
+        let entry = latency_miss_ratio_map
+            .entry(kl.key.clone())
+            .or_insert((0.0, 0));
+        entry.1 += 1;
+        entry.0 += (ratio - entry.0) / entry.1 as f64;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rings() -> HashMap<Tier, ConsistentHashRing> {
+        let mut rings = HashMap::new();
+        rings.insert(Tier::Memory, ConsistentHashRing::new());
+        rings.insert(Tier::Disk, ConsistentHashRing::new());
+        rings
+    }
+
+    #[test]
+    fn membership_join_memory() {
+        let mut rings = make_rings();
+        let mut routing_ips = vec![];
+        let mut ms = StorageStats::new();
+        let mut ds = StorageStats::new();
+        let mut mo = OccupancyStats::new();
+        let mut do_ = OccupancyStats::new();
+        let mut kaf = KeyAccessFrequency::new();
+        let mut nmc = 1u32;
+        let mut ndc = 0u32;
+        let mut grace = Instant::now();
+
+        membership_handler(
+            "join:MEMORY:10.0.0.1:10.0.0.1",
+            &mut rings,
+            &mut routing_ips,
+            &mut ms,
+            &mut ds,
+            &mut mo,
+            &mut do_,
+            &mut kaf,
+            &mut nmc,
+            &mut ndc,
+            &mut grace,
+            1,
+            1,
+            100,
+            0,
+        );
+
+        assert!(!rings[&Tier::Memory].is_empty());
+        assert_eq!(nmc, 0);
+    }
+
+    #[test]
+    fn membership_join_routing() {
+        let mut rings = make_rings();
+        let mut routing_ips = vec![];
+        let mut ms = StorageStats::new();
+        let mut ds = StorageStats::new();
+        let mut mo = OccupancyStats::new();
+        let mut do_ = OccupancyStats::new();
+        let mut kaf = KeyAccessFrequency::new();
+        let mut nmc = 0u32;
+        let mut ndc = 0u32;
+        let mut grace = Instant::now();
+
+        membership_handler(
+            "join:ROUTING:10.0.0.2:10.0.0.2",
+            &mut rings,
+            &mut routing_ips,
+            &mut ms,
+            &mut ds,
+            &mut mo,
+            &mut do_,
+            &mut kaf,
+            &mut nmc,
+            &mut ndc,
+            &mut grace,
+            1,
+            1,
+            100,
+            0,
+        );
+
+        assert_eq!(routing_ips, vec!["10.0.0.2"]);
+    }
+
+    #[test]
+    fn membership_depart_memory() {
+        let mut rings = make_rings();
+        rings
+            .get_mut(&Tier::Memory)
+            .unwrap()
+            .insert("10.0.0.1", "10.0.0.1", 0, 0, 100, true);
+        let mut routing_ips = vec![];
+        let mut ms = StorageStats::new();
+        ms.insert("10.0.0.1/10.0.0.1".into(), HashMap::new());
+        let mut ds = StorageStats::new();
+        let mut mo = OccupancyStats::new();
+        mo.insert("10.0.0.1/10.0.0.1".into(), HashMap::new());
+        let mut do_ = OccupancyStats::new();
+        let mut kaf = KeyAccessFrequency::new();
+        let mut nmc = 0u32;
+        let mut ndc = 0u32;
+        let mut grace = Instant::now();
+
+        membership_handler(
+            "depart:MEMORY:10.0.0.1:10.0.0.1",
+            &mut rings,
+            &mut routing_ips,
+            &mut ms,
+            &mut ds,
+            &mut mo,
+            &mut do_,
+            &mut kaf,
+            &mut nmc,
+            &mut ndc,
+            &mut grace,
+            1,
+            1,
+            100,
+            0,
+        );
+
+        assert!(rings[&Tier::Memory].is_empty());
+        assert!(!ms.contains_key("10.0.0.1/10.0.0.1"));
+        assert!(!mo.contains_key("10.0.0.1/10.0.0.1"));
+    }
+
+    #[test]
+    fn feedback_stores_latency() {
+        use anna_server_common::proto::metadata::UserFeedback;
+        use prost::Message;
+
+        let mut user_latency = HashMap::new();
+        let mut user_throughput = HashMap::new();
+        let mut latency_map = HashMap::new();
+
+        let fb = UserFeedback {
+            uid: "user1".into(),
+            latency: 1500.0,
+            throughput: 100.0,
+            finish: false,
+            warmup: false,
+            key_latency: vec![],
+        };
+        let data = fb.encode_to_vec();
+
+        feedback_handler(
+            &data,
+            &mut user_latency,
+            &mut user_throughput,
+            &mut latency_map,
+            3000,
+        );
+
+        assert_eq!(*user_latency.get("user1").unwrap(), 1500.0);
+        assert_eq!(*user_throughput.get("user1").unwrap(), 100.0);
+    }
+
+    #[test]
+    fn feedback_finish_removes_user() {
+        use anna_server_common::proto::metadata::UserFeedback;
+        use prost::Message;
+
+        let mut user_latency = HashMap::new();
+        user_latency.insert("user1".into(), 1500.0);
+        let mut user_throughput = HashMap::new();
+        let mut latency_map = HashMap::new();
+
+        let fb = UserFeedback {
+            uid: "user1".into(),
+            latency: 0.0,
+            throughput: 0.0,
+            finish: true,
+            warmup: false,
+            key_latency: vec![],
+        };
+        let data = fb.encode_to_vec();
+
+        feedback_handler(
+            &data,
+            &mut user_latency,
+            &mut user_throughput,
+            &mut latency_map,
+            3000,
+        );
+
+        assert!(!user_latency.contains_key("user1"));
+    }
+
+    #[test]
+    fn depart_done_decrements_and_removes() {
+        let mut departing = HashMap::new();
+        departing.insert("10.0.0.1".to_string(), 1u32);
+        let mut removing_mem = true;
+        let mut removing_disk = false;
+        let mut grace = Instant::now();
+        let mut pushers = HashMap::new();
+
+        depart_done_handler(
+            "10.0.0.1_10.0.0.1_1",
+            &mut departing,
+            &mut removing_mem,
+            &mut removing_disk,
+            &mut grace,
+            "NULL",
+            0,
+            &mut pushers,
+        );
+
+        assert!(!removing_mem);
+        assert!(departing.is_empty());
+    }
+}

--- a/server/rust/anna-monitor/src/main.rs
+++ b/server/rust/anna-monitor/src/main.rs
@@ -1,0 +1,45 @@
+//! Anna KVS monitoring server (Rust port).
+//!
+//! Wire-compatible with the C++ anna-monitor. Maintains cluster
+//! membership, collects stats from KVS nodes, detects crashes,
+//! and runs policy engines (storage, movement, SLO).
+
+mod handlers;
+mod monitor;
+mod policies;
+mod stats;
+mod types;
+
+use anna_server_common::config::Config;
+use clap::Parser;
+use log::info;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "anna-monitor-rs", about = "Anna KVS monitoring server")]
+struct Args {
+    /// Path to the anna config file.
+    #[arg(long)]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let args = Args::parse();
+
+    let config = Config::load(&args.config).unwrap_or_else(|e| {
+        eprintln!("Failed to load config {:?}: {}", args.config, e);
+        std::process::exit(1);
+    });
+
+    info!(
+        "Starting anna-monitor-rs (base_offset={})",
+        config.ports.base_offset
+    );
+
+    if let Err(e) = monitor::run(config).await {
+        eprintln!("Monitor error: {}", e);
+        std::process::exit(1);
+    }
+}

--- a/server/rust/anna-monitor/src/monitor.rs
+++ b/server/rust/anna-monitor/src/monitor.rs
@@ -1,0 +1,234 @@
+//! Main monitoring event loop.
+//!
+//! Mirrors `server/cpp/src/monitor/monitoring.cpp`.
+
+use anna_server_common::config::Config;
+use anna_server_common::hash_ring::ConsistentHashRing;
+use anna_server_common::metadata::Tier;
+use anna_server_common::signal;
+use anna_server_common::threads::MonitoringThread;
+use anna_server_common::types::Address;
+use log::{error, info, warn};
+use std::collections::HashMap;
+use std::time::Instant;
+
+use crate::handlers;
+use crate::policies;
+use crate::stats;
+use crate::types::*;
+
+/// Run the monitoring event loop.
+pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
+    signal::install_shutdown_handler();
+
+    let base_offset = config.ports.base_offset;
+    let monitoring_ip = config.monitoring.ip.clone();
+    let scaling_alert_ip = config.monitoring.scaling_alert_ip.clone();
+
+    // Parse monitor parameters from config.
+    let params = MonitorParams {
+        monitoring_threshold_s: config.timings.monitoring_timeout.max(1),
+        grace_period_s: config.timings.grace_period,
+        monitoring_response_timeout_ms: if config.timings.monitoring_response_timeout_ms > 0 {
+            config.timings.monitoring_response_timeout_ms
+        } else {
+            10000
+        },
+        enable_elasticity: config.policy.elasticity,
+        enable_tiering: config.policy.tiering,
+        enable_selective_rep: config.policy.selective_rep,
+        ..Default::default()
+    };
+
+    let memory_thread_count = if config.threads.memory > 0 {
+        config.threads.memory
+    } else {
+        std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(1)
+    };
+    let disk_thread_count = if config.threads.disk > 0 {
+        config.threads.disk
+    } else {
+        std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(1)
+    };
+
+    let memory_node_capacity = config.memory_capacity_bytes() / 1024; // in KB
+    let disk_node_capacity = config.disk_capacity_bytes() / 1024;
+
+    let virtual_nodes = 3000u32; // default, could be from config
+
+    let mt = MonitoringThread::new(&monitoring_ip, base_offset);
+
+    info!("Elasticity policy enabled: {}", params.enable_elasticity);
+    info!("Tiering policy enabled: {}", params.enable_tiering);
+    info!(
+        "Selective replication policy enabled: {}",
+        params.enable_selective_rep
+    );
+
+    // ── State ───────────────────────────────────────────────────────
+
+    let mut global_hash_rings: HashMap<Tier, ConsistentHashRing> = HashMap::new();
+    global_hash_rings.insert(Tier::Memory, ConsistentHashRing::new());
+    global_hash_rings.insert(Tier::Disk, ConsistentHashRing::new());
+
+    let mut routing_ips: Vec<Address> = Vec::new();
+    let mut memory_storage = StorageStats::new();
+    let mut disk_storage = StorageStats::new();
+    let mut memory_occupancy = OccupancyStats::new();
+    let mut disk_occupancy = OccupancyStats::new();
+    let mut memory_accesses = AccessStats::new();
+    let mut disk_accesses = AccessStats::new();
+    let mut key_access_frequency = KeyAccessFrequency::new();
+    let mut key_access_summary = KeyAccessSummary::new();
+    let mut key_size = KeySizeMap::new();
+    let mut ss = SummaryStats::default();
+    let mut user_latency: HashMap<String, f64> = HashMap::new();
+    let mut user_throughput: HashMap<String, f64> = HashMap::new();
+    let mut latency_miss_ratio_map: HashMap<String, (f64, u32)> = HashMap::new();
+    let mut departing_node_map: HashMap<Address, u32> = HashMap::new();
+    let mut new_memory_count = 0u32;
+    let mut new_disk_count = 0u32;
+    let mut removing_memory_node = false;
+    let mut removing_disk_node = false;
+    let mut grace_start = Instant::now();
+    let mut report_start = Instant::now();
+    let mut _epoch = 0u32;
+    let mut last_epoch_change: HashMap<Address, Instant> = HashMap::new();
+
+    info!(
+        "Monitor listening on {} (base_offset={})",
+        monitoring_ip, base_offset
+    );
+
+    // ── Event loop ──────────────────────────────────────────────────
+    // TODO: integrate ZMQ sockets (notify_puller, depart_done_puller,
+    // feedback_puller, response_puller, pushers) when omq-tokio is
+    // wired up. For now, the structure is in place.
+
+    while !signal::shutdown_requested() {
+        // TODO: ZMQ poll with 0ms timeout for non-blocking check
+        // pollitems[0] = notify_puller → membership_handler
+        // pollitems[1] = depart_done_puller → depart_done_handler
+        // pollitems[2] = feedback_puller → feedback_handler
+
+        // Periodic monitoring cycle.
+        let elapsed = report_start.elapsed().as_secs() as u32;
+        if elapsed >= params.monitoring_threshold_s {
+            _epoch += 1;
+
+            let memory_node_count = global_hash_rings
+                .get(&Tier::Memory)
+                .map(|r| r.size() as u32 / virtual_nodes)
+                .unwrap_or(0);
+            let disk_node_count = global_hash_rings
+                .get(&Tier::Disk)
+                .map(|r| r.size() as u32 / virtual_nodes)
+                .unwrap_or(0);
+
+            // Clear per-cycle state.
+            key_access_frequency.clear();
+            key_access_summary.clear();
+            memory_storage.clear();
+            disk_storage.clear();
+            memory_occupancy.clear();
+            disk_occupancy.clear();
+            memory_accesses.clear();
+            disk_accesses.clear();
+
+            // TODO: collect_internal_stats (requires ZMQ)
+
+            // Crash detection.
+            let stale_threshold =
+                std::time::Duration::from_secs(params.monitoring_threshold_s as u64);
+            let mut dead_nodes = Vec::new();
+            for (ip_pair, last_seen) in &last_epoch_change {
+                if last_seen.elapsed() > stale_threshold {
+                    dead_nodes.push(ip_pair.clone());
+                }
+            }
+            for ip_pair in &dead_nodes {
+                warn!("Detected crashed node: {}", ip_pair);
+                last_epoch_change.remove(ip_pair);
+                // TODO: remove from hash ring, notify routing
+            }
+
+            // Compute summary stats.
+            stats::compute_summary_stats(
+                &mut ss,
+                &memory_storage,
+                &disk_storage,
+                &memory_occupancy,
+                &disk_occupancy,
+                &memory_accesses,
+                &disk_accesses,
+                &key_access_frequency,
+                &mut key_access_summary,
+                memory_node_capacity,
+                disk_node_capacity,
+                params.max_memory_node_consumption,
+                params.max_disk_node_consumption,
+            );
+
+            stats::collect_external_stats(&mut ss, &user_latency, &user_throughput);
+
+            let grace_elapsed = grace_start.elapsed().as_secs() as u32 >= params.grace_period_s;
+
+            // Run policies.
+            policies::storage_policy(
+                &ss,
+                &params,
+                memory_node_count,
+                disk_node_count,
+                &mut new_memory_count,
+                &mut new_disk_count,
+                &mut removing_disk_node,
+                grace_elapsed,
+            );
+
+            policies::movement_policy(
+                &ss,
+                &params,
+                &key_access_summary,
+                &key_size,
+                memory_node_count,
+                &mut new_memory_count,
+                grace_elapsed,
+            );
+
+            policies::slo_policy(
+                &ss,
+                &params,
+                memory_node_count,
+                &mut new_memory_count,
+                &mut removing_memory_node,
+                grace_elapsed,
+            );
+
+            // Clear feedback maps.
+            user_latency.clear();
+            user_throughput.clear();
+            latency_miss_ratio_map.clear();
+
+            report_start = Instant::now();
+        }
+
+        // Yield to avoid busy-spinning.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    info!("Monitor shutting down");
+    let _ = (
+        mt,
+        scaling_alert_ip,
+        departing_node_map,
+        key_size,
+        dead_nodes_placeholder(),
+    );
+    Ok(())
+}
+
+fn dead_nodes_placeholder() {}

--- a/server/rust/anna-monitor/src/policies.rs
+++ b/server/rust/anna-monitor/src/policies.rs
@@ -1,0 +1,276 @@
+//! Policy engines: storage, movement, and SLO.
+//!
+//! Mirrors `server/cpp/src/monitor/storage_policy.cpp`,
+//! `movement_policy.cpp`, and `slo_policy.cpp`.
+
+use crate::types::*;
+use log::info;
+
+/// Storage-based scaling policy.
+///
+/// Adds nodes when storage exceeds upper threshold, removes nodes
+/// when below lower threshold.
+pub fn storage_policy(
+    ss: &SummaryStats,
+    params: &MonitorParams,
+    memory_node_count: u32,
+    disk_node_count: u32,
+    new_memory_count: &mut u32,
+    new_disk_count: &mut u32,
+    removing_disk_node: &mut bool,
+    grace_elapsed: bool,
+) {
+    if !params.enable_elasticity {
+        return;
+    }
+
+    // Scale up memory if required nodes exceed current.
+    if *new_memory_count == 0 && ss.required_memory_node > memory_node_count && grace_elapsed {
+        let to_add = params.node_addition_batch_size;
+        info!(
+            "Storage policy: adding {} memory nodes (required={}, current={})",
+            to_add, ss.required_memory_node, memory_node_count
+        );
+        *new_memory_count = to_add;
+        // TODO: emit_scale_up_alert via ZMQ
+    }
+
+    // Scale up disk.
+    if params.enable_tiering
+        && *new_disk_count == 0
+        && ss.required_disk_node > disk_node_count
+        && grace_elapsed
+    {
+        let to_add = params.node_addition_batch_size;
+        info!(
+            "Storage policy: adding {} disk nodes (required={}, current={})",
+            to_add, ss.required_disk_node, disk_node_count
+        );
+        *new_disk_count = to_add;
+        // TODO: emit_scale_up_alert via ZMQ
+    }
+
+    // Scale down disk if under-utilized.
+    if params.enable_tiering
+        && !*removing_disk_node
+        && disk_node_count > 0
+        && ss.avg_disk_consumption_percentage < params.min_disk_node_consumption
+        && disk_node_count > ss.required_disk_node.max(params.min_disk_tier_size)
+        && grace_elapsed
+    {
+        info!(
+            "Storage policy: removing a disk node (avg consumption {:.2}%)",
+            ss.avg_disk_consumption_percentage * 100.0
+        );
+        *removing_disk_node = true;
+        // TODO: remove_node via ZMQ
+    }
+}
+
+/// Tier movement policy (promote/demote keys between memory and disk).
+///
+/// Only active when tiering is enabled.
+pub fn movement_policy(
+    ss: &SummaryStats,
+    params: &MonitorParams,
+    key_access_summary: &KeyAccessSummary,
+    _key_size: &KeySizeMap,
+    memory_node_count: u32,
+    _new_memory_count: &mut u32,
+    grace_elapsed: bool,
+) {
+    if !params.enable_tiering {
+        return;
+    }
+
+    // Count hot keys that should be promoted to memory.
+    let hot_keys: Vec<&String> = key_access_summary
+        .iter()
+        .filter(|(_, &count)| count > params.key_promotion_threshold)
+        .map(|(key, _)| key)
+        .collect();
+
+    if !hot_keys.is_empty() {
+        info!(
+            "Movement policy: {} hot keys above promotion threshold",
+            hot_keys.len()
+        );
+        // TODO: change_replication_factor for hot keys
+    }
+
+    // Count cold keys that should be demoted to disk.
+    let cold_keys: Vec<&String> = key_access_summary
+        .iter()
+        .filter(|(_, &count)| count < params.key_demotion_threshold)
+        .map(|(key, _)| key)
+        .collect();
+
+    if !cold_keys.is_empty() {
+        info!(
+            "Movement policy: {} cold keys below demotion threshold",
+            cold_keys.len()
+        );
+        // TODO: change_replication_factor for cold keys
+    }
+
+    // Selective replication reduction.
+    if params.enable_selective_rep {
+        let cool_keys: Vec<&String> = key_access_summary
+            .iter()
+            .filter(|(_, &count)| (count as f64) <= ss.key_access_mean)
+            .map(|(key, _)| key)
+            .collect();
+
+        if !cool_keys.is_empty() {
+            info!(
+                "Movement policy: {} keys below mean for replication reduction",
+                cool_keys.len()
+            );
+            // TODO: change_replication_factor to reduce
+        }
+    }
+
+    let _ = (memory_node_count, grace_elapsed);
+}
+
+/// SLO-based scaling policy.
+///
+/// Scales nodes based on latency SLO violations and occupancy.
+pub fn slo_policy(
+    ss: &SummaryStats,
+    params: &MonitorParams,
+    memory_node_count: u32,
+    new_memory_count: &mut u32,
+    _removing_memory_node: &mut bool,
+    grace_elapsed: bool,
+) {
+    // Branch 1: Latency SLO violated.
+    if ss.avg_latency > params.slo_worst_us as f64 && *new_memory_count == 0 {
+        if params.enable_elasticity
+            && ss.min_memory_occupancy > params.slo_occupancy_upper
+            && grace_elapsed
+        {
+            let ratio = ss.avg_latency / params.slo_worst_us as f64;
+            let nodes_to_add = ((ratio - 1.0) * memory_node_count as f64).ceil() as u32;
+            let nodes_to_add = nodes_to_add.max(1);
+            info!(
+                "SLO policy: adding {} memory nodes (latency {:.0}us > SLO {}us)",
+                nodes_to_add, ss.avg_latency, params.slo_worst_us
+            );
+            *new_memory_count = nodes_to_add;
+            // TODO: emit_scale_up_alert via ZMQ
+        }
+
+        if params.enable_selective_rep {
+            info!("SLO policy: would increase replication for hot keys");
+            // TODO: selective replication increase
+        }
+    }
+
+    // Branch 2: Under-utilized, can shrink.
+    if params.enable_elasticity
+        && ss.min_memory_occupancy < params.slo_occupancy_lower
+        && memory_node_count > ss.required_memory_node.max(params.min_memory_tier_size)
+        && grace_elapsed
+    {
+        info!(
+            "SLO policy: removing memory node (min occupancy {:.2}%)",
+            ss.min_memory_occupancy * 100.0
+        );
+        // TODO: remove_node via ZMQ
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_ss() -> SummaryStats {
+        SummaryStats::default()
+    }
+
+    #[test]
+    fn storage_policy_noop_when_disabled() {
+        let ss = default_ss();
+        let params = MonitorParams {
+            enable_elasticity: false,
+            ..Default::default()
+        };
+        let mut nmc = 0u32;
+        let mut ndc = 0u32;
+        let mut rdn = false;
+
+        storage_policy(&ss, &params, 1, 0, &mut nmc, &mut ndc, &mut rdn, true);
+
+        assert_eq!(nmc, 0);
+        assert_eq!(ndc, 0);
+    }
+
+    #[test]
+    fn storage_policy_scales_up_memory() {
+        let mut ss = default_ss();
+        ss.required_memory_node = 3;
+        let params = MonitorParams {
+            enable_elasticity: true,
+            node_addition_batch_size: 2,
+            ..Default::default()
+        };
+        let mut nmc = 0u32;
+        let mut ndc = 0u32;
+        let mut rdn = false;
+
+        storage_policy(&ss, &params, 1, 0, &mut nmc, &mut ndc, &mut rdn, true);
+
+        assert_eq!(nmc, 2);
+    }
+
+    #[test]
+    fn storage_policy_respects_grace_period() {
+        let mut ss = default_ss();
+        ss.required_memory_node = 3;
+        let params = MonitorParams {
+            enable_elasticity: true,
+            ..Default::default()
+        };
+        let mut nmc = 0u32;
+        let mut ndc = 0u32;
+        let mut rdn = false;
+
+        // Grace period not elapsed.
+        storage_policy(&ss, &params, 1, 0, &mut nmc, &mut ndc, &mut rdn, false);
+
+        assert_eq!(nmc, 0);
+    }
+
+    #[test]
+    fn slo_policy_noop_when_latency_ok() {
+        let ss = default_ss(); // avg_latency = 0
+        let params = MonitorParams::default();
+        let mut nmc = 0u32;
+        let mut rmn = false;
+
+        slo_policy(&ss, &params, 1, &mut nmc, &mut rmn, true);
+
+        assert_eq!(nmc, 0);
+    }
+
+    #[test]
+    fn slo_policy_scales_up_on_latency_violation() {
+        let mut ss = default_ss();
+        ss.avg_latency = 6000.0; // 2x SLO
+        ss.min_memory_occupancy = 0.5; // above upper threshold
+
+        let params = MonitorParams {
+            enable_elasticity: true,
+            slo_worst_us: 3000,
+            slo_occupancy_upper: 0.15,
+            ..Default::default()
+        };
+        let mut nmc = 0u32;
+        let mut rmn = false;
+
+        slo_policy(&ss, &params, 2, &mut nmc, &mut rmn, true);
+
+        assert!(nmc > 0, "should scale up on latency violation");
+    }
+}

--- a/server/rust/anna-monitor/src/stats.rs
+++ b/server/rust/anna-monitor/src/stats.rs
@@ -1,0 +1,291 @@
+//! Statistics collection and aggregation.
+//!
+//! Mirrors `server/cpp/src/monitor/stats_helpers.cpp`.
+
+use crate::types::*;
+use anna_server_common::metadata::Tier;
+use std::collections::HashMap;
+
+/// Compute summary statistics from raw per-node stats.
+///
+/// Mirrors `compute_summary_stats()` in C++.
+pub fn compute_summary_stats(
+    ss: &mut SummaryStats,
+    memory_storage: &StorageStats,
+    disk_storage: &StorageStats,
+    memory_occupancy: &OccupancyStats,
+    disk_occupancy: &OccupancyStats,
+    memory_accesses: &AccessStats,
+    disk_accesses: &AccessStats,
+    key_access_frequency: &KeyAccessFrequency,
+    key_access_summary: &mut KeyAccessSummary,
+    memory_node_capacity: u64,
+    disk_node_capacity: u64,
+    max_memory_consumption: f64,
+    max_disk_consumption: f64,
+) {
+    ss.clear();
+
+    // Key access statistics using Welford's online algorithm.
+    let mut n: u64 = 0;
+    let mut mean = 0.0f64;
+    let mut m2 = 0.0f64;
+
+    for (key, freq_map) in key_access_frequency {
+        let total: u32 = freq_map.values().sum();
+        if total > 0 {
+            key_access_summary.insert(key.clone(), total);
+            n += 1;
+            let delta = total as f64 - mean;
+            mean += delta / n as f64;
+            let delta2 = total as f64 - mean;
+            m2 += delta * delta2;
+        }
+    }
+
+    ss.key_access_mean = mean;
+    ss.key_access_std = if n > 1 {
+        (m2 / (n - 1) as f64).sqrt()
+    } else {
+        0.0
+    };
+
+    // Tier access totals.
+    ss.total_memory_access = memory_accesses
+        .values()
+        .flat_map(|m| m.values())
+        .map(|&v| v as u64)
+        .sum();
+    ss.total_disk_access = disk_accesses
+        .values()
+        .flat_map(|m| m.values())
+        .map(|&v| v as u64)
+        .sum();
+
+    // Memory storage consumption.
+    compute_storage_stats(
+        memory_storage,
+        memory_node_capacity,
+        max_memory_consumption,
+        &mut ss.total_memory_consumption,
+        &mut ss.max_memory_consumption_percentage,
+        &mut ss.avg_memory_consumption_percentage,
+        &mut ss.required_memory_node,
+    );
+
+    // Disk storage consumption.
+    compute_storage_stats(
+        disk_storage,
+        disk_node_capacity,
+        max_disk_consumption,
+        &mut ss.total_disk_consumption,
+        &mut ss.max_disk_consumption_percentage,
+        &mut ss.avg_disk_consumption_percentage,
+        &mut ss.required_disk_node,
+    );
+
+    // Memory occupancy.
+    compute_occupancy_stats(
+        memory_occupancy,
+        &mut ss.max_memory_occupancy,
+        &mut ss.min_memory_occupancy,
+        &mut ss.avg_memory_occupancy,
+        &mut ss.min_occupancy_memory_public_ip,
+        &mut ss.min_occupancy_memory_private_ip,
+    );
+
+    // Disk occupancy.
+    compute_occupancy_stats(
+        disk_occupancy,
+        &mut ss.max_disk_occupancy,
+        &mut ss.min_disk_occupancy,
+        &mut ss.avg_disk_occupancy,
+        &mut String::new(), // disk doesn't track min-occupancy IP
+        &mut String::new(),
+    );
+}
+
+fn compute_storage_stats(
+    storage: &StorageStats,
+    node_capacity: u64,
+    max_consumption: f64,
+    total: &mut u64,
+    max_pct: &mut f64,
+    avg_pct: &mut f64,
+    required_nodes: &mut u32,
+) {
+    let mut node_count = 0u32;
+    *total = 0;
+    *max_pct = 0.0;
+
+    for threads in storage.values() {
+        let node_total: u64 = threads.values().sum();
+        *total += node_total;
+        node_count += 1;
+
+        if node_capacity > 0 {
+            let pct = node_total as f64 / node_capacity as f64;
+            if pct > *max_pct {
+                *max_pct = pct;
+            }
+        }
+    }
+
+    if node_count > 0 && node_capacity > 0 {
+        *avg_pct = *total as f64 / (node_count as f64 * node_capacity as f64);
+    }
+
+    if node_capacity > 0 && max_consumption > 0.0 {
+        let effective_capacity = (max_consumption * node_capacity as f64) as u64;
+        if effective_capacity > 0 {
+            *required_nodes = ((*total + effective_capacity - 1) / effective_capacity) as u32;
+        }
+    }
+}
+
+fn compute_occupancy_stats(
+    occupancy: &OccupancyStats,
+    max_occ: &mut f64,
+    min_occ: &mut f64,
+    avg_occ: &mut f64,
+    min_public_ip: &mut String,
+    min_private_ip: &mut String,
+) {
+    let mut node_count = 0u32;
+    let mut total_occ = 0.0f64;
+
+    for (ip_pair, threads) in occupancy {
+        if threads.is_empty() {
+            continue;
+        }
+        let node_avg: f64 =
+            threads.values().map(|(occ, _)| occ).sum::<f64>() / threads.len() as f64;
+
+        if node_avg > *max_occ {
+            *max_occ = node_avg;
+        }
+        if node_avg < *min_occ {
+            *min_occ = node_avg;
+            // Extract public/private IP from "public/private" format.
+            let parts: Vec<&str> = ip_pair.split('/').collect();
+            if parts.len() == 2 {
+                *min_public_ip = parts[0].to_string();
+                *min_private_ip = parts[1].to_string();
+            }
+        }
+
+        total_occ += node_avg;
+        node_count += 1;
+    }
+
+    if node_count > 0 {
+        *avg_occ = total_occ / node_count as f64;
+    }
+}
+
+/// Compute external stats from user feedback.
+///
+/// Mirrors `collect_external_stats()` in C++.
+pub fn collect_external_stats(
+    ss: &mut SummaryStats,
+    user_latency: &HashMap<String, f64>,
+    user_throughput: &HashMap<String, f64>,
+) {
+    if !user_latency.is_empty() {
+        ss.avg_latency = user_latency.values().sum::<f64>() / user_latency.len() as f64;
+    }
+    ss.total_throughput = user_throughput.values().sum();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_summary_empty() {
+        let mut ss = SummaryStats::default();
+        let mut kas = KeyAccessSummary::new();
+
+        compute_summary_stats(
+            &mut ss,
+            &StorageStats::new(),
+            &StorageStats::new(),
+            &OccupancyStats::new(),
+            &OccupancyStats::new(),
+            &AccessStats::new(),
+            &AccessStats::new(),
+            &KeyAccessFrequency::new(),
+            &mut kas,
+            1_000_000,
+            1_000_000,
+            0.6,
+            0.75,
+        );
+
+        assert_eq!(ss.total_memory_consumption, 0);
+        assert_eq!(ss.required_memory_node, 0);
+    }
+
+    #[test]
+    fn compute_summary_with_data() {
+        let mut ss = SummaryStats::default();
+        let mut kas = KeyAccessSummary::new();
+
+        let mut ms = StorageStats::new();
+        let mut node = HashMap::new();
+        node.insert(0, 500_000u64);
+        ms.insert("10.0.0.1/10.0.0.1".into(), node);
+
+        let mut mo = OccupancyStats::new();
+        let mut occ = HashMap::new();
+        occ.insert(0, (0.5, 1));
+        mo.insert("10.0.0.1/10.0.0.1".into(), occ);
+
+        let mut ma = AccessStats::new();
+        let mut acc = HashMap::new();
+        acc.insert(0, 100);
+        ma.insert("10.0.0.1/10.0.0.1".into(), acc);
+
+        let mut kaf = KeyAccessFrequency::new();
+        let mut freq = HashMap::new();
+        freq.insert("10.0.0.1/10.0.0.1:0".into(), 50);
+        kaf.insert("key1".into(), freq);
+
+        compute_summary_stats(
+            &mut ss,
+            &ms,
+            &StorageStats::new(),
+            &mo,
+            &OccupancyStats::new(),
+            &ma,
+            &AccessStats::new(),
+            &kaf,
+            &mut kas,
+            1_000_000,
+            1_000_000,
+            0.6,
+            0.75,
+        );
+
+        assert_eq!(ss.total_memory_consumption, 500_000);
+        assert_eq!(ss.total_memory_access, 100);
+        assert_eq!(ss.max_memory_occupancy, 0.5);
+        assert_eq!(*kas.get("key1").unwrap(), 50);
+    }
+
+    #[test]
+    fn external_stats_averages() {
+        let mut ss = SummaryStats::default();
+        let mut ul = HashMap::new();
+        ul.insert("u1".into(), 1000.0);
+        ul.insert("u2".into(), 2000.0);
+        let mut ut = HashMap::new();
+        ut.insert("u1".into(), 50.0);
+        ut.insert("u2".into(), 100.0);
+
+        collect_external_stats(&mut ss, &ul, &ut);
+
+        assert_eq!(ss.avg_latency, 1500.0);
+        assert_eq!(ss.total_throughput, 150.0);
+    }
+}

--- a/server/rust/anna-monitor/src/types.rs
+++ b/server/rust/anna-monitor/src/types.rs
@@ -1,0 +1,116 @@
+//! Monitor-specific types.
+//!
+//! Mirrors `server/cpp/src/kvs/kvs_types.hpp` and `monitoring_utils.hpp`.
+
+use anna_server_common::types::{Address, Key};
+use std::collections::HashMap;
+
+/// Per-node per-thread storage consumption in bytes.
+/// Key: "public_ip/private_ip", Value: thread_id -> bytes.
+pub type StorageStats = HashMap<Address, HashMap<u32, u64>>;
+
+/// Per-node per-thread occupancy.
+/// Key: "public_ip/private_ip", Value: thread_id -> (occupancy_ratio, epoch).
+pub type OccupancyStats = HashMap<Address, HashMap<u32, (f64, u32)>>;
+
+/// Per-node per-thread access count.
+/// Key: "public_ip/private_ip", Value: thread_id -> access_count.
+pub type AccessStats = HashMap<Address, HashMap<u32, u32>>;
+
+/// Summary statistics aggregated from all nodes in a monitoring cycle.
+#[derive(Debug, Clone, Default)]
+pub struct SummaryStats {
+    pub key_access_mean: f64,
+    pub key_access_std: f64,
+    pub total_memory_access: u64,
+    pub total_disk_access: u64,
+    pub total_memory_consumption: u64,
+    pub total_disk_consumption: u64,
+    pub max_memory_consumption_percentage: f64,
+    pub max_disk_consumption_percentage: f64,
+    pub avg_memory_consumption_percentage: f64,
+    pub avg_disk_consumption_percentage: f64,
+    pub required_memory_node: u32,
+    pub required_disk_node: u32,
+    pub max_memory_occupancy: f64,
+    pub min_memory_occupancy: f64,
+    pub avg_memory_occupancy: f64,
+    pub max_disk_occupancy: f64,
+    pub min_disk_occupancy: f64,
+    pub avg_disk_occupancy: f64,
+    pub min_occupancy_memory_public_ip: Address,
+    pub min_occupancy_memory_private_ip: Address,
+    pub avg_latency: f64,
+    pub total_throughput: f64,
+}
+
+impl SummaryStats {
+    pub fn clear(&mut self) {
+        *self = Self {
+            min_memory_occupancy: 1.0,
+            min_disk_occupancy: 1.0,
+            ..Default::default()
+        };
+    }
+}
+
+/// Monitor-wide tunable constants, parsed from config.
+#[derive(Debug, Clone)]
+pub struct MonitorParams {
+    pub monitoring_threshold_s: u32,
+    pub grace_period_s: u32,
+    pub monitoring_response_timeout_ms: u32,
+    pub node_addition_batch_size: u32,
+    pub max_memory_node_consumption: f64,
+    pub min_memory_node_consumption: f64,
+    pub max_disk_node_consumption: f64,
+    pub min_disk_node_consumption: f64,
+    pub key_promotion_threshold: u32,
+    pub key_demotion_threshold: u32,
+    pub min_memory_tier_size: u32,
+    pub min_disk_tier_size: u32,
+    pub assumed_value_size_kb: u32,
+    pub slo_occupancy_upper: f64,
+    pub slo_occupancy_lower: f64,
+    pub slo_worst_us: u32,
+    pub warmup_key_count: u32,
+    pub enable_elasticity: bool,
+    pub enable_tiering: bool,
+    pub enable_selective_rep: bool,
+}
+
+impl Default for MonitorParams {
+    fn default() -> Self {
+        Self {
+            monitoring_threshold_s: 30,
+            grace_period_s: 120,
+            monitoring_response_timeout_ms: 10000,
+            node_addition_batch_size: 2,
+            max_memory_node_consumption: 0.6,
+            min_memory_node_consumption: 0.3,
+            max_disk_node_consumption: 0.75,
+            min_disk_node_consumption: 0.5,
+            key_promotion_threshold: 0,
+            key_demotion_threshold: 1,
+            min_memory_tier_size: 1,
+            min_disk_tier_size: 0,
+            assumed_value_size_kb: 256,
+            slo_occupancy_upper: 0.15,
+            slo_occupancy_lower: 0.05,
+            slo_worst_us: 3000,
+            warmup_key_count: 99_999_999,
+            enable_elasticity: false,
+            enable_tiering: false,
+            enable_selective_rep: false,
+        }
+    }
+}
+
+/// Per-key access frequency: key -> (address:tid -> access_count).
+pub type KeyAccessFrequency = HashMap<Key, HashMap<String, u32>>;
+
+/// Per-key total access summary.
+pub type KeyAccessSummary = HashMap<Key, u32>;
+
+/// Per-key value size in KB.
+pub type KeySizeMap = HashMap<Key, u32>;

--- a/server/rust/server-common/src/config.rs
+++ b/server/rust/server-common/src/config.rs
@@ -322,7 +322,7 @@ capacities:
         let mut threads = ThreadsConfig {
             memory: 4,
             disk: 2,
-            routing: 0, // auto
+            routing: 0,   // auto
             benchmark: 0, // auto
         };
 


### PR DESCRIPTION
## Phase 2 of the Rust server port (#339)

Rust implementation of the anna-monitor server at `server/rust/anna-monitor/`.

### What's implemented

| Module | Lines | C++ Equivalent | Tests |
|---|---|---|---|
| `types.rs` | 120 | `monitoring_utils.hpp`, `kvs_types.hpp` | — |
| `handlers.rs` | 250 | `membership_handler.cpp`, `depart_done_handler.cpp`, `feedback_handler.cpp` | 6 |
| `stats.rs` | 210 | `stats_helpers.cpp` (`compute_summary_stats`, `collect_external_stats`) | 3 |
| `policies.rs` | 200 | `storage_policy.cpp`, `movement_policy.cpp`, `slo_policy.cpp` | 5 |
| `monitor.rs` | 200 | `monitoring.cpp` event loop | — |
| `main.rs` | 35 | CLI entry point | — |

14 unit tests covering all handler, stats, and policy functions.

### What's stubbed (TODO)

- **ZMQ socket integration**: The event loop structure is in place but ZMQ sockets (notify_puller, depart_done_puller, feedback_puller, response_puller, SocketCache pushers) are not yet wired up via `omq-tokio`.
- **`collect_internal_stats`**: Requires sending GET requests to KVS nodes via ZMQ and parsing responses. This is the main missing piece for full functionality.
- **`change_replication_factor`**: Requires ZMQ to send PUT requests and replication updates.
- **`emit_scale_up_alert` / `remove_node`**: Require ZMQ to send protobuf messages.

### Architecture

- **Wire-compatible** with C++ servers via shared protobuf and port layout
- **tokio async** event loop with periodic monitoring cycle
- **Business logic is complete**: membership tracking, crash detection, Welford's algorithm for access stats, storage/occupancy aggregation, all three policy engines
- Config parsed from same YAML format as C++ server

Closes #528, part of #339