### PR TITLE
Wire ZMQ sockets and dual-monitor test infrastructure (#529)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,12 @@ coverage: test
 	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info || true
 
 .PHONY: test
-test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage docs
+test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage rust-monitor-tests docs
+
+.PHONY: rust-monitor-tests
+rust-monitor-tests: server-rust
+	@echo "Running monitor integration tests with Rust monitor (anna-monitor-rs)"
+	@ANNA_MONITOR_BIN=$(shell pwd)/target/debug/anna-monitor-rs cargo test --test monitor 2>&1 | tail -5
 
 .PHONY: server-system-coverage
 server-system-coverage:

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ fmt:
 
 # Debug build, use "-DCMAKE_BUILD_TYPE=Release" for a Release build
 .PHONY: build
-build: client-cpp server-cpp client-rust client-python client-go
+build: client-cpp server-cpp server-rust client-rust client-python client-go
 
 UNAME := $(shell uname)
 
@@ -130,6 +130,11 @@ endif
 client-rust:
 	@echo "Building rust code in workspace into ./target"
 	@$(CARGO_ENV) RUSTFLAGS="$(RUST_LINK_ALLOW)" cargo build --quiet
+
+.PHONY: server-rust
+server-rust:
+	@echo "Building Rust server binaries"
+	@$(CARGO_ENV) RUSTFLAGS="$(RUST_LINK_ALLOW)" cargo build --quiet -p anna-monitor
 
 .PHONY: client-python
 client-python:

--- a/clients/rust/tests/common/mod.rs
+++ b/clients/rust/tests/common/mod.rs
@@ -142,6 +142,25 @@ pub fn wait_for_routing(base_offset: u16) {
     std::thread::sleep(Duration::from_secs(1));
 }
 
+/// Resolve the binary path for a server component, checking for
+/// ANNA_MONITOR_BIN override for the monitor binary.
+pub fn resolve_server_binary(name: &str, default_dir: &Path) -> PathBuf {
+    if name == "anna-monitor" {
+        if let Ok(alt) = std::env::var("ANNA_MONITOR_BIN") {
+            let alt_bin = PathBuf::from(&alt);
+            if alt_bin.exists() {
+                eprintln!("Using Rust monitor binary: {}", alt_bin.display());
+                return alt_bin;
+            }
+            eprintln!(
+                "WARNING: ANNA_MONITOR_BIN={} not found, falling back to C++ monitor",
+                alt
+            );
+        }
+    }
+    default_dir.join(name)
+}
+
 pub struct ServerGuard {
     processes: Vec<Child>,
 }
@@ -162,21 +181,7 @@ impl ServerGuard {
         let mut processes: Vec<Child> = Vec::new();
 
         for name in ["anna-monitor", "anna-route", "anna-kvs"] {
-            // Allow overriding the monitor binary via ANNA_MONITOR_BIN.
-            let bin = if name == "anna-monitor" {
-                if let Ok(alt) = std::env::var("ANNA_MONITOR_BIN") {
-                    let alt_bin = std::path::PathBuf::from(&alt);
-                    if alt_bin.exists() {
-                        alt_bin
-                    } else {
-                        bin_dir.join(name)
-                    }
-                } else {
-                    bin_dir.join(name)
-                }
-            } else {
-                bin_dir.join(name)
-            };
+            let bin = resolve_server_binary(name, &bin_dir);
             if !bin.exists() {
                 for mut p in processes {
                     p.kill().ok();

--- a/clients/rust/tests/common/mod.rs
+++ b/clients/rust/tests/common/mod.rs
@@ -162,7 +162,21 @@ impl ServerGuard {
         let mut processes: Vec<Child> = Vec::new();
 
         for name in ["anna-monitor", "anna-route", "anna-kvs"] {
-            let bin = bin_dir.join(name);
+            // Allow overriding the monitor binary via ANNA_MONITOR_BIN.
+            let bin = if name == "anna-monitor" {
+                if let Ok(alt) = std::env::var("ANNA_MONITOR_BIN") {
+                    let alt_bin = std::path::PathBuf::from(&alt);
+                    if alt_bin.exists() {
+                        alt_bin
+                    } else {
+                        bin_dir.join(name)
+                    }
+                } else {
+                    bin_dir.join(name)
+                }
+            } else {
+                bin_dir.join(name)
+            };
             if !bin.exists() {
                 for mut p in processes {
                     p.kill().ok();

--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -189,7 +189,21 @@ impl MonitorTestCluster {
         );
 
         for name in ["anna-monitor", "anna-route", "anna-kvs"] {
-            let bin = server_bin_dir().join(name);
+            // Allow overriding the monitor binary via ANNA_MONITOR_BIN.
+            let bin = if name == "anna-monitor" {
+                if let Ok(alt) = std::env::var("ANNA_MONITOR_BIN") {
+                    let alt_bin = std::path::PathBuf::from(&alt);
+                    if alt_bin.exists() {
+                        alt_bin
+                    } else {
+                        server_bin_dir().join(name)
+                    }
+                } else {
+                    server_bin_dir().join(name)
+                }
+            } else {
+                server_bin_dir().join(name)
+            };
             if !bin.exists() {
                 self.shutdown();
                 panic!("Server binary {} not found", name);

--- a/clients/rust/tests/monitor.rs
+++ b/clients/rust/tests/monitor.rs
@@ -189,21 +189,7 @@ impl MonitorTestCluster {
         );
 
         for name in ["anna-monitor", "anna-route", "anna-kvs"] {
-            // Allow overriding the monitor binary via ANNA_MONITOR_BIN.
-            let bin = if name == "anna-monitor" {
-                if let Ok(alt) = std::env::var("ANNA_MONITOR_BIN") {
-                    let alt_bin = std::path::PathBuf::from(&alt);
-                    if alt_bin.exists() {
-                        alt_bin
-                    } else {
-                        server_bin_dir().join(name)
-                    }
-                } else {
-                    server_bin_dir().join(name)
-                }
-            } else {
-                server_bin_dir().join(name)
-            };
+            let bin = common::resolve_server_binary(name, &server_bin_dir());
             if !bin.exists() {
                 self.shutdown();
                 panic!("Server binary {} not found", name);

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -165,27 +165,6 @@ fn server_bin_dir() -> PathBuf {
 }
 
 fn spawn_server(name: &str, config: &Path, extra_path: &str) -> Option<Child> {
-    // Allow overriding the monitor binary via ANNA_MONITOR_BIN env var.
-    // This enables running the same tests against the Rust monitor.
-    if name == "anna-monitor" {
-        if let Ok(alt_bin) = std::env::var("ANNA_MONITOR_BIN") {
-            let bin = std::path::PathBuf::from(&alt_bin);
-            if bin.exists() {
-                let child = Command::new(&bin)
-                    .args(["--config", &config.to_string_lossy()])
-                    .env("PATH", extra_path)
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .spawn()
-                    .unwrap_or_else(|e| panic!("Failed to spawn {}: {}", alt_bin, e));
-                return Some(child);
-            }
-            eprintln!(
-                "ANNA_MONITOR_BIN={} not found, falling back to C++ monitor",
-                alt_bin
-            );
-        }
-    }
     spawn_server_with_env(name, config, extra_path, &[])
 }
 
@@ -195,7 +174,7 @@ fn spawn_server_with_env(
     extra_path: &str,
     env_vars: &[(&str, &str)],
 ) -> Option<Child> {
-    let bin = server_bin_dir().join(name);
+    let bin = common::resolve_server_binary(name, &server_bin_dir());
     if !bin.exists() {
         return None;
     }

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -165,6 +165,27 @@ fn server_bin_dir() -> PathBuf {
 }
 
 fn spawn_server(name: &str, config: &Path, extra_path: &str) -> Option<Child> {
+    // Allow overriding the monitor binary via ANNA_MONITOR_BIN env var.
+    // This enables running the same tests against the Rust monitor.
+    if name == "anna-monitor" {
+        if let Ok(alt_bin) = std::env::var("ANNA_MONITOR_BIN") {
+            let bin = std::path::PathBuf::from(&alt_bin);
+            if bin.exists() {
+                let child = Command::new(&bin)
+                    .args(["--config", &config.to_string_lossy()])
+                    .env("PATH", extra_path)
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .unwrap_or_else(|e| panic!("Failed to spawn {}: {}", alt_bin, e));
+                return Some(child);
+            }
+            eprintln!(
+                "ANNA_MONITOR_BIN={} not found, falling back to C++ monitor",
+                alt_bin
+            );
+        }
+    }
     spawn_server_with_env(name, config, extra_path, &[])
 }
 

--- a/server/rust/anna-monitor/src/handlers.rs
+++ b/server/rust/anna-monitor/src/handlers.rs
@@ -127,24 +127,25 @@ pub fn membership_handler(
 /// Process a depart-done ack from a departing node.
 ///
 /// Message format: "public_ip_private_ip_tier_id"
+/// Returns `Some((tier_id, public_ip, private_ip))` if departure is complete
+/// (all thread acks received), so the caller can send a ScalingAlert via ZMQ.
 pub fn depart_done_handler(
     msg: &str,
     departing_node_map: &mut HashMap<Address, u32>,
     removing_memory_node: &mut bool,
     removing_disk_node: &mut bool,
     grace_start: &mut Instant,
-    scaling_alert_ip: &str,
-    base_offset: u32,
-    pushers: &mut HashMap<String, Vec<u8>>, // placeholder for ZMQ pushers
-) {
+) -> Option<(u32, String, String)> {
     let parts: Vec<&str> = msg.split('_').collect();
     if parts.len() < 3 {
         error!("Invalid depart_done message: {}", msg);
-        return;
+        return None;
     }
 
-    let private_ip = parts[1];
-    if let Some(count) = departing_node_map.get_mut(private_ip) {
+    let public_ip = parts[0].to_string();
+    let private_ip = parts[1].to_string();
+
+    if let Some(count) = departing_node_map.get_mut(&private_ip) {
         *count -= 1;
         if *count == 0 {
             let tier_id: u32 = parts[2].parse().unwrap_or(0);
@@ -155,17 +156,15 @@ pub fn depart_done_handler(
             }
 
             info!("Depart done for node {} (tier {})", private_ip, tier_id);
-
-            // TODO: Send ScalingAlert protobuf to scaling_alert_ip.
-            // This requires ZMQ socket integration.
-            let _ = (scaling_alert_ip, base_offset, pushers);
-
             *grace_start = Instant::now();
-            departing_node_map.remove(private_ip);
+            departing_node_map.remove(&private_ip);
+            return Some((tier_id, public_ip, private_ip));
         }
     } else {
         error!("Received depart_done for unknown node: {}", private_ip);
     }
+
+    None
 }
 
 /// Process user feedback (latency/throughput reports).
@@ -401,20 +400,19 @@ mod tests {
         let mut removing_mem = true;
         let mut removing_disk = false;
         let mut grace = Instant::now();
-        let mut pushers = HashMap::new();
 
-        depart_done_handler(
+        let result = depart_done_handler(
             "10.0.0.1_10.0.0.1_1",
             &mut departing,
             &mut removing_mem,
             &mut removing_disk,
             &mut grace,
-            "NULL",
-            0,
-            &mut pushers,
         );
 
         assert!(!removing_mem);
         assert!(departing.is_empty());
+        assert!(result.is_some());
+        let (tier_id, _pub_ip, _priv_ip) = result.unwrap();
+        assert_eq!(tier_id, 1); // Memory
     }
 }

--- a/server/rust/anna-monitor/src/main.rs
+++ b/server/rust/anna-monitor/src/main.rs
@@ -7,6 +7,7 @@
 mod handlers;
 mod monitor;
 mod policies;
+mod replication;
 mod stats;
 mod types;
 

--- a/server/rust/anna-monitor/src/monitor.rs
+++ b/server/rust/anna-monitor/src/monitor.rs
@@ -6,16 +6,54 @@ use anna_server_common::config::Config;
 use anna_server_common::hash_ring::ConsistentHashRing;
 use anna_server_common::metadata::Tier;
 use anna_server_common::signal;
-use anna_server_common::threads::MonitoringThread;
+use anna_server_common::threads::{MonitoringThread, RoutingThread, ServerThread};
 use anna_server_common::types::Address;
 use log::{error, info, warn};
+use omq_tokio::{Context, Message as ZmqMessage, Options, Socket as OmqSocket, SocketType};
+use prost::Message;
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::handlers;
 use crate::policies;
 use crate::stats;
 use crate::types::*;
+
+/// Lazy-connecting PUSH socket cache.
+struct SocketCache {
+    ctx: Context,
+    sockets: HashMap<Address, OmqSocket>,
+}
+
+impl SocketCache {
+    fn new(ctx: Context) -> Self {
+        Self {
+            ctx,
+            sockets: HashMap::new(),
+        }
+    }
+
+    async fn send(&mut self, addr: &str, data: &[u8]) -> Result<(), String> {
+        if !self.sockets.contains_key(addr) {
+            let sock = self.ctx.socket(SocketType::Push, Options::default());
+            let endpoint = addr
+                .parse()
+                .map_err(|e| format!("Invalid address {}: {}", addr, e))?;
+            sock.connect(endpoint)
+                .await
+                .map_err(|e| format!("Failed to connect to {}: {}", addr, e))?;
+            self.sockets.insert(addr.to_string(), sock);
+        }
+        let sock = self.sockets.get_mut(addr).expect("socket just inserted");
+        sock.send(ZmqMessage::from(data.to_vec()))
+            .await
+            .map_err(|e| format!("Failed to send to {}: {}", addr, e))
+    }
+
+    async fn send_string(&mut self, addr: &str, msg: &str) -> Result<(), String> {
+        self.send(addr, msg.as_bytes()).await
+    }
+}
 
 /// Run the monitoring event loop.
 pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
@@ -25,7 +63,6 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     let monitoring_ip = config.monitoring.ip.clone();
     let scaling_alert_ip = config.monitoring.scaling_alert_ip.clone();
 
-    // Parse monitor parameters from config.
     let params = MonitorParams {
         monitoring_threshold_s: config.timings.monitoring_timeout.max(1),
         grace_period_s: config.timings.grace_period,
@@ -55,10 +92,9 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
             .unwrap_or(1)
     };
 
-    let memory_node_capacity = config.memory_capacity_bytes() / 1024; // in KB
+    let memory_node_capacity = config.memory_capacity_bytes() / 1024;
     let disk_node_capacity = config.disk_capacity_bytes() / 1024;
-
-    let virtual_nodes = 3000u32; // default, could be from config
+    let virtual_nodes = 3000u32;
 
     let mt = MonitoringThread::new(&monitoring_ip, base_offset);
 
@@ -68,6 +104,32 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
         "Selective replication policy enabled: {}",
         params.enable_selective_rep
     );
+
+    // ── ZMQ Sockets ─────────────────────────────────────────────────
+
+    let ctx = Context::new();
+
+    let notify_puller = ctx.socket(SocketType::Pull, Options::default());
+    notify_puller
+        .bind(mt.notify_connect_address().parse()?)
+        .await?;
+
+    let depart_done_puller = ctx.socket(SocketType::Pull, Options::default());
+    depart_done_puller
+        .bind(mt.depart_done_connect_address().parse()?)
+        .await?;
+
+    let feedback_puller = ctx.socket(SocketType::Pull, Options::default());
+    feedback_puller
+        .bind(mt.feedback_report_connect_address().parse()?)
+        .await?;
+
+    let response_puller = ctx.socket(SocketType::Pull, Options::default());
+    response_puller
+        .bind(mt.response_connect_address().parse()?)
+        .await?;
+
+    let mut pushers = SocketCache::new(ctx.clone());
 
     // ── State ───────────────────────────────────────────────────────
 
@@ -96,8 +158,9 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     let mut removing_disk_node = false;
     let mut grace_start = Instant::now();
     let mut report_start = Instant::now();
-    let mut _epoch = 0u32;
+    let mut epoch = 0u32;
     let mut last_epoch_change: HashMap<Address, Instant> = HashMap::new();
+    let mut rid = 0u32;
 
     info!(
         "Monitor listening on {} (base_offset={})",
@@ -105,20 +168,83 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // ── Event loop ──────────────────────────────────────────────────
-    // TODO: integrate ZMQ sockets (notify_puller, depart_done_puller,
-    // feedback_puller, response_puller, pushers) when omq-tokio is
-    // wired up. For now, the structure is in place.
+
+    let poll_timeout = Duration::from_millis(100);
 
     while !signal::shutdown_requested() {
-        // TODO: ZMQ poll with 0ms timeout for non-blocking check
-        // pollitems[0] = notify_puller → membership_handler
-        // pollitems[1] = depart_done_puller → depart_done_handler
-        // pollitems[2] = feedback_puller → feedback_handler
+        // Non-blocking poll: try each socket with a short timeout.
+        // Process at most one message per iteration to keep the loop responsive.
 
-        // Periodic monitoring cycle.
+        if let Ok(Ok(msg)) = tokio::time::timeout(poll_timeout, notify_puller.recv()).await {
+            let data: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
+            let text = String::from_utf8_lossy(&data);
+
+            // Record last_epoch_change for join events.
+            let parts: Vec<&str> = text.split(':').collect();
+            if parts.len() >= 4 {
+                let ip_pair = format!("{}/{}", parts[2], parts[3]);
+                if parts[0] == "join" {
+                    last_epoch_change.insert(ip_pair, Instant::now());
+                } else if parts[0] == "depart" {
+                    last_epoch_change.remove(&ip_pair);
+                }
+            }
+
+            handlers::membership_handler(
+                &text,
+                &mut global_hash_rings,
+                &mut routing_ips,
+                &mut memory_storage,
+                &mut disk_storage,
+                &mut memory_occupancy,
+                &mut disk_occupancy,
+                &mut key_access_frequency,
+                &mut new_memory_count,
+                &mut new_disk_count,
+                &mut grace_start,
+                memory_thread_count,
+                disk_thread_count,
+                virtual_nodes,
+                base_offset,
+            );
+        }
+
+        if let Ok(Ok(msg)) = tokio::time::timeout(Duration::ZERO, depart_done_puller.recv()).await {
+            let data: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
+            let text = String::from_utf8_lossy(&data);
+
+            if let Some((_tier_id, _pub_ip, _priv_ip)) = handlers::depart_done_handler(
+                &text,
+                &mut departing_node_map,
+                &mut removing_memory_node,
+                &mut removing_disk_node,
+                &mut grace_start,
+            ) {
+                // Send ScalingAlert (REMOVE) to scaling system.
+                let alert_addr = anna_server_common::threads::scaling_alert_address(
+                    &scaling_alert_ip,
+                    base_offset,
+                );
+                // TODO: build and send ScalingAlert protobuf
+                let _ = alert_addr;
+            }
+        }
+
+        if let Ok(Ok(msg)) = tokio::time::timeout(Duration::ZERO, feedback_puller.recv()).await {
+            let data: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
+            handlers::feedback_handler(
+                &data,
+                &mut user_latency,
+                &mut user_throughput,
+                &mut latency_miss_ratio_map,
+                params.slo_worst_us,
+            );
+        }
+
+        // ── Periodic monitoring cycle ───────────────────────────────
         let elapsed = report_start.elapsed().as_secs() as u32;
         if elapsed >= params.monitoring_threshold_s {
-            _epoch += 1;
+            epoch += 1;
 
             let memory_node_count = global_hash_rings
                 .get(&Tier::Memory)
@@ -139,21 +265,83 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
             memory_accesses.clear();
             disk_accesses.clear();
 
-            // TODO: collect_internal_stats (requires ZMQ)
+            // Collect internal stats from all KVS nodes.
+            collect_internal_stats(
+                &global_hash_rings,
+                &mt,
+                &mut pushers,
+                &response_puller,
+                &mut memory_storage,
+                &mut disk_storage,
+                &mut memory_occupancy,
+                &mut disk_occupancy,
+                &mut memory_accesses,
+                &mut disk_accesses,
+                &mut key_access_frequency,
+                &mut key_size,
+                memory_thread_count,
+                disk_thread_count,
+                base_offset,
+                &mut rid,
+                &monitoring_ip,
+                Duration::from_millis(params.monitoring_response_timeout_ms as u64),
+            )
+            .await;
 
             // Crash detection.
-            let stale_threshold =
-                std::time::Duration::from_secs(params.monitoring_threshold_s as u64);
+            let stale_threshold = Duration::from_secs(params.monitoring_threshold_s as u64);
             let mut dead_nodes = Vec::new();
+
+            // Build set of reporting nodes from occupancy data.
+            let mut reporting_nodes = std::collections::HashSet::new();
+            for ip_pair in memory_occupancy.keys() {
+                reporting_nodes.insert(ip_pair.clone());
+            }
+            for ip_pair in disk_occupancy.keys() {
+                reporting_nodes.insert(ip_pair.clone());
+            }
+
+            // Update last_epoch_change for reporting nodes.
+            for ip_pair in &reporting_nodes {
+                last_epoch_change
+                    .entry(ip_pair.clone())
+                    .and_modify(|t| *t = Instant::now())
+                    .or_insert_with(Instant::now);
+            }
+
+            // Detect dead nodes.
             for (ip_pair, last_seen) in &last_epoch_change {
-                if last_seen.elapsed() > stale_threshold {
+                if !reporting_nodes.contains(ip_pair) && last_seen.elapsed() > stale_threshold {
                     dead_nodes.push(ip_pair.clone());
                 }
             }
+
             for ip_pair in &dead_nodes {
                 warn!("Detected crashed node: {}", ip_pair);
+                let parts: Vec<&str> = ip_pair.split('/').collect();
+                if parts.len() == 2 {
+                    let (pub_ip, priv_ip) = (parts[0], parts[1]);
+
+                    // Remove from hash rings.
+                    for ring in global_hash_rings.values_mut() {
+                        ring.remove(pub_ip, priv_ip, 0);
+                    }
+
+                    // Notify all routing nodes.
+                    for tier_name in ["MEMORY", "DISK"] {
+                        let msg = format!("depart:{}:{}:{}", tier_name, pub_ip, priv_ip);
+                        for rt_ip in &routing_ips {
+                            let rt = RoutingThread::new(rt_ip, 0, base_offset);
+                            if let Err(e) = pushers
+                                .send_string(&rt.notify_connect_address(), &msg)
+                                .await
+                            {
+                                error!("Failed to notify routing of crash: {}", e);
+                            }
+                        }
+                    }
+                }
                 last_epoch_change.remove(ip_pair);
-                // TODO: remove from hash ring, notify routing
             }
 
             // Compute summary stats.
@@ -215,20 +403,228 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
 
             report_start = Instant::now();
         }
-
-        // Yield to avoid busy-spinning.
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
 
     info!("Monitor shutting down");
-    let _ = (
-        mt,
-        scaling_alert_ip,
-        departing_node_map,
-        key_size,
-        dead_nodes_placeholder(),
-    );
+    let _ = (epoch, departing_node_map, key_size);
     Ok(())
 }
 
-fn dead_nodes_placeholder() {}
+/// Collect internal stats from all KVS nodes by sending GET requests
+/// for metadata keys and parsing the responses.
+///
+/// Sends requests to all threads on all nodes, collects responses,
+/// then processes them into the stat maps.
+async fn collect_internal_stats(
+    global_hash_rings: &HashMap<Tier, ConsistentHashRing>,
+    mt: &MonitoringThread,
+    pushers: &mut SocketCache,
+    response_puller: &OmqSocket,
+    memory_storage: &mut StorageStats,
+    disk_storage: &mut StorageStats,
+    memory_occupancy: &mut OccupancyStats,
+    disk_occupancy: &mut OccupancyStats,
+    memory_accesses: &mut AccessStats,
+    disk_accesses: &mut AccessStats,
+    key_access_frequency: &mut KeyAccessFrequency,
+    key_size: &mut KeySizeMap,
+    memory_thread_count: u32,
+    disk_thread_count: u32,
+    base_offset: u32,
+    rid: &mut u32,
+    monitor_ip: &str,
+    timeout: Duration,
+) {
+    use anna_server_common::proto::kvs::{
+        KeyRequest, KeyResponse, KeyTuple, LatticeType, RequestType,
+    };
+
+    // Phase 1: Send all requests and collect raw response bytes.
+    let mut responses: Vec<Vec<u8>> = Vec::new();
+
+    let tier_configs: &[(Tier, u32)] = &[
+        (Tier::Memory, memory_thread_count),
+        (Tier::Disk, disk_thread_count),
+    ];
+
+    for &(tier, thread_count) in tier_configs {
+        let ring = match global_hash_rings.get(&tier) {
+            Some(r) => r,
+            None => continue,
+        };
+
+        let tier_name = match tier {
+            Tier::Memory => "MEMORY",
+            Tier::Disk => "DISK",
+            _ => continue,
+        };
+
+        for st in ring.get_unique_servers() {
+            for tid in 0..thread_count {
+                let server_thread =
+                    ServerThread::new(st.public_ip(), st.private_ip(), tid, base_offset);
+
+                let ip_pair = format!("{}/{}", st.public_ip(), st.private_ip());
+                let meta_keys = [
+                    format!(
+                        "ANNA_METADATA|server_stats|{}|{}|{}",
+                        ip_pair, tid, tier_name
+                    ),
+                    format!("ANNA_METADATA|key_access|{}|{}|{}", ip_pair, tid, tier_name),
+                    format!("ANNA_METADATA|key_size|{}|{}|{}", ip_pair, tid, tier_name),
+                ];
+
+                *rid += 1;
+                let request_id = format!("{}:{}", monitor_ip, rid);
+
+                let mut request = KeyRequest {
+                    r#type: RequestType::Get as i32,
+                    response_address: mt.response_connect_address(),
+                    request_id,
+                    ..Default::default()
+                };
+
+                for key in &meta_keys {
+                    request.tuples.push(KeyTuple {
+                        key: key.clone(),
+                        lattice_type: LatticeType::Lww as i32,
+                        ..Default::default()
+                    });
+                }
+
+                let target_addr = server_thread.key_request_connect_address();
+                let encoded = request.encode_to_vec();
+
+                if let Err(e) = pushers.send(&target_addr, &encoded).await {
+                    warn!("Failed to send stats request to {}: {}", target_addr, e);
+                    continue;
+                }
+
+                match tokio::time::timeout(timeout, response_puller.recv()).await {
+                    Ok(Ok(msg)) => {
+                        let bytes: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
+                        responses.push(bytes);
+                    }
+                    Ok(Err(e)) => {
+                        warn!("ZMQ recv error for stats from {}: {}", ip_pair, e);
+                    }
+                    Err(_) => {
+                        warn!("Stats collection timed out for {}:{}", ip_pair, tid);
+                    }
+                }
+            }
+        }
+    }
+
+    // Phase 2: Process all collected responses.
+    for bytes in &responses {
+        if let Ok(response) = KeyResponse::decode(bytes.as_slice()) {
+            process_stats_response(
+                &response,
+                &mut *memory_storage,
+                &mut *disk_storage,
+                &mut *memory_occupancy,
+                &mut *disk_occupancy,
+                &mut *memory_accesses,
+                &mut *disk_accesses,
+                &mut *key_access_frequency,
+                &mut *key_size,
+            );
+        }
+    }
+}
+
+/// Process a stats response from a KVS node.
+fn process_stats_response(
+    response: &anna_server_common::proto::kvs::KeyResponse,
+    memory_storage: &mut StorageStats,
+    disk_storage: &mut StorageStats,
+    memory_occupancy: &mut OccupancyStats,
+    disk_occupancy: &mut OccupancyStats,
+    memory_accesses: &mut AccessStats,
+    disk_accesses: &mut AccessStats,
+    key_access_frequency: &mut KeyAccessFrequency,
+    key_size: &mut KeySizeMap,
+) {
+    use anna_server_common::proto::kvs::LwwValue;
+    use anna_server_common::proto::metadata::{KeyAccessData, KeySizeData, ServerThreadStatistics};
+
+    for tuple in &response.tuples {
+        if tuple.error != 0 {
+            continue; // KEY_DNE or other error
+        }
+
+        let key = &tuple.key;
+        let parts: Vec<&str> = key.split('|').collect();
+        // Expected: ANNA_METADATA|type|ip_pair|tid|tier
+        if parts.len() < 5 {
+            continue;
+        }
+
+        let meta_type = parts[1];
+        let ip_pair = parts[2].to_string();
+        let tid: u32 = parts[3].parse().unwrap_or(0);
+        let tier_name = parts[4];
+
+        // Unwrap LWW wrapper.
+        let inner_payload = match LwwValue::decode(tuple.payload.as_slice()) {
+            Ok(lww) => lww.value,
+            Err(_) => continue,
+        };
+
+        let is_memory = tier_name == "MEMORY";
+
+        match meta_type {
+            "server_stats" => {
+                if let Ok(stats) = ServerThreadStatistics::decode(inner_payload.as_slice()) {
+                    if is_memory {
+                        memory_storage
+                            .entry(ip_pair.clone())
+                            .or_default()
+                            .insert(tid, stats.storage_consumption);
+                        memory_occupancy
+                            .entry(ip_pair.clone())
+                            .or_default()
+                            .insert(tid, (stats.occupancy, stats.epoch));
+                        memory_accesses
+                            .entry(ip_pair)
+                            .or_default()
+                            .insert(tid, stats.access_count);
+                    } else {
+                        disk_storage
+                            .entry(ip_pair.clone())
+                            .or_default()
+                            .insert(tid, stats.storage_consumption);
+                        disk_occupancy
+                            .entry(ip_pair.clone())
+                            .or_default()
+                            .insert(tid, (stats.occupancy, stats.epoch));
+                        disk_accesses
+                            .entry(ip_pair)
+                            .or_default()
+                            .insert(tid, stats.access_count);
+                    }
+                }
+            }
+            "key_access" => {
+                if let Ok(access_data) = KeyAccessData::decode(inner_payload.as_slice()) {
+                    let thread_key = format!("{}:{}", ip_pair, tid);
+                    for ka in &access_data.keys {
+                        key_access_frequency
+                            .entry(ka.key.clone())
+                            .or_default()
+                            .insert(thread_key.clone(), ka.access_count);
+                    }
+                }
+            }
+            "key_size" => {
+                if let Ok(size_data) = KeySizeData::decode(inner_payload.as_slice()) {
+                    for ks in &size_data.key_sizes {
+                        key_size.insert(ks.key.clone(), ks.size);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/server/rust/anna-monitor/src/monitor.rs
+++ b/server/rust/anna-monitor/src/monitor.rs
@@ -391,9 +391,15 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
             // Only detect dead nodes if we got SOME responses this cycle.
             // This prevents false positives during startup when the KVS
             // hasn't published its first stats report yet.
+            // Use 2x threshold to give newly joined nodes time for their
+            // first stats report (server_report_period may exceed
+            // monitoring_timeout).
+            let crash_threshold = stale_threshold * 2;
             if !reporting_nodes.is_empty() {
                 for (ip_pair, last_seen) in &last_epoch_change {
-                    if !reporting_nodes.contains(ip_pair) && last_seen.elapsed() > stale_threshold {
+                    if !reporting_nodes.contains(ip_pair)
+                        && last_seen.elapsed() > crash_threshold
+                    {
                         dead_nodes.push(ip_pair.clone());
                     }
                 }

--- a/server/rust/anna-monitor/src/monitor.rs
+++ b/server/rust/anna-monitor/src/monitor.rs
@@ -55,6 +55,65 @@ impl SocketCache {
     }
 }
 
+/// Send a ScalingAlert (ADD) to the external scaling system.
+async fn emit_scale_up_alert(
+    pushers: &mut SocketCache,
+    scaling_alert_ip: &str,
+    base_offset: u32,
+    tier_name: &str,
+    count: u32,
+    new_count: &mut u32,
+) {
+    use anna_server_common::proto::metadata::ScalingAlert;
+
+    let alert = ScalingAlert {
+        action: 1, // ADD
+        tier: match tier_name {
+            "MEMORY" => 1,
+            "DISK" => 2,
+            _ => 0,
+        },
+        count,
+        departed_node_ip: String::new(),
+    };
+    let encoded = alert.encode_to_vec();
+    let addr = anna_server_common::threads::scaling_alert_address(scaling_alert_ip, base_offset);
+
+    if let Err(e) = pushers.send(&addr, &encoded).await {
+        error!("Failed to send scale-up alert: {}", e);
+    } else {
+        info!(
+            "Emitted scale-up alert: add {} {} node(s)",
+            count, tier_name
+        );
+        *new_count = count;
+    }
+}
+
+/// Send a self-depart command to a KVS node, initiating graceful removal.
+async fn remove_node(
+    pushers: &mut SocketCache,
+    mt: &MonitoringThread,
+    node: &ServerThread,
+    departing_node_map: &mut HashMap<Address, u32>,
+    removing: &mut bool,
+    thread_count: u32,
+) {
+    let depart_addr = mt.depart_done_connect_address();
+
+    if let Err(e) = pushers
+        .send_string(&node.self_depart_connect_address(), &depart_addr)
+        .await
+    {
+        error!("Failed to send depart to {}: {}", node.private_ip(), e);
+        return;
+    }
+
+    departing_node_map.insert(node.private_ip().to_string(), thread_count);
+    *removing = true;
+    info!("Initiated removal of node {}", node.private_ip());
+}
+
 /// Run the monitoring event loop.
 pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     signal::install_shutdown_handler();
@@ -221,12 +280,22 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                 &mut grace_start,
             ) {
                 // Send ScalingAlert (REMOVE) to scaling system.
+                use anna_server_common::proto::metadata::ScalingAlert;
+                let alert = ScalingAlert {
+                    action: 2, // REMOVE
+                    tier: _tier_id as i32,
+                    count: 1,
+                    departed_node_ip: format!("{}_{}", _pub_ip, _priv_ip),
+                };
                 let alert_addr = anna_server_common::threads::scaling_alert_address(
                     &scaling_alert_ip,
                     base_offset,
                 );
-                // TODO: build and send ScalingAlert protobuf
-                let _ = alert_addr;
+                let encoded = alert.encode_to_vec();
+                if let Err(e) = pushers.send(&alert_addr, &encoded).await {
+                    error!("Failed to send depart ScalingAlert: {}", e);
+                }
+                grace_start = Instant::now();
             }
         }
 
@@ -365,7 +434,10 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
 
             let grace_elapsed = grace_start.elapsed().as_secs() as u32 >= params.grace_period_s;
 
-            // Run policies.
+            // Run policies — they set new_*_count to request scaling.
+            let prev_mem = new_memory_count;
+            let prev_disk = new_disk_count;
+
             policies::storage_policy(
                 &ss,
                 &params,
@@ -396,6 +468,32 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                 grace_elapsed,
             );
 
+            // Send scaling alerts if policies requested new nodes.
+            if new_memory_count > prev_mem {
+                emit_scale_up_alert(
+                    &mut pushers,
+                    &scaling_alert_ip,
+                    base_offset,
+                    "MEMORY",
+                    new_memory_count,
+                    &mut new_memory_count,
+                )
+                .await;
+                grace_start = Instant::now();
+            }
+            if new_disk_count > prev_disk {
+                emit_scale_up_alert(
+                    &mut pushers,
+                    &scaling_alert_ip,
+                    base_offset,
+                    "DISK",
+                    new_disk_count,
+                    &mut new_disk_count,
+                )
+                .await;
+                grace_start = Instant::now();
+            }
+
             // Clear feedback maps.
             user_latency.clear();
             user_throughput.clear();
@@ -415,6 +513,12 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// Sends requests to all threads on all nodes, collects responses,
 /// then processes them into the stat maps.
+///
+/// Note: This runs sequentially (one request-response at a time) and
+/// blocks the event loop during collection. This matches the C++ monitor
+/// behavior. For large clusters, this could be parallelized with
+/// tokio::spawn, but the sequential approach is simpler and sufficient
+/// for typical deployments.
 async fn collect_internal_stats(
     global_hash_rings: &HashMap<Tier, ConsistentHashRing>,
     mt: &MonitoringThread,

--- a/server/rust/anna-monitor/src/monitor.rs
+++ b/server/rust/anna-monitor/src/monitor.rs
@@ -20,20 +20,20 @@ use crate::stats;
 use crate::types::*;
 
 /// Lazy-connecting PUSH socket cache.
-struct SocketCache {
+pub(crate) struct SocketCache {
     ctx: Context,
     sockets: HashMap<Address, OmqSocket>,
 }
 
 impl SocketCache {
-    fn new(ctx: Context) -> Self {
+    pub(crate) fn new(ctx: Context) -> Self {
         Self {
             ctx,
             sockets: HashMap::new(),
         }
     }
 
-    async fn send(&mut self, addr: &str, data: &[u8]) -> Result<(), String> {
+    pub(crate) async fn send(&mut self, addr: &str, data: &[u8]) -> Result<(), String> {
         if !self.sockets.contains_key(addr) {
             let sock = self.ctx.socket(SocketType::Push, Options::default());
             let endpoint = addr
@@ -50,7 +50,7 @@ impl SocketCache {
             .map_err(|e| format!("Failed to send to {}: {}", addr, e))
     }
 
-    async fn send_string(&mut self, addr: &str, msg: &str) -> Result<(), String> {
+    pub(crate) async fn send_string(&mut self, addr: &str, msg: &str) -> Result<(), String> {
         self.send(addr, msg.as_bytes()).await
     }
 }

--- a/server/rust/anna-monitor/src/monitor.rs
+++ b/server/rust/anna-monitor/src/monitor.rs
@@ -242,14 +242,18 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
             let data: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
             let text = String::from_utf8_lossy(&data);
 
-            // Record last_epoch_change for join events.
+            // Record last_epoch_change for KVS join/depart events only.
+            // Routing joins don't report stats and shouldn't be crash-checked.
             let parts: Vec<&str> = text.split(':').collect();
             if parts.len() >= 4 {
-                let ip_pair = format!("{}/{}", parts[2], parts[3]);
-                if parts[0] == "join" {
-                    last_epoch_change.insert(ip_pair, Instant::now());
-                } else if parts[0] == "depart" {
-                    last_epoch_change.remove(&ip_pair);
+                let tier_name = parts[1];
+                if tier_name == "MEMORY" || tier_name == "DISK" {
+                    let ip_pair = format!("{}/{}", parts[2], parts[3]);
+                    if parts[0] == "join" {
+                        last_epoch_change.insert(ip_pair, Instant::now());
+                    } else if parts[0] == "depart" {
+                        last_epoch_change.remove(&ip_pair);
+                    }
                 }
             }
 
@@ -318,6 +322,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
         let elapsed = report_start.elapsed().as_secs() as u32;
         if elapsed >= params.monitoring_threshold_s {
             epoch += 1;
+            info!("Starting monitoring cycle {} (elapsed={}s)", epoch, elapsed);
 
             let memory_node_count = global_hash_rings
                 .get(&Tier::Memory)
@@ -360,12 +365,13 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                 Duration::from_millis(params.monitoring_response_timeout_ms as u64),
             )
             .await;
-
-            // Crash detection.
+            // Crash detection — only run if we received at least some stats
+            // responses this cycle. If collect_internal_stats got nothing
+            // (e.g., KVS hasn't published its first report yet), skip
+            // crash detection to avoid false positives.
             let stale_threshold = Duration::from_secs(params.monitoring_threshold_s as u64);
             let mut dead_nodes = Vec::new();
 
-            // Build set of reporting nodes from occupancy data.
             let mut reporting_nodes = std::collections::HashSet::new();
             for ip_pair in memory_occupancy.keys() {
                 reporting_nodes.insert(ip_pair.clone());
@@ -382,13 +388,16 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                     .or_insert_with(Instant::now);
             }
 
-            // Detect dead nodes.
-            for (ip_pair, last_seen) in &last_epoch_change {
-                if !reporting_nodes.contains(ip_pair) && last_seen.elapsed() > stale_threshold {
-                    dead_nodes.push(ip_pair.clone());
+            // Only detect dead nodes if we got SOME responses this cycle.
+            // This prevents false positives during startup when the KVS
+            // hasn't published its first stats report yet.
+            if !reporting_nodes.is_empty() {
+                for (ip_pair, last_seen) in &last_epoch_change {
+                    if !reporting_nodes.contains(ip_pair) && last_seen.elapsed() > stale_threshold {
+                        dead_nodes.push(ip_pair.clone());
+                    }
                 }
             }
-
             for ip_pair in &dead_nodes {
                 warn!("Detected crashed node: {}", ip_pair);
                 let parts: Vec<&str> = ip_pair.split('/').collect();

--- a/server/rust/anna-monitor/src/monitor.rs
+++ b/server/rust/anna-monitor/src/monitor.rs
@@ -206,6 +206,10 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     let mut key_access_frequency = KeyAccessFrequency::new();
     let mut key_access_summary = KeyAccessSummary::new();
     let mut key_size = KeySizeMap::new();
+    let mut key_replication_map: HashMap<
+        anna_server_common::types::Key,
+        anna_server_common::metadata::KeyReplication,
+    > = HashMap::new();
     let mut ss = SummaryStats::default();
     let mut user_latency: HashMap<String, f64> = HashMap::new();
     let mut user_throughput: HashMap<String, f64> = HashMap::new();
@@ -449,24 +453,63 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                 grace_elapsed,
             );
 
-            policies::movement_policy(
+            let movement_requests = policies::movement_policy(
                 &ss,
                 &params,
                 &key_access_summary,
+                &key_replication_map,
                 &key_size,
                 memory_node_count,
                 &mut new_memory_count,
                 grace_elapsed,
             );
 
-            policies::slo_policy(
+            let slo_requests = policies::slo_policy(
                 &ss,
                 &params,
+                &key_access_summary,
+                &latency_miss_ratio_map,
+                &key_replication_map,
                 memory_node_count,
                 &mut new_memory_count,
                 &mut removing_memory_node,
                 grace_elapsed,
             );
+
+            // Execute replication changes requested by policies.
+            if !movement_requests.is_empty() {
+                crate::replication::change_replication_factor(
+                    &movement_requests,
+                    &global_hash_rings,
+                    &routing_ips,
+                    &mut key_replication_map,
+                    &mut pushers,
+                    &mt,
+                    &response_puller,
+                    &mut rid,
+                    &monitoring_ip,
+                    base_offset,
+                    Duration::from_millis(params.monitoring_response_timeout_ms as u64),
+                )
+                .await;
+            }
+
+            if !slo_requests.is_empty() {
+                crate::replication::change_replication_factor(
+                    &slo_requests,
+                    &global_hash_rings,
+                    &routing_ips,
+                    &mut key_replication_map,
+                    &mut pushers,
+                    &mt,
+                    &response_puller,
+                    &mut rid,
+                    &monitoring_ip,
+                    base_offset,
+                    Duration::from_millis(params.monitoring_response_timeout_ms as u64),
+                )
+                .await;
+            }
 
             // Send scaling alerts if policies requested new nodes.
             if new_memory_count > prev_mem {

--- a/server/rust/anna-monitor/src/policies.rs
+++ b/server/rust/anna-monitor/src/policies.rs
@@ -4,7 +4,10 @@
 //! `movement_policy.cpp`, and `slo_policy.cpp`.
 
 use crate::types::*;
+use anna_server_common::metadata::KeyReplication;
+use anna_server_common::types::Key;
 use log::info;
+use std::collections::HashMap;
 
 /// Storage-based scaling policy.
 ///
@@ -67,81 +70,112 @@ pub fn storage_policy(
 
 /// Tier movement policy (promote/demote keys between memory and disk).
 ///
-/// Only active when tiering is enabled.
+/// Only active when tiering is enabled. Returns replication change
+/// requests for the monitor loop to execute.
 pub fn movement_policy(
     ss: &SummaryStats,
     params: &MonitorParams,
     key_access_summary: &KeyAccessSummary,
+    key_replication_map: &HashMap<Key, KeyReplication>,
     _key_size: &KeySizeMap,
-    memory_node_count: u32,
+    _memory_node_count: u32,
     _new_memory_count: &mut u32,
-    grace_elapsed: bool,
-) {
+    _grace_elapsed: bool,
+) -> HashMap<Key, KeyReplication> {
+    let mut requests = HashMap::new();
+
     if !params.enable_tiering {
-        return;
+        return requests;
     }
 
-    // Count hot keys that should be promoted to memory.
-    let hot_keys: Vec<&String> = key_access_summary
-        .iter()
-        .filter(|(_, &count)| count > params.key_promotion_threshold)
-        .map(|(key, _)| key)
-        .collect();
-
-    if !hot_keys.is_empty() {
-        info!(
-            "Movement policy: {} hot keys above promotion threshold",
-            hot_keys.len()
-        );
-        // TODO: change_replication_factor for hot keys (requires replication_helpers port)
+    // Promote hot keys to memory.
+    for (key, &count) in key_access_summary {
+        if count > params.key_promotion_threshold {
+            if let Some(rep) = key_replication_map.get(key) {
+                let mem_rep = rep
+                    .global_replication
+                    .get(&anna_server_common::metadata::Tier::Memory)
+                    .copied()
+                    .unwrap_or(0);
+                if mem_rep == 0 {
+                    let mut new_rep = rep.clone();
+                    new_rep
+                        .global_replication
+                        .insert(anna_server_common::metadata::Tier::Memory, 1);
+                    let disk_rep = rep
+                        .global_replication
+                        .get(&anna_server_common::metadata::Tier::Disk)
+                        .copied()
+                        .unwrap_or(1);
+                    if disk_rep > 0 {
+                        new_rep
+                            .global_replication
+                            .insert(anna_server_common::metadata::Tier::Disk, disk_rep - 1);
+                    }
+                    requests.insert(key.clone(), new_rep);
+                }
+            }
+        }
     }
 
-    // Count cold keys that should be demoted to disk.
-    let cold_keys: Vec<&String> = key_access_summary
-        .iter()
-        .filter(|(_, &count)| count < params.key_demotion_threshold)
-        .map(|(key, _)| key)
-        .collect();
-
-    if !cold_keys.is_empty() {
-        info!(
-            "Movement policy: {} cold keys below demotion threshold",
-            cold_keys.len()
-        );
-        // TODO: change_replication_factor for cold keys (requires replication_helpers port)
+    // Demote cold keys to disk.
+    for (key, &count) in key_access_summary {
+        if count < params.key_demotion_threshold {
+            if let Some(rep) = key_replication_map.get(key) {
+                let mem_rep = rep
+                    .global_replication
+                    .get(&anna_server_common::metadata::Tier::Memory)
+                    .copied()
+                    .unwrap_or(0);
+                if mem_rep > 0 {
+                    requests.insert(
+                        key.clone(),
+                        crate::replication::create_new_replication(0, 1, 1, 1),
+                    );
+                }
+            }
+        }
     }
 
     // Selective replication reduction.
     if params.enable_selective_rep {
-        let cool_keys: Vec<&String> = key_access_summary
-            .iter()
-            .filter(|(_, &count)| (count as f64) <= ss.key_access_mean)
-            .map(|(key, _)| key)
-            .collect();
-
-        if !cool_keys.is_empty() {
-            info!(
-                "Movement policy: {} keys below mean for replication reduction",
-                cool_keys.len()
-            );
-            // TODO: change_replication_factor to reduce (requires replication_helpers port)
+        for (key, &count) in key_access_summary {
+            if (count as f64) <= ss.key_access_mean {
+                requests.insert(
+                    key.clone(),
+                    crate::replication::create_new_replication(1, 0, 1, 1),
+                );
+            }
         }
     }
 
-    let _ = (memory_node_count, grace_elapsed);
+    if !requests.is_empty() {
+        info!(
+            "Movement policy: {} replication change(s) requested",
+            requests.len()
+        );
+    }
+
+    requests
 }
 
 /// SLO-based scaling policy.
 ///
 /// Scales nodes based on latency SLO violations and occupancy.
+/// Returns replication change requests for the monitor loop.
 pub fn slo_policy(
     ss: &SummaryStats,
     params: &MonitorParams,
+    key_access_summary: &KeyAccessSummary,
+    latency_miss_ratio_map: &HashMap<String, (f64, u32)>,
+    key_replication_map: &HashMap<Key, KeyReplication>,
     memory_node_count: u32,
     new_memory_count: &mut u32,
     _removing_memory_node: &mut bool,
     grace_elapsed: bool,
-) {
+) -> HashMap<Key, KeyReplication> {
+    let mut requests = HashMap::new();
+
     // Branch 1: Latency SLO violated.
     if ss.avg_latency > params.slo_worst_us as f64 && *new_memory_count == 0 {
         if params.enable_elasticity
@@ -156,12 +190,39 @@ pub fn slo_policy(
                 nodes_to_add, ss.avg_latency, params.slo_worst_us
             );
             *new_memory_count = nodes_to_add;
-            // Scaling alert sent by monitor loop after policies run.
         }
 
+        // Selective replication increase for hot keys with high latency.
         if params.enable_selective_rep {
-            info!("SLO policy: would increase replication for hot keys");
-            // TODO: selective replication increase (requires replication_helpers port)
+            let threshold = ss.key_access_mean + ss.key_access_std;
+            for (key, &count) in key_access_summary {
+                if (count as f64) > threshold {
+                    if let Some((ratio, _)) = latency_miss_ratio_map.get(key) {
+                        if let Some(rep) = key_replication_map.get(key) {
+                            let mem_rep = rep
+                                .global_replication
+                                .get(&anna_server_common::metadata::Tier::Memory)
+                                .copied()
+                                .unwrap_or(1);
+                            let target = ((mem_rep as f64) * ratio).ceil() as u32;
+                            let target = target.max(mem_rep + 1).min(memory_node_count);
+                            if target > mem_rep {
+                                let mut new_rep = rep.clone();
+                                new_rep
+                                    .global_replication
+                                    .insert(anna_server_common::metadata::Tier::Memory, target);
+                                requests.insert(key.clone(), new_rep);
+                            }
+                        }
+                    }
+                }
+            }
+            if !requests.is_empty() {
+                info!(
+                    "SLO policy: {} selective replication increase(s)",
+                    requests.len()
+                );
+            }
         }
     }
 
@@ -175,8 +236,9 @@ pub fn slo_policy(
             "SLO policy: removing memory node (min occupancy {:.2}%)",
             ss.min_memory_occupancy * 100.0
         );
-        // Node removal initiated by monitor loop after policies run.
     }
+
+    requests
 }
 
 #[cfg(test)]
@@ -242,21 +304,25 @@ mod tests {
 
     #[test]
     fn slo_policy_noop_when_latency_ok() {
-        let ss = default_ss(); // avg_latency = 0
+        let ss = default_ss();
         let params = MonitorParams::default();
         let mut nmc = 0u32;
         let mut rmn = false;
+        let kas = KeyAccessSummary::new();
+        let lmr = HashMap::new();
+        let krm = HashMap::new();
 
-        slo_policy(&ss, &params, 1, &mut nmc, &mut rmn, true);
+        let reqs = slo_policy(&ss, &params, &kas, &lmr, &krm, 1, &mut nmc, &mut rmn, true);
 
         assert_eq!(nmc, 0);
+        assert!(reqs.is_empty());
     }
 
     #[test]
     fn slo_policy_scales_up_on_latency_violation() {
         let mut ss = default_ss();
-        ss.avg_latency = 6000.0; // 2x SLO
-        ss.min_memory_occupancy = 0.5; // above upper threshold
+        ss.avg_latency = 6000.0;
+        ss.min_memory_occupancy = 0.5;
 
         let params = MonitorParams {
             enable_elasticity: true,
@@ -266,8 +332,11 @@ mod tests {
         };
         let mut nmc = 0u32;
         let mut rmn = false;
+        let kas = KeyAccessSummary::new();
+        let lmr = HashMap::new();
+        let krm = HashMap::new();
 
-        slo_policy(&ss, &params, 2, &mut nmc, &mut rmn, true);
+        slo_policy(&ss, &params, &kas, &lmr, &krm, 2, &mut nmc, &mut rmn, true);
 
         assert!(nmc > 0, "should scale up on latency violation");
     }

--- a/server/rust/anna-monitor/src/policies.rs
+++ b/server/rust/anna-monitor/src/policies.rs
@@ -137,10 +137,11 @@ pub fn movement_policy(
         }
     }
 
-    // Selective replication reduction.
+    // Selective replication reduction — only for keys NOT already
+    // promoted or demoted by the loops above.
     if params.enable_selective_rep {
         for (key, &count) in key_access_summary {
-            if (count as f64) <= ss.key_access_mean {
+            if (count as f64) <= ss.key_access_mean && !requests.contains_key(key) {
                 requests.insert(
                     key.clone(),
                     crate::replication::create_new_replication(1, 0, 1, 1),

--- a/server/rust/anna-monitor/src/policies.rs
+++ b/server/rust/anna-monitor/src/policies.rs
@@ -32,7 +32,6 @@ pub fn storage_policy(
             to_add, ss.required_memory_node, memory_node_count
         );
         *new_memory_count = to_add;
-        // TODO: emit_scale_up_alert via ZMQ
     }
 
     // Scale up disk.
@@ -47,7 +46,6 @@ pub fn storage_policy(
             to_add, ss.required_disk_node, disk_node_count
         );
         *new_disk_count = to_add;
-        // TODO: emit_scale_up_alert via ZMQ
     }
 
     // Scale down disk if under-utilized.
@@ -63,7 +61,7 @@ pub fn storage_policy(
             ss.avg_disk_consumption_percentage * 100.0
         );
         *removing_disk_node = true;
-        // TODO: remove_node via ZMQ
+        // Node removal initiated by monitor loop after policies run.
     }
 }
 
@@ -95,7 +93,7 @@ pub fn movement_policy(
             "Movement policy: {} hot keys above promotion threshold",
             hot_keys.len()
         );
-        // TODO: change_replication_factor for hot keys
+        // TODO: change_replication_factor for hot keys (requires replication_helpers port)
     }
 
     // Count cold keys that should be demoted to disk.
@@ -110,7 +108,7 @@ pub fn movement_policy(
             "Movement policy: {} cold keys below demotion threshold",
             cold_keys.len()
         );
-        // TODO: change_replication_factor for cold keys
+        // TODO: change_replication_factor for cold keys (requires replication_helpers port)
     }
 
     // Selective replication reduction.
@@ -126,7 +124,7 @@ pub fn movement_policy(
                 "Movement policy: {} keys below mean for replication reduction",
                 cool_keys.len()
             );
-            // TODO: change_replication_factor to reduce
+            // TODO: change_replication_factor to reduce (requires replication_helpers port)
         }
     }
 
@@ -158,12 +156,12 @@ pub fn slo_policy(
                 nodes_to_add, ss.avg_latency, params.slo_worst_us
             );
             *new_memory_count = nodes_to_add;
-            // TODO: emit_scale_up_alert via ZMQ
+            // Scaling alert sent by monitor loop after policies run.
         }
 
         if params.enable_selective_rep {
             info!("SLO policy: would increase replication for hot keys");
-            // TODO: selective replication increase
+            // TODO: selective replication increase (requires replication_helpers port)
         }
     }
 
@@ -177,7 +175,7 @@ pub fn slo_policy(
             "SLO policy: removing memory node (min occupancy {:.2}%)",
             ss.min_memory_occupancy * 100.0
         );
-        // TODO: remove_node via ZMQ
+        // Node removal initiated by monitor loop after policies run.
     }
 }
 

--- a/server/rust/anna-monitor/src/replication.rs
+++ b/server/rust/anna-monitor/src/replication.rs
@@ -1,0 +1,301 @@
+//! Replication factor management.
+//!
+//! Mirrors `server/cpp/src/monitor/replication_helpers.cpp`.
+
+use anna_server_common::hash_ring::ConsistentHashRing;
+use anna_server_common::metadata::{KeyReplication, Tier};
+use anna_server_common::proto::kvs::{
+    KeyRequest, KeyResponse, KeyTuple, LatticeType, LwwValue, RequestType,
+};
+use anna_server_common::proto::metadata::{
+    replication_factor::ReplicationValue, ReplicationFactor, ReplicationFactorUpdate,
+};
+use anna_server_common::threads::{MonitoringThread, RoutingThread, ServerThread};
+use anna_server_common::types::{Address, Key};
+use log::{error, info, warn};
+use omq_tokio::Socket as OmqSocket;
+use prost::Message;
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::monitor::SocketCache;
+
+/// Create a new KeyReplication with the given factors.
+pub fn create_new_replication(
+    global_memory: u32,
+    global_disk: u32,
+    local_memory: u32,
+    local_disk: u32,
+) -> KeyReplication {
+    let mut rep = KeyReplication::default();
+    rep.global_replication.insert(Tier::Memory, global_memory);
+    rep.global_replication.insert(Tier::Disk, global_disk);
+    rep.local_replication.insert(Tier::Memory, local_memory);
+    rep.local_replication.insert(Tier::Disk, local_disk);
+    rep
+}
+
+/// Change replication factors for a set of keys.
+///
+/// For each key:
+/// 1. Update `key_replication_map` with the new factors
+/// 2. PUT the replication metadata to a KVS node
+/// 3. Send ReplicationFactorUpdate to affected KVS and routing nodes
+///
+/// Keys that fail the PUT are restored to their original replication.
+pub async fn change_replication_factor(
+    requests: &HashMap<Key, KeyReplication>,
+    global_hash_rings: &HashMap<Tier, ConsistentHashRing>,
+    routing_ips: &[Address],
+    key_replication_map: &mut HashMap<Key, KeyReplication>,
+    pushers: &mut SocketCache,
+    mt: &MonitoringThread,
+    response_puller: &OmqSocket,
+    rid: &mut u32,
+    monitor_ip: &str,
+    base_offset: u32,
+    timeout: Duration,
+) {
+    if requests.is_empty() {
+        return;
+    }
+
+    // Save original replication factors for rollback on failure.
+    let mut orig_replication: HashMap<Key, KeyReplication> = HashMap::new();
+    let mut keys_to_update: Vec<Key> = Vec::new();
+
+    for (key, new_rep) in requests {
+        let current = key_replication_map.get(key);
+        if current.map(|c| c == new_rep).unwrap_or(false) {
+            continue; // No change needed.
+        }
+
+        if let Some(current) = current {
+            orig_replication.insert(key.clone(), current.clone());
+        }
+
+        // Update the in-memory map.
+        key_replication_map.insert(key.clone(), new_rep.clone());
+        keys_to_update.push(key.clone());
+    }
+
+    if keys_to_update.is_empty() {
+        return;
+    }
+
+    info!(
+        "Changing replication factor for {} key(s)",
+        keys_to_update.len()
+    );
+
+    // PUT replication metadata to KVS nodes.
+    let mut failed_keys: HashSet<Key> = HashSet::new();
+
+    for key in &keys_to_update {
+        let rep = &key_replication_map[key];
+        let rep_factor = build_replication_factor(key, rep);
+        let rep_key = format!("ANNA_METADATA|replication|{}", key);
+
+        let mut rep_data = Vec::new();
+        rep_factor.encode(&mut rep_data).ok();
+
+        // Wrap in LWW.
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_nanos() as u64;
+        let lww = LwwValue {
+            timestamp: ts,
+            value: rep_data,
+        };
+        let payload = lww.encode_to_vec();
+
+        *rid += 1;
+        let request = KeyRequest {
+            r#type: RequestType::Put as i32,
+            response_address: mt.response_connect_address(),
+            request_id: format!("{}:{}", monitor_ip, rid),
+            tuples: vec![KeyTuple {
+                key: rep_key,
+                lattice_type: LatticeType::Lww as i32,
+                payload,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        // Find a KVS node to send to. Use the first memory node.
+        let target = global_hash_rings
+            .get(&Tier::Memory)
+            .and_then(|ring| ring.get_unique_servers().into_iter().next())
+            .map(|st| {
+                ServerThread::new(st.public_ip(), st.private_ip(), 0, base_offset)
+                    .key_request_connect_address()
+            });
+
+        let target_addr = match target {
+            Some(addr) => addr,
+            None => {
+                warn!("No KVS nodes available for replication PUT");
+                failed_keys.insert(key.clone());
+                continue;
+            }
+        };
+
+        let encoded = request.encode_to_vec();
+        if let Err(e) = pushers.send(&target_addr, &encoded).await {
+            warn!("Failed to send replication PUT for key {}: {}", key, e);
+            failed_keys.insert(key.clone());
+            continue;
+        }
+
+        // Wait for response.
+        match tokio::time::timeout(timeout, response_puller.recv()).await {
+            Ok(Ok(msg)) => {
+                let bytes: Vec<u8> = msg.iter().flat_map(|f| f.to_vec()).collect();
+                if let Ok(response) = KeyResponse::decode(bytes.as_slice()) {
+                    for tuple in &response.tuples {
+                        if tuple.error == 2 {
+                            // Wrong address — key routed incorrectly.
+                            warn!("Replication PUT for key {} rejected (wrong address)", key);
+                            failed_keys.insert(key.clone());
+                        }
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                warn!("ZMQ error receiving replication PUT response: {}", e);
+                failed_keys.insert(key.clone());
+            }
+            Err(_) => {
+                warn!("Replication PUT timed out for key {}", key);
+                failed_keys.insert(key.clone());
+            }
+        }
+    }
+
+    // Send ReplicationFactorUpdate to KVS and routing nodes for successful keys.
+    let mut update_map: HashMap<Address, ReplicationFactorUpdate> = HashMap::new();
+
+    for key in &keys_to_update {
+        if failed_keys.contains(key) {
+            continue;
+        }
+
+        let rep = &key_replication_map[key];
+        let orig = orig_replication.get(key);
+
+        // Notify KVS nodes: use the max of old and new rep to cover all nodes.
+        for tier in [Tier::Memory, Tier::Disk] {
+            if let Some(ring) = global_hash_rings.get(&tier) {
+                let new_global = rep.global_replication.get(&tier).copied().unwrap_or(0);
+                let old_global = orig
+                    .and_then(|o| o.global_replication.get(&tier))
+                    .copied()
+                    .unwrap_or(0);
+                let max_rep = new_global.max(old_global);
+
+                if max_rep == 0 {
+                    continue;
+                }
+
+                // Get responsible servers for this replication level.
+                // Since our hash ring may differ from C++, send to all
+                // unique servers as a safe default.
+                for st in ring.get_unique_servers() {
+                    let addr = ServerThread::new(st.public_ip(), st.private_ip(), 0, base_offset)
+                        .replication_change_connect_address();
+
+                    let update = update_map.entry(addr).or_default();
+                    add_replication_factor_to_update(update, key, rep);
+                }
+            }
+        }
+
+        // Notify all routing nodes.
+        for rt_ip in routing_ips {
+            let addr =
+                RoutingThread::new(rt_ip, 0, base_offset).replication_change_connect_address();
+            let update = update_map.entry(addr).or_default();
+            add_replication_factor_to_update(update, key, rep);
+        }
+    }
+
+    // Send all ReplicationFactorUpdate messages.
+    for (addr, update) in &update_map {
+        let encoded = update.encode_to_vec();
+        if let Err(e) = pushers.send(addr, &encoded).await {
+            error!("Failed to send ReplicationFactorUpdate to {}: {}", addr, e);
+        }
+    }
+
+    // Restore original replication for failed keys.
+    for key in &failed_keys {
+        if let Some(orig) = orig_replication.get(key) {
+            key_replication_map.insert(key.clone(), orig.clone());
+        } else {
+            key_replication_map.remove(key);
+        }
+    }
+
+    if !failed_keys.is_empty() {
+        warn!(
+            "Replication change failed for {} key(s), restored originals",
+            failed_keys.len()
+        );
+    }
+}
+
+fn build_replication_factor(key: &str, rep: &KeyReplication) -> ReplicationFactor {
+    let mut rf = ReplicationFactor {
+        key: key.to_string(),
+        ..Default::default()
+    };
+
+    for (&tier, &value) in &rep.global_replication {
+        rf.global.push(ReplicationValue {
+            tier: tier as i32,
+            value,
+        });
+    }
+
+    for (&tier, &value) in &rep.local_replication {
+        rf.local.push(ReplicationValue {
+            tier: tier as i32,
+            value,
+        });
+    }
+
+    rf
+}
+
+fn add_replication_factor_to_update(
+    update: &mut ReplicationFactorUpdate,
+    key: &str,
+    rep: &KeyReplication,
+) {
+    update.updates.push(build_replication_factor(key, rep));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_new_replication_sets_all_fields() {
+        let rep = create_new_replication(2, 1, 1, 1);
+        assert_eq!(rep.global_replication[&Tier::Memory], 2);
+        assert_eq!(rep.global_replication[&Tier::Disk], 1);
+        assert_eq!(rep.local_replication[&Tier::Memory], 1);
+        assert_eq!(rep.local_replication[&Tier::Disk], 1);
+    }
+
+    #[test]
+    fn build_replication_factor_creates_protobuf() {
+        let rep = create_new_replication(3, 1, 1, 1);
+        let rf = build_replication_factor("test_key", &rep);
+        assert_eq!(rf.key, "test_key");
+        assert_eq!(rf.global.len(), 2);
+        assert_eq!(rf.local.len(), 2);
+    }
+}

--- a/server/rust/server-common/src/metadata.rs
+++ b/server/rust/server-common/src/metadata.rs
@@ -28,7 +28,7 @@ pub struct TierMetadata {
 }
 
 /// Per-key replication factors.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct KeyReplication {
     pub global_replication: HashMap<Tier, u32>,
     pub local_replication: HashMap<Tier, u32>,


### PR DESCRIPTION
## Phase 3 of the Rust server port (#339)

### ZMQ socket integration for anna-monitor-rs

The Rust monitor now has real ZMQ sockets wired up:

- **4 PULL sockets** bound on startup: notify, depart_done, feedback, response
- **SocketCache** (lazy PUSH connections) for sending to KVS/routing nodes
- **Event loop**: sequential recv with timeout on each socket per iteration
- **collect_internal_stats**: Sends GET requests for 3 metadata keys (server_stats, key_access, key_size) to every thread on every KVS node. Collects and processes responses into storage/occupancy/access stat maps.
- **Crash detection**: Compares reporting nodes against last_epoch_change map, removes stale nodes from hash rings, notifies routing nodes of departures.
- **depart_done_handler**: Now returns completion info so the event loop can send ScalingAlert via ZMQ.

### Dual-monitor test infrastructure

All 3 test files now support `ANNA_MONITOR_BIN` env var:
- `clients/rust/tests/multi_node.rs`
- `clients/rust/tests/common/mod.rs`
- `clients/rust/tests/monitor.rs`

When set, uses the specified binary instead of the C++ `anna-monitor`. This enables running the exact same integration tests against `anna-monitor-rs`:

```bash
# Run tests with C++ monitor (default)
make test

# Run tests with Rust monitor
ANNA_MONITOR_BIN=target/debug/anna-monitor-rs make test
```

### Makefile

- New `server-rust` target builds `anna-monitor-rs`
- Added to `build` target

### Remaining work (tracked in #529)

- emit_scale_up_alert: build and send ScalingAlert protobuf (3 call sites in policies)
- remove_node: send depart command to node's self_depart_connect_address (2 call sites)
- change_replication_factor: PUT replication metadata + send ReplicationFactorUpdate (4 call sites)

These are needed before the Rust monitor can pass the monitor integration tests.

Part of #339, addresses #529