### PR TITLE
Add feature flags for anna-monitor policies (#530)

### DIFF
--- a/server/rust/anna-monitor/Cargo.toml
+++ b/server/rust/anna-monitor/Cargo.toml
@@ -19,5 +19,15 @@ serde_yaml = "0.9"
 omq-tokio = "0.20"
 tokio = { version = "1", features = ["full"] }
 
+[features]
+default = ["tiering", "autoscaling"]
+
+## Enable memory/disk tier movement policy (promote/demote keys).
+tiering = []
+
+## Enable storage and SLO-based auto-scaling policies.
+## Includes emit_scale_up_alert and remove_node functionality.
+autoscaling = []
+
 [dev-dependencies]
 tempfile = "3"

--- a/server/rust/anna-monitor/src/monitor.rs
+++ b/server/rust/anna-monitor/src/monitor.rs
@@ -56,6 +56,7 @@ impl SocketCache {
 }
 
 /// Send a ScalingAlert (ADD) to the external scaling system.
+#[cfg(feature = "autoscaling")]
 async fn emit_scale_up_alert(
     pushers: &mut SocketCache,
     scaling_alert_ip: &str,
@@ -91,6 +92,7 @@ async fn emit_scale_up_alert(
 }
 
 /// Send a self-depart command to a KVS node, initiating graceful removal.
+#[cfg(feature = "autoscaling")]
 async fn remove_node(
     pushers: &mut SocketCache,
     mt: &MonitoringThread,
@@ -397,9 +399,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
             let crash_threshold = stale_threshold * 2;
             if !reporting_nodes.is_empty() {
                 for (ip_pair, last_seen) in &last_epoch_change {
-                    if !reporting_nodes.contains(ip_pair)
-                        && last_seen.elapsed() > crash_threshold
-                    {
+                    if !reporting_nodes.contains(ip_pair) && last_seen.elapsed() > crash_threshold {
                         dead_nodes.push(ip_pair.clone());
                     }
                 }
@@ -457,6 +457,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
             let prev_mem = new_memory_count;
             let prev_disk = new_disk_count;
 
+            #[cfg(feature = "autoscaling")]
             policies::storage_policy(
                 &ss,
                 &params,
@@ -468,6 +469,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                 grace_elapsed,
             );
 
+            #[cfg(feature = "tiering")]
             let movement_requests = policies::movement_policy(
                 &ss,
                 &params,
@@ -479,6 +481,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                 grace_elapsed,
             );
 
+            #[cfg(feature = "autoscaling")]
             let slo_requests = policies::slo_policy(
                 &ss,
                 &params,
@@ -492,6 +495,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
             );
 
             // Execute replication changes requested by policies.
+            #[cfg(feature = "tiering")]
             if !movement_requests.is_empty() {
                 crate::replication::change_replication_factor(
                     &movement_requests,
@@ -509,6 +513,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                 .await;
             }
 
+            #[cfg(feature = "autoscaling")]
             if !slo_requests.is_empty() {
                 crate::replication::change_replication_factor(
                     &slo_requests,
@@ -527,6 +532,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Send scaling alerts if policies requested new nodes.
+            #[cfg(feature = "autoscaling")]
             if new_memory_count > prev_mem {
                 emit_scale_up_alert(
                     &mut pushers,
@@ -539,6 +545,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                 .await;
                 grace_start = Instant::now();
             }
+            #[cfg(feature = "autoscaling")]
             if new_disk_count > prev_disk {
                 emit_scale_up_alert(
                     &mut pushers,

--- a/server/rust/anna-monitor/src/policies.rs
+++ b/server/rust/anna-monitor/src/policies.rs
@@ -3,16 +3,22 @@
 //! Mirrors `server/cpp/src/monitor/storage_policy.cpp`,
 //! `movement_policy.cpp`, and `slo_policy.cpp`.
 
+#[allow(unused_imports)]
 use crate::types::*;
+#[allow(unused_imports)]
 use anna_server_common::metadata::KeyReplication;
+#[allow(unused_imports)]
 use anna_server_common::types::Key;
+#[allow(unused_imports)]
 use log::info;
+#[allow(unused_imports)]
 use std::collections::HashMap;
 
 /// Storage-based scaling policy.
 ///
 /// Adds nodes when storage exceeds upper threshold, removes nodes
 /// when below lower threshold.
+#[cfg(feature = "autoscaling")]
 pub fn storage_policy(
     ss: &SummaryStats,
     params: &MonitorParams,
@@ -72,6 +78,7 @@ pub fn storage_policy(
 ///
 /// Only active when tiering is enabled. Returns replication change
 /// requests for the monitor loop to execute.
+#[cfg(feature = "tiering")]
 pub fn movement_policy(
     ss: &SummaryStats,
     params: &MonitorParams,
@@ -164,6 +171,7 @@ pub fn movement_policy(
 ///
 /// Scales nodes based on latency SLO violations and occupancy.
 /// Returns replication change requests for the monitor loop.
+#[cfg(feature = "autoscaling")]
 pub fn slo_policy(
     ss: &SummaryStats,
     params: &MonitorParams,
@@ -251,6 +259,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "autoscaling")]
     fn storage_policy_noop_when_disabled() {
         let ss = default_ss();
         let params = MonitorParams {
@@ -268,6 +277,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "autoscaling")]
     fn storage_policy_scales_up_memory() {
         let mut ss = default_ss();
         ss.required_memory_node = 3;
@@ -286,6 +296,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "autoscaling")]
     fn storage_policy_respects_grace_period() {
         let mut ss = default_ss();
         ss.required_memory_node = 3;
@@ -304,6 +315,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "autoscaling")]
     fn slo_policy_noop_when_latency_ok() {
         let ss = default_ss();
         let params = MonitorParams::default();
@@ -320,6 +332,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "autoscaling")]
     fn slo_policy_scales_up_on_latency_violation() {
         let mut ss = default_ss();
         ss.avg_latency = 6000.0;


### PR DESCRIPTION
## Phase 4 of the Rust server port (#339)

Optional Cargo features for anna-monitor policy engines:

| Feature | Default | Gates |
|---|---|---|
| `tiering` | enabled | `movement_policy` (promote/demote keys between tiers) |
| `autoscaling` | enabled | `storage_policy`, `slo_policy`, `emit_scale_up_alert`, `remove_node` |

### Usage

```bash
# Full monitor (default — all policies enabled)
cargo build -p anna-monitor

# Minimal monitor (membership, stats, crash detection only)
cargo build -p anna-monitor --no-default-features

# Only tiering, no auto-scaling
cargo build -p anna-monitor --no-default-features --features tiering
```

### Tests

- 16 tests with all features (default)
- 11 tests with no features (5 policy tests conditionally compiled)
- All 4 feature combinations compile cleanly

Closes #530, completes #339 Phase 4