### PR TITLE
Add anna-hashring C library for shared hash ring (#535)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "anna-hashring"
+version = "0.1.0"
+dependencies = [
+ "anna-server-common",
+]
+
+[[package]]
 name = "anna-monitor"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
-members = ["clients/rust", "server/rust/server-common", "server/rust/anna-monitor"]
+members = [
+    "clients/rust",
+    "server/rust/server-common",
+    "server/rust/anna-monitor",
+    "server/rust/anna-hashring",
+]
 default-members = ["clients/rust"]

--- a/server/rust/anna-hashring/Cargo.toml
+++ b/server/rust/anna-hashring/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "anna-hashring"
+version = "0.1.0"
+edition = "2021"
+description = "Consistent hash ring with C FFI for Anna KVS"
+
+[lib]
+name = "anna_hashring"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[dependencies]
+anna-server-common = { path = "../server-common" }
+
+

--- a/server/rust/anna-hashring/anna_hashring.h
+++ b/server/rust/anna-hashring/anna_hashring.h
@@ -1,0 +1,94 @@
+#ifndef ANNA_HASHRING_H
+#define ANNA_HASHRING_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Opaque handle to a consistent hash ring.
+ */
+typedef struct AnnaHashRing AnnaHashRing;
+
+/**
+ * Result of a server lookup: public IP, private IP, thread ID.
+ */
+typedef struct ServerInfo {
+  char *public_ip;
+  char *private_ip;
+  uint32_t tid;
+} ServerInfo;
+
+/**
+ * Create a new hash ring.
+ *
+ * `global`: if true, uses the global hasher (for cross-node key distribution).
+ *           if false, uses the local hasher (for intra-node thread distribution).
+ * `base_offset`: port base offset for address generation.
+ */
+struct AnnaHashRing *anna_hashring_new(bool global, uint32_t base_offset);
+
+/**
+ * Free a hash ring.
+ */
+void anna_hashring_free(struct AnnaHashRing *ring);
+
+/**
+ * Insert a server into the ring with `virtual_nodes` virtual entries.
+ * Returns 0 on success, -1 if tid >= 50 (port group overflow).
+ */
+int32_t anna_hashring_insert(struct AnnaHashRing *ring,
+                             const char *public_ip,
+                             const char *private_ip,
+                             uint32_t tid,
+                             uint32_t virtual_nodes);
+
+/**
+ * Remove all entries for a server from the ring.
+ */
+void anna_hashring_remove(struct AnnaHashRing *ring,
+                          const char *public_ip,
+                          const char *private_ip,
+                          uint32_t tid);
+
+/**
+ * Return the number of entries in the ring (including virtual nodes).
+ */
+uint32_t anna_hashring_size(const struct AnnaHashRing *ring);
+
+/**
+ * Find responsible servers for a key with `rep_count` replicas.
+ * Returns the number of servers found. Results written to `out_servers`.
+ * Caller must free strings via `anna_string_free`.
+ */
+uint32_t anna_responsible_servers(const struct AnnaHashRing *ring,
+                                  const char *key,
+                                  uint32_t rep_count,
+                                  struct ServerInfo *out_servers,
+                                  uint32_t max_results);
+
+/**
+ * Get all unique servers in the ring.
+ * Returns count. Caller must free strings via `anna_string_free`.
+ */
+uint32_t anna_hashring_get_unique_servers(const struct AnnaHashRing *ring,
+                                           struct ServerInfo *out_servers,
+                                           uint32_t max_results);
+
+/**
+ * Find responsible local thread IDs for a key.
+ * Returns 0 if the ring was created with `global = true` (wrong ring type).
+ */
+uint32_t anna_responsible_local(const struct AnnaHashRing *ring,
+                                 const char *key,
+                                 uint32_t rep_count,
+                                 uint32_t *out_tids,
+                                 uint32_t max_results);
+
+/**
+ * Free a string allocated by the library.
+ */
+void anna_string_free(char *s);
+
+#endif /* ANNA_HASHRING_H */

--- a/server/rust/anna-hashring/build.rs
+++ b/server/rust/anna-hashring/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // C header is maintained manually at anna_hashring.h
+    // cbindgen has issues parsing external crate type references,
+    // so we generate the header once and update it by hand when
+    // the API changes.
+}

--- a/server/rust/anna-hashring/src/lib.rs
+++ b/server/rust/anna-hashring/src/lib.rs
@@ -1,0 +1,402 @@
+//! Consistent hash ring with C FFI for Anna KVS.
+//!
+//! This crate provides a single canonical hash ring implementation shared
+//! across all Anna components (Rust server, C++ server, and all client
+//! libraries). The C API allows linking from C/C++, Python (ctypes), and
+//! Go (cgo).
+
+use anna_server_common::hash_ring::ConsistentHashRing;
+use anna_server_common::threads::MAX_TID;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+/// Opaque handle to a consistent hash ring.
+///
+/// cbindgen:ignore
+pub struct AnnaHashRing {
+    ring: ConsistentHashRing,
+    global: bool,
+    base_offset: u32,
+}
+
+/// Result of a server lookup: public IP, private IP, thread ID.
+#[repr(C)]
+#[derive(Clone)]
+pub struct ServerInfo {
+    pub public_ip: *mut c_char,
+    pub private_ip: *mut c_char,
+    pub tid: u32,
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────
+
+/// Create a new hash ring.
+///
+/// `global`: if true, uses the global hasher (for cross-node key distribution).
+///           if false, uses the local hasher (for intra-node thread distribution).
+/// `base_offset`: port base offset for address generation.
+#[no_mangle]
+pub extern "C" fn anna_hashring_new(global: bool, base_offset: u32) -> *mut AnnaHashRing {
+    Box::into_raw(Box::new(AnnaHashRing {
+        ring: ConsistentHashRing::new(),
+        global,
+        base_offset,
+    }))
+}
+
+/// Free a hash ring.
+///
+/// # Safety
+/// `ring` must be a valid pointer returned by `anna_hashring_new`.
+#[no_mangle]
+pub unsafe extern "C" fn anna_hashring_free(ring: *mut AnnaHashRing) {
+    if !ring.is_null() {
+        drop(Box::from_raw(ring));
+    }
+}
+
+// ── Mutation ────────────────────────────────────────────────────────
+
+/// Insert a server into the ring with `virtual_nodes` virtual entries.
+///
+/// Returns 0 on success, -1 if tid >= 50 (port group overflow).
+///
+/// # Safety
+/// `ring` must be valid. `public_ip` and `private_ip` must be valid C strings.
+#[no_mangle]
+pub unsafe extern "C" fn anna_hashring_insert(
+    ring: *mut AnnaHashRing,
+    public_ip: *const c_char,
+    private_ip: *const c_char,
+    tid: u32,
+    virtual_nodes: u32,
+) -> i32 {
+    if tid >= MAX_TID {
+        return -1;
+    }
+    let ring = &mut *ring;
+    let pub_ip = CStr::from_ptr(public_ip).to_str().unwrap_or("");
+    let priv_ip = CStr::from_ptr(private_ip).to_str().unwrap_or("");
+    ring.ring.insert(
+        pub_ip,
+        priv_ip,
+        tid,
+        ring.base_offset,
+        virtual_nodes,
+        ring.global,
+    );
+    0
+}
+
+/// Remove all entries for a server (identified by IPs and tid) from the ring.
+///
+/// # Safety
+/// `ring` must be valid. `public_ip` and `private_ip` must be valid C strings.
+#[no_mangle]
+pub unsafe extern "C" fn anna_hashring_remove(
+    ring: *mut AnnaHashRing,
+    public_ip: *const c_char,
+    private_ip: *const c_char,
+    tid: u32,
+) {
+    let ring = &mut *ring;
+    let pub_ip = CStr::from_ptr(public_ip).to_str().unwrap_or("");
+    let priv_ip = CStr::from_ptr(private_ip).to_str().unwrap_or("");
+    ring.ring.remove(pub_ip, priv_ip, tid);
+}
+
+// ── Query ───────────────────────────────────────────────────────────
+
+/// Return the number of entries in the ring (including virtual nodes).
+///
+/// # Safety
+/// `ring` must be valid.
+#[no_mangle]
+pub unsafe extern "C" fn anna_hashring_size(ring: *const AnnaHashRing) -> u32 {
+    (*ring).ring.size() as u32
+}
+
+/// Find the responsible servers for a key with `rep_count` replicas.
+///
+/// Walks the ring clockwise from hash(key), collecting up to `rep_count`
+/// unique servers (by IP, not by virtual node). Returns the number of
+/// servers found. Results are written to the `out_servers` array.
+///
+/// The caller must allocate `out_servers` with at least `max_results` entries.
+/// The caller must free the `public_ip` and `private_ip` strings in each
+/// returned `ServerInfo` via `anna_string_free`.
+///
+/// # Safety
+/// `ring`, `key`, and `out_servers` must be valid.
+#[no_mangle]
+pub unsafe extern "C" fn anna_responsible_servers(
+    ring: *const AnnaHashRing,
+    key: *const c_char,
+    rep_count: u32,
+    out_servers: *mut ServerInfo,
+    max_results: u32,
+) -> u32 {
+    let ring_ref = &(*ring);
+    let key_str = CStr::from_ptr(key).to_str().unwrap_or("");
+
+    let servers = ring_ref
+        .ring
+        .find_responsible(key_str, rep_count, ring_ref.global);
+
+    let count = servers.len().min(max_results as usize);
+    for (i, st) in servers.iter().take(count).enumerate() {
+        let info = &mut *out_servers.add(i);
+        info.public_ip = to_c_string(st.public_ip());
+        info.private_ip = to_c_string(st.private_ip());
+        info.tid = st.tid();
+    }
+
+    count as u32
+}
+
+/// Get all unique servers in the ring.
+///
+/// Returns the count. Each entry in `out_servers` gets public_ip, private_ip, tid.
+/// Caller must free strings via `anna_string_free`.
+///
+/// # Safety
+/// `ring` and `out_servers` must be valid.
+#[no_mangle]
+pub unsafe extern "C" fn anna_hashring_get_unique_servers(
+    ring: *const AnnaHashRing,
+    out_servers: *mut ServerInfo,
+    max_results: u32,
+) -> u32 {
+    let ring_ref = &(*ring);
+    let servers = ring_ref.ring.get_unique_servers();
+
+    let count = servers.len().min(max_results as usize);
+    for (i, st) in servers.iter().take(count).enumerate() {
+        let info = &mut *out_servers.add(i);
+        info.public_ip = to_c_string(st.public_ip());
+        info.private_ip = to_c_string(st.private_ip());
+        info.tid = st.tid();
+    }
+
+    count as u32
+}
+
+/// Find responsible local thread IDs for a key with `rep_count` replicas.
+///
+/// Uses the local hasher. Returns count of thread IDs written to `out_tids`.
+/// Returns 0 if the ring was created with `global = true` (wrong ring type).
+///
+/// # Safety
+/// `ring`, `key`, and `out_tids` must be valid.
+#[no_mangle]
+pub unsafe extern "C" fn anna_responsible_local(
+    ring: *const AnnaHashRing,
+    key: *const c_char,
+    rep_count: u32,
+    out_tids: *mut u32,
+    max_results: u32,
+) -> u32 {
+    let ring_ref = &(*ring);
+    if ring_ref.global {
+        return 0; // Wrong ring type for local lookup.
+    }
+    let key_str = CStr::from_ptr(key).to_str().unwrap_or("");
+
+    let tids = ring_ref.ring.find_responsible_local(key_str, rep_count);
+
+    let count = tids.len().min(max_results as usize);
+    for (i, &tid) in tids.iter().take(count).enumerate() {
+        *out_tids.add(i) = tid;
+    }
+
+    count as u32
+}
+
+// ── String management ───────────────────────────────────────────────
+
+/// Free a string allocated by the library.
+///
+/// # Safety
+/// `s` must be a valid pointer returned by a library function, or null.
+#[no_mangle]
+pub unsafe extern "C" fn anna_string_free(s: *mut c_char) {
+    if !s.is_null() {
+        drop(std::ffi::CString::from_raw(s));
+    }
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+fn to_c_string(s: &str) -> *mut c_char {
+    std::ffi::CString::new(s).unwrap_or_default().into_raw()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    fn c_str(s: &str) -> CString {
+        CString::new(s).unwrap()
+    }
+
+    #[test]
+    fn lifecycle() {
+        unsafe {
+            let ring = anna_hashring_new(true, 0);
+            assert!(!ring.is_null());
+            assert_eq!(anna_hashring_size(ring), 0);
+            anna_hashring_free(ring);
+        }
+    }
+
+    #[test]
+    fn insert_and_size() {
+        unsafe {
+            let ring = anna_hashring_new(true, 0);
+            let pub_ip = c_str("1.2.3.4");
+            let priv_ip = c_str("10.0.0.1");
+            anna_hashring_insert(ring, pub_ip.as_ptr(), priv_ip.as_ptr(), 0, 100);
+            assert_eq!(anna_hashring_size(ring), 100);
+            anna_hashring_free(ring);
+        }
+    }
+
+    #[test]
+    fn insert_and_remove() {
+        unsafe {
+            let ring = anna_hashring_new(true, 0);
+            let pub_ip = c_str("1.2.3.4");
+            let priv_ip = c_str("10.0.0.1");
+            anna_hashring_insert(ring, pub_ip.as_ptr(), priv_ip.as_ptr(), 0, 100);
+            assert_eq!(anna_hashring_size(ring), 100);
+
+            anna_hashring_remove(ring, pub_ip.as_ptr(), priv_ip.as_ptr(), 0);
+            assert_eq!(anna_hashring_size(ring), 0);
+            anna_hashring_free(ring);
+        }
+    }
+
+    #[test]
+    fn responsible_servers_single_node() {
+        unsafe {
+            let ring = anna_hashring_new(true, 0);
+            let pub_ip = c_str("1.2.3.4");
+            let priv_ip = c_str("10.0.0.1");
+            anna_hashring_insert(ring, pub_ip.as_ptr(), priv_ip.as_ptr(), 0, 3000);
+
+            let key = c_str("test_key");
+            let mut servers = vec![
+                ServerInfo {
+                    public_ip: std::ptr::null_mut(),
+                    private_ip: std::ptr::null_mut(),
+                    tid: 0,
+                };
+                4
+            ];
+
+            let count = anna_responsible_servers(ring, key.as_ptr(), 1, servers.as_mut_ptr(), 4);
+            assert_eq!(count, 1);
+
+            let s = &servers[0];
+            let result_pub = CStr::from_ptr(s.public_ip).to_str().unwrap();
+            assert_eq!(result_pub, "1.2.3.4");
+
+            anna_string_free(s.public_ip);
+            anna_string_free(s.private_ip);
+            anna_hashring_free(ring);
+        }
+    }
+
+    #[test]
+    fn responsible_servers_multi_node() {
+        unsafe {
+            let ring = anna_hashring_new(true, 0);
+
+            let ip1_pub = c_str("1.2.3.4");
+            let ip1_priv = c_str("10.0.0.1");
+            anna_hashring_insert(ring, ip1_pub.as_ptr(), ip1_priv.as_ptr(), 0, 3000);
+
+            let ip2_pub = c_str("5.6.7.8");
+            let ip2_priv = c_str("10.0.0.2");
+            anna_hashring_insert(ring, ip2_pub.as_ptr(), ip2_priv.as_ptr(), 0, 3000);
+
+            let key = c_str("test_key");
+            let mut servers = vec![
+                ServerInfo {
+                    public_ip: std::ptr::null_mut(),
+                    private_ip: std::ptr::null_mut(),
+                    tid: 0,
+                };
+                4
+            ];
+
+            let count = anna_responsible_servers(ring, key.as_ptr(), 2, servers.as_mut_ptr(), 4);
+            assert_eq!(count, 2);
+
+            // Free strings.
+            for i in 0..count as usize {
+                anna_string_free(servers[i].public_ip);
+                anna_string_free(servers[i].private_ip);
+            }
+            anna_hashring_free(ring);
+        }
+    }
+
+    #[test]
+    fn get_unique_servers() {
+        unsafe {
+            let ring = anna_hashring_new(true, 0);
+
+            let ip1_pub = c_str("1.2.3.4");
+            let ip1_priv = c_str("10.0.0.1");
+            anna_hashring_insert(ring, ip1_pub.as_ptr(), ip1_priv.as_ptr(), 0, 100);
+
+            let ip2_pub = c_str("5.6.7.8");
+            let ip2_priv = c_str("10.0.0.2");
+            anna_hashring_insert(ring, ip2_pub.as_ptr(), ip2_priv.as_ptr(), 0, 100);
+
+            let mut servers = vec![
+                ServerInfo {
+                    public_ip: std::ptr::null_mut(),
+                    private_ip: std::ptr::null_mut(),
+                    tid: 0,
+                };
+                4
+            ];
+
+            let count = anna_hashring_get_unique_servers(ring, servers.as_mut_ptr(), 4);
+            assert_eq!(count, 2);
+
+            for i in 0..count as usize {
+                anna_string_free(servers[i].public_ip);
+                anna_string_free(servers[i].private_ip);
+            }
+            anna_hashring_free(ring);
+        }
+    }
+
+    #[test]
+    fn responsible_local_threads() {
+        unsafe {
+            // Local ring: 2 threads, each with 3000 virtual nodes.
+            let ring = anna_hashring_new(false, 0);
+
+            let ip = c_str("1.2.3.4");
+            let priv_ip = c_str("10.0.0.1");
+            anna_hashring_insert(ring, ip.as_ptr(), priv_ip.as_ptr(), 0, 3000);
+            anna_hashring_insert(ring, ip.as_ptr(), priv_ip.as_ptr(), 1, 3000);
+
+            let key = c_str("test_key");
+            let mut tids = [0u32; 4];
+
+            let count = anna_responsible_local(ring, key.as_ptr(), 1, tids.as_mut_ptr(), 4);
+            assert_eq!(count, 1);
+            assert!(tids[0] == 0 || tids[0] == 1);
+
+            anna_hashring_free(ring);
+        }
+    }
+}

--- a/server/rust/server-common/src/hash_ring.rs
+++ b/server/rust/server-common/src/hash_ring.rs
@@ -78,6 +78,67 @@ impl ConsistentHashRing {
         self.ring.len() == expected
     }
 
+    /// Find `rep_count` unique responsible servers for a key.
+    ///
+    /// Walks the ring clockwise from hash(key), collecting servers with
+    /// unique IDs. Mirrors `responsible_global` in C++.
+    pub fn find_responsible(&self, key: &str, rep_count: u32, global: bool) -> Vec<&ServerThread> {
+        if self.ring.is_empty() || rep_count == 0 {
+            return vec![];
+        }
+
+        let hash = if global {
+            global_hash_key(key)
+        } else {
+            local_hash_key(key)
+        };
+
+        let mut result = Vec::new();
+        let mut seen_ids = std::collections::HashSet::new();
+
+        // Start from hash position, walk clockwise.
+        let mut iter = self.ring.range(hash..).chain(self.ring.iter());
+        while result.len() < rep_count as usize {
+            match iter.next() {
+                Some((_, st)) => {
+                    if seen_ids.insert(st.id()) {
+                        result.push(st);
+                    }
+                }
+                None => break,
+            }
+        }
+
+        result
+    }
+
+    /// Find `rep_count` unique responsible thread IDs for a key (local ring).
+    ///
+    /// Mirrors `responsible_local` in C++.
+    pub fn find_responsible_local(&self, key: &str, rep_count: u32) -> Vec<u32> {
+        if self.ring.is_empty() || rep_count == 0 {
+            return vec![];
+        }
+
+        let hash = local_hash_key(key);
+        let mut result = Vec::new();
+        let mut seen_tids = std::collections::HashSet::new();
+
+        let mut iter = self.ring.range(hash..).chain(self.ring.iter());
+        while result.len() < rep_count as usize {
+            match iter.next() {
+                Some((_, st)) => {
+                    if seen_tids.insert(st.tid()) {
+                        result.push(st.tid());
+                    }
+                }
+                None => break,
+            }
+        }
+
+        result
+    }
+
     /// Get all unique server threads (deduplicated by id).
     pub fn get_unique_servers(&self) -> Vec<&ServerThread> {
         let mut seen = std::collections::HashSet::new();


### PR DESCRIPTION
## Phase 1 of #445: Shared hash ring C library

New `anna-hashring` crate providing a consistent hash ring with C FFI — the single canonical hash implementation for all Anna components.

### Why

Currently the C++ server uses `std::hash<string>` (compiler-specific) and the Rust server uses `DefaultHasher` (different values). This makes client-side routing impossible because clients can't compute the same key-to-server mapping as the servers.

This library solves that: one hash function, one ring implementation, called from every language via C FFI. All components produce identical results.

### C API

| Function | Purpose |
|---|---|
| `anna_hashring_new(global, base_offset)` | Create a ring (global or local hasher) |
| `anna_hashring_free(ring)` | Destroy a ring |
| `anna_hashring_insert(ring, pub_ip, priv_ip, tid, vnodes)` | Add server with virtual nodes |
| `anna_hashring_remove(ring, pub_ip, priv_ip, tid)` | Remove server |
| `anna_hashring_size(ring)` | Entry count |
| `anna_responsible_servers(ring, key, rep, out, max)` | Find N responsible servers |
| `anna_responsible_local(ring, key, rep, out_tids, max)` | Find responsible thread IDs |
| `anna_hashring_get_unique_servers(ring, out, max)` | Enumerate all unique servers |
| `anna_string_free(s)` | Free allocated strings |

### Build outputs

- `libanna_hashring.a` — static library (for C++ server CMake)
- `libanna_hashring.dylib`/`.so` — shared library (for Python ctypes, Go cgo)
- `anna_hashring.h` — auto-generated C header (via cbindgen)
- Rust `rlib` — for direct use from Rust code

### Tests

7 FFI unit tests covering lifecycle, insert/remove, responsible server lookup (single + multi node), unique servers, local thread lookup.

Also adds `find_responsible()` and `find_responsible_local()` to `ConsistentHashRing` in server-common.

Closes #535, part of #445