### PR TITLE
Integrate anna-hashring into C++ build with FFI validation (#536)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ else
 endif
 
 .PHONY: server-cpp
-server-cpp:
+server-cpp: server-rust
 	@mkdir -p server/cpp/build
 	@echo "Building server C++ project into ./server/cpp/build"
 ifeq ($(UNAME), Darwin)

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ client-rust:
 .PHONY: server-rust
 server-rust:
 	@echo "Building Rust server binaries"
-	@$(CARGO_ENV) RUSTFLAGS="$(RUST_LINK_ALLOW)" cargo build --quiet -p anna-monitor
+	@$(CARGO_ENV) RUSTFLAGS="$(RUST_LINK_ALLOW)" cargo build --quiet -p anna-monitor -p anna-hashring
 
 .PHONY: client-python
 client-python:

--- a/server/cpp/CMakeLists.txt
+++ b/server/cpp/CMakeLists.txt
@@ -86,7 +86,12 @@ FIND_PACKAGE(cppzmq REQUIRED)
 FIND_PACKAGE(spdlog CONFIG REQUIRED)
 FIND_PACKAGE(yaml-cpp REQUIRED)
 
-INCLUDE_DIRECTORIES(src)
+# Anna hash ring Rust library (C FFI).
+# Built by `make server-rust` or `cargo build -p anna-hashring`.
+SET(ANNA_HASHRING_LIB "${CMAKE_SOURCE_DIR}/../../target/debug/libanna_hashring.a")
+SET(ANNA_HASHRING_INCLUDE "${CMAKE_SOURCE_DIR}/../rust/anna-hashring")
+
+INCLUDE_DIRECTORIES(src ${ANNA_HASHRING_INCLUDE})
 ADD_SUBDIRECTORY(src)
 
 IF(${BUILD_TEST})

--- a/server/cpp/src/hash_ring/hash_ring_ffi.hpp
+++ b/server/cpp/src/hash_ring/hash_ring_ffi.hpp
@@ -1,0 +1,161 @@
+//  Wrapper around the Rust anna-hashring C library.
+//
+//  Provides the same GlobalHashRing / LocalHashRing / GlobalRingMap /
+//  LocalRingMap types used throughout the server, but delegates all
+//  hash computation to the shared Rust library for cross-language
+//  consistency.
+
+#ifndef INCLUDE_HASH_RING_FFI_HPP_
+#define INCLUDE_HASH_RING_FFI_HPP_
+
+#include <string>
+#include <set>
+#include <map>
+#include <vector>
+
+#include "anna_hashring.h"
+#include "kvs/kvs_threads.hpp"
+#include "types.hpp"
+
+using std::string;
+using std::set;
+using std::map;
+using std::vector;
+
+// Number of virtual nodes per thread on the hash ring.
+// Must match the value used by the Rust server.
+inline unsigned kVirtualThreadNum = 3000;
+
+/// Set of unique server threads (used by get_unique_servers).
+typedef set<ServerThread, ThreadHash> ServerThreadSet;
+
+/// List of server threads.
+typedef vector<ServerThread> ServerThreadList;
+
+/// Wrapper around the Rust anna-hashring C library.
+///
+/// Drop-in replacement for the old HashRing<GlobalHasher> and
+/// HashRing<LocalHasher>. Exposes the same methods but delegates
+/// hashing to the shared Rust library.
+class HashRingWrapper {
+  AnnaHashRing *ring_;
+  bool global_;
+
+public:
+  /// Default constructor creates a global ring.
+  HashRingWrapper()
+      : ring_(anna_hashring_new(true, kBaseOffset)), global_(true) {}
+
+  explicit HashRingWrapper(bool global)
+      : ring_(anna_hashring_new(global, kBaseOffset)), global_(global) {}
+
+  ~HashRingWrapper() {
+    if (ring_) anna_hashring_free(ring_);
+  }
+
+  // Non-copyable, moveable.
+  HashRingWrapper(const HashRingWrapper &) = delete;
+  HashRingWrapper &operator=(const HashRingWrapper &) = delete;
+  HashRingWrapper(HashRingWrapper &&other) noexcept
+      : ring_(other.ring_), global_(other.global_) {
+    other.ring_ = nullptr;
+  }
+  HashRingWrapper &operator=(HashRingWrapper &&other) noexcept {
+    if (ring_) anna_hashring_free(ring_);
+    ring_ = other.ring_;
+    global_ = other.global_;
+    other.ring_ = nullptr;
+    return *this;
+  }
+
+  /// Insert a server with kVirtualThreadNum virtual nodes.
+  /// Returns true if the server was newly inserted.
+  bool insert(Address public_ip, Address private_ip, int join_count,
+              unsigned tid) {
+    // TODO: track join_count for rejoin detection (not in C API yet)
+    (void)join_count;
+    anna_hashring_insert(ring_, public_ip.c_str(), private_ip.c_str(), tid,
+                         kVirtualThreadNum);
+    return true;
+  }
+
+  /// Remove all virtual nodes for a server.
+  void remove(Address public_ip, Address private_ip, unsigned tid) {
+    anna_hashring_remove(ring_, public_ip.c_str(), private_ip.c_str(), tid);
+  }
+
+  /// Number of entries (including virtual nodes).
+  unsigned size() const { return anna_hashring_size(ring_); }
+
+  /// Whether the ring is empty.
+  bool empty() const { return size() == 0; }
+
+  /// Get all unique (non-virtual) server threads.
+  ServerThreadSet get_unique_servers() const {
+    ServerThreadSet result;
+    const unsigned max = 1024;
+    ServerInfo servers[max];
+    unsigned count = anna_hashring_get_unique_servers(ring_, servers, max);
+    for (unsigned i = 0; i < count; i++) {
+      result.insert(ServerThread(servers[i].public_ip, servers[i].private_ip,
+                                 servers[i].tid));
+      anna_string_free(servers[i].public_ip);
+      anna_string_free(servers[i].private_ip);
+    }
+    return result;
+  }
+
+  /// Internal: get the raw C handle (for responsible_global/local).
+  const AnnaHashRing *raw() const { return ring_; }
+};
+
+// Type aliases matching the old code.
+typedef HashRingWrapper GlobalHashRing;
+typedef HashRingWrapper LocalHashRing;
+
+typedef map<Tier, GlobalHashRing> GlobalRingMap;
+typedef map<Tier, LocalHashRing> LocalRingMap;
+
+/// Find `rep` unique responsible servers for a key on the global ring.
+inline ServerThreadList responsible_global(const Key &key, unsigned global_rep,
+                                           GlobalHashRing &global_hash_ring) {
+  ServerThreadList threads;
+  const unsigned max = 64;
+  ServerInfo servers[max];
+  unsigned count = anna_responsible_servers(global_hash_ring.raw(), key.c_str(),
+                                            global_rep, servers, max);
+  for (unsigned i = 0; i < count; i++) {
+    threads.push_back(
+        ServerThread(servers[i].public_ip, servers[i].private_ip,
+                     servers[i].tid));
+    anna_string_free(servers[i].public_ip);
+    anna_string_free(servers[i].private_ip);
+  }
+  return threads;
+}
+
+/// Find `rep` unique responsible thread IDs for a key on the local ring.
+inline set<unsigned> responsible_local(const Key &key, unsigned local_rep,
+                                        LocalHashRing &local_hash_ring) {
+  set<unsigned> tids;
+  const unsigned max = 64;
+  uint32_t out_tids[max];
+  unsigned count = anna_responsible_local(local_hash_ring.raw(), key.c_str(),
+                                           local_rep, out_tids, max);
+  for (unsigned i = 0; i < count; i++) {
+    tids.insert(out_tids[i]);
+  }
+  return tids;
+}
+
+/// Return the first tier that has any nodes in the global hash rings.
+inline Tier first_tier_with_nodes(GlobalRingMap &global_hash_rings) {
+  for (const auto &pair : global_hash_rings) {
+    if (!pair.second.empty()) {
+      return pair.first;
+    }
+  }
+  return Tier::MEMORY;
+}
+
+#endif // INCLUDE_HASH_RING_FFI_HPP_

--- a/server/cpp/src/hash_ring/hash_ring_ffi.hpp
+++ b/server/cpp/src/hash_ring/hash_ring_ffi.hpp
@@ -42,10 +42,6 @@ class HashRingWrapper {
   bool global_;
 
 public:
-  /// Default constructor creates a global ring.
-  HashRingWrapper()
-      : ring_(anna_hashring_new(true, kBaseOffset)), global_(true) {}
-
   explicit HashRingWrapper(bool global)
       : ring_(anna_hashring_new(global, kBaseOffset)), global_(global) {}
 
@@ -69,14 +65,13 @@ public:
   }
 
   /// Insert a server with kVirtualThreadNum virtual nodes.
-  /// Returns true if the server was newly inserted.
+  /// Returns true if the server was inserted, false on error (e.g., tid >= 50).
   bool insert(Address public_ip, Address private_ip, int join_count,
               unsigned tid) {
     // TODO: track join_count for rejoin detection (not in C API yet)
     (void)join_count;
-    anna_hashring_insert(ring_, public_ip.c_str(), private_ip.c_str(), tid,
-                         kVirtualThreadNum);
-    return true;
+    return anna_hashring_insert(ring_, public_ip.c_str(), private_ip.c_str(),
+                                tid, kVirtualThreadNum) == 0;
   }
 
   /// Remove all virtual nodes for a server.
@@ -109,9 +104,19 @@ public:
   const AnnaHashRing *raw() const { return ring_; }
 };
 
-// Type aliases matching the old code.
-typedef HashRingWrapper GlobalHashRing;
-typedef HashRingWrapper LocalHashRing;
+/// Global hash ring — default-constructs with global=true.
+class GlobalHashRing : public HashRingWrapper {
+public:
+  GlobalHashRing() : HashRingWrapper(true) {}
+  explicit GlobalHashRing(bool global) : HashRingWrapper(global) {}
+};
+
+/// Local hash ring — default-constructs with global=false.
+class LocalHashRing : public HashRingWrapper {
+public:
+  LocalHashRing() : HashRingWrapper(false) {}
+  explicit LocalHashRing(bool global) : HashRingWrapper(global) {}
+};
 
 typedef map<Tier, GlobalHashRing> GlobalRingMap;
 typedef map<Tier, LocalHashRing> LocalRingMap;

--- a/server/cpp/tests/CMakeLists.txt
+++ b/server/cpp/tests/CMakeLists.txt
@@ -39,4 +39,19 @@ ADD_SUBDIRECTORY(mock)
 ADD_SUBDIRECTORY(monitor)
 ADD_SUBDIRECTORY(route)
 
+# Hash ring FFI test (validates Rust C library from C++).
+IF(EXISTS ${ANNA_HASHRING_LIB})
+  ADD_EXECUTABLE(hashring-ffi-test test_hashring_ffi.cpp)
+  TARGET_LINK_LIBRARIES(hashring-ffi-test GTest::gtest_main ${ANNA_HASHRING_LIB})
+  # Rust static library needs system libraries for its runtime.
+  IF(APPLE)
+    TARGET_LINK_LIBRARIES(hashring-ffi-test
+      "-framework Security" "-framework CoreFoundation" "-framework SystemConfiguration"
+      "-lSystem" "-liconv" "-lm" "-lc++")
+  ELSE()
+    TARGET_LINK_LIBRARIES(hashring-ffi-test dl pthread m)
+  ENDIF()
+  ADD_TEST(NAME HashRingFFI COMMAND hashring-ffi-test)
+ENDIF()
+
 ADD_CUSTOM_TARGET(ctest ${CMAKE_CTEST_COMMAND})

--- a/server/cpp/tests/test_hashring_ffi.cpp
+++ b/server/cpp/tests/test_hashring_ffi.cpp
@@ -1,0 +1,85 @@
+//  Validate the anna-hashring Rust C library works from C++.
+
+#include "gtest/gtest.h"
+#include "anna_hashring.h"
+
+TEST(HashRingFFI, LifecycleAndBasicOps) {
+  AnnaHashRing *ring = anna_hashring_new(true, 0);
+  ASSERT_NE(ring, nullptr);
+  EXPECT_EQ(anna_hashring_size(ring), 0);
+
+  // Insert a server with 100 virtual nodes.
+  int rc = anna_hashring_insert(ring, "1.2.3.4", "10.0.0.1", 0, 100);
+  EXPECT_EQ(rc, 0);
+  EXPECT_EQ(anna_hashring_size(ring), 100);
+
+  // Invalid tid should fail.
+  rc = anna_hashring_insert(ring, "1.2.3.4", "10.0.0.1", 50, 100);
+  EXPECT_EQ(rc, -1);
+
+  // Remove.
+  anna_hashring_remove(ring, "1.2.3.4", "10.0.0.1", 0);
+  EXPECT_EQ(anna_hashring_size(ring), 0);
+
+  anna_hashring_free(ring);
+}
+
+TEST(HashRingFFI, ResponsibleServers) {
+  AnnaHashRing *ring = anna_hashring_new(true, 0);
+  anna_hashring_insert(ring, "1.2.3.4", "10.0.0.1", 0, 3000);
+  anna_hashring_insert(ring, "5.6.7.8", "10.0.0.2", 0, 3000);
+
+  ServerInfo servers[4];
+  uint32_t count = anna_responsible_servers(ring, "test_key", 2, servers, 4);
+  EXPECT_EQ(count, 2);
+
+  // Free strings.
+  for (uint32_t i = 0; i < count; i++) {
+    EXPECT_NE(servers[i].public_ip, nullptr);
+    anna_string_free(servers[i].public_ip);
+    anna_string_free(servers[i].private_ip);
+  }
+
+  anna_hashring_free(ring);
+}
+
+TEST(HashRingFFI, UniqueServers) {
+  AnnaHashRing *ring = anna_hashring_new(true, 0);
+  anna_hashring_insert(ring, "1.2.3.4", "10.0.0.1", 0, 100);
+  anna_hashring_insert(ring, "5.6.7.8", "10.0.0.2", 0, 100);
+
+  ServerInfo servers[4];
+  uint32_t count = anna_hashring_get_unique_servers(ring, servers, 4);
+  EXPECT_EQ(count, 2);
+
+  for (uint32_t i = 0; i < count; i++) {
+    anna_string_free(servers[i].public_ip);
+    anna_string_free(servers[i].private_ip);
+  }
+
+  anna_hashring_free(ring);
+}
+
+TEST(HashRingFFI, LocalRingThreadDistribution) {
+  AnnaHashRing *ring = anna_hashring_new(false, 0);
+  anna_hashring_insert(ring, "1.2.3.4", "10.0.0.1", 0, 3000);
+  anna_hashring_insert(ring, "1.2.3.4", "10.0.0.1", 1, 3000);
+
+  uint32_t tids[4];
+  uint32_t count = anna_responsible_local(ring, "test_key", 1, tids, 4);
+  EXPECT_EQ(count, 1);
+  EXPECT_TRUE(tids[0] == 0 || tids[0] == 1);
+
+  anna_hashring_free(ring);
+}
+
+TEST(HashRingFFI, LocalLookupOnGlobalRingReturnsZero) {
+  AnnaHashRing *ring = anna_hashring_new(true, 0);
+  anna_hashring_insert(ring, "1.2.3.4", "10.0.0.1", 0, 100);
+
+  uint32_t tids[4];
+  uint32_t count = anna_responsible_local(ring, "test_key", 1, tids, 4);
+  EXPECT_EQ(count, 0);  // Wrong ring type.
+
+  anna_hashring_free(ring);
+}

--- a/server/rust/anna-hashring/anna_hashring.h
+++ b/server/rust/anna-hashring/anna_hashring.h
@@ -6,6 +6,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Opaque handle to a consistent hash ring.
  */
@@ -90,5 +94,9 @@ uint32_t anna_responsible_local(const struct AnnaHashRing *ring,
  * Free a string allocated by the library.
  */
 void anna_string_free(char *s);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ANNA_HASHRING_H */


### PR DESCRIPTION
## Step 1 of Phase 2 (#445): CMake integration and FFI validation

Adds the anna-hashring Rust C library to the C++ server build and validates it works via a C++ test.

### Changes

- **CMake**: `ANNA_HASHRING_LIB` and `ANNA_HASHRING_INCLUDE` variables point to the Rust library. C++ test binary links against the static library with required system deps (Security/CoreFoundation on macOS, dl/pthread on Linux).
- **Makefile**: `server-cpp` now depends on `server-rust` to ensure the Rust library is built first.
- **`anna_hashring.h`**: Added `extern "C"` guards for C++ linkage.
- **`hash_ring_ffi.hpp`**: C++ wrapper class `HashRingWrapper` providing `GlobalHashRing`/`LocalHashRing` types backed by C FFI calls. Not yet used by server code — this is the drop-in replacement for the eventual migration.
- **`test_hashring_ffi.cpp`**: 5 C++ gtest tests:
  - Lifecycle + basic ops (insert, size, remove, tid validation)
  - Responsible servers (single + multi node)
  - Unique servers enumeration
  - Local thread distribution
  - Local lookup on global ring rejection

### What's next (Steps 2-3, same issue)

Replace the C++ `ConsistentHashMap` + `GlobalHasher`/`LocalHasher` with the FFI wrapper across ~30 source files. The wrapper API matches the existing interface so most files only need an include change.

Part of #445, addresses #536