### PR TITLE
Add KVS member list metadata + client-side discovery (#537)

### DIFF
--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -644,6 +644,18 @@ impl KVSClient {
             .unwrap_or_default()
     }
 
+    /// Retrieve KVS member IPs from the metadata key.
+    ///
+    /// Returns a list of `"public_ip/private_ip"` strings for all KVS nodes
+    /// in the cluster. Returns an empty vec if the metadata key hasn't been
+    /// written yet (the KVS publishes it periodically during stats reporting).
+    pub async fn get_kvs_members(&mut self) -> Vec<String> {
+        match self.get_bytes("ANNA_METADATA|kvs_members").await {
+            Ok(bytes) => Self::decode_monitoring_ips(&bytes), // Same StringSet format
+            Err(_) => vec![],
+        }
+    }
+
     /// Store a key-value pair (Last-Writer-Wins lattice).
     ///
     /// ```rust

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -613,3 +613,39 @@ async fn scan_keys() {
         .expect("SCAN empty failed");
     assert!(none.is_empty(), "expected 0 keys for non-existent prefix");
 }
+
+/// Client-side routing: verify get_kvs_members returns node IPs.
+#[tokio::test]
+#[cfg(unix)]
+async fn kvs_members_metadata() {
+    let config_path = generate_config(1222);
+    let _guard = ServerGuard::start(&config_path, 1222);
+    let config = client_config(1222);
+    let mut client = KVSClient::new(&config, Some(16)).await;
+
+    // PUT a key so the server has been active.
+    client.put("member_test", "val").await.expect("PUT failed");
+
+    // Wait for the KVS to publish its member list (happens during
+    // stats reporting, period=15s in test config). Poll with retries.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let mut members = vec![];
+    while std::time::Instant::now() < deadline {
+        members = client.get_kvs_members().await;
+        if !members.is_empty() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    assert!(
+        !members.is_empty(),
+        "KVS should publish member list within 20s"
+    );
+    // Single-node cluster: expect exactly one member.
+    assert_eq!(members.len(), 1, "expected 1 KVS member");
+    assert!(
+        members[0].contains("127.0.0.1"),
+        "member should contain localhost IP"
+    );
+}

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -1262,10 +1262,7 @@ async fn self_depart_signal() {
             if cluster
                 .processes
                 .iter_mut()
-                .any(|p| {
-                    p.label == kvs_label
-                        && p.child.try_wait().ok().flatten().is_some()
-                })
+                .any(|p| p.label == kvs_label && p.child.try_wait().ok().flatten().is_some())
             {
                 kvs_exited = true;
                 break;

--- a/server/cpp/src/kvs/server.cpp
+++ b/server/cpp/src/kvs/server.cpp
@@ -789,6 +789,33 @@ void run(unsigned thread_id, string disk_root, Address public_ip, Address privat
         }
       }
 
+      // Publish KVS member list so clients can build local hash rings
+      // for client-side routing (eliminating the routing tier dependency).
+      {
+        shared::StringSet members_set;
+        for (const auto &pair : global_hash_rings) {
+          for (const ServerThread &st :
+               pair.second.get_unique_servers()) {
+            members_set.add_keys(st.public_ip() + "/" + st.private_ip());
+          }
+        }
+        if (members_set.keys_size() > 0) {
+          string serialized_members;
+          members_set.SerializeToString(&serialized_members);
+
+          req.Clear();
+          req.set_type(kvs::RequestType::PUT);
+          prepare_put_tuple(
+              req, kMetadataIdentifier + kMetadataDelimiter + "kvs_members",
+              kvs::LatticeType::LWW, serialize(ts, serialized_members));
+
+          string serialized;
+          req.SerializeToString(&serialized);
+          kZmqUtil->send_string(serialized,
+                                &pushers[wt.key_request_connect_address()]);
+        }
+      }
+
       report_start = std::chrono::system_clock::now();
 
       // Get the most recent list of cache IPs from the external management


### PR DESCRIPTION
## Phase 3 Step 1 of #445: KVS member discovery

Foundation for client-side routing. The KVS now publishes its cluster membership as a metadata key, enabling clients to discover all nodes without the routing tier.

### Server change

KVS publishes `ANNA_METADATA|kvs_members` as a `StringSet` of `"public_ip/private_ip"` pairs during each stats reporting cycle. Uses the same pattern as `cluster_topology` and `monitoring_ips`.

### Client change

New `get_kvs_members()` method on `KVSClient` reads the member list. Combined with `get_cluster_topology()` (for thread counts) and the `anna-hashring` library (for hash computation), a client can now compute key-to-server mappings locally.

### Integration test

`kvs_members_metadata`: verifies the member list is published and contains the expected node within 20s.

### What's next (same issue #537)

Wire up the client to actually use the hash ring for routing:
1. On first request, query a KVS node for members + topology
2. Build local hash ring via `anna-hashring`
3. Compute responsible server for each key
4. Route directly, with WRONG_THREAD retry as safety net

Part of #445, addresses #537