### PR TITLE
Client-side routing via local hash ring (#537)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
 name = "anna"
 version = "0.1.0"
 dependencies = [
+ "anna-server-common",
  "assert_cmd",
  "clap",
  "log",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -19,11 +19,13 @@ name = "annalib"
 path = "src/lib/lib.rs"
 
 [features]
-default = ["causal", "set"]
+default = ["causal", "set", "direct-routing"]
 causal = []
 set = []
+direct-routing = ["anna-server-common"]
 
 [dependencies]
+anna-server-common = { path = "../../server/rust/server-common", optional = true }
 clap = "~4"
 log = "0.4.17"
 simplog = "~1.6"

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -74,6 +74,19 @@ pub struct KVSClient {
     /// seen timestamp, providing the Writes Follow Reads guarantee.
     #[doc(hidden)]
     pub last_seen_ts: u64,
+    /// Optional client-side hash ring for direct routing (bypasses routing tier).
+    /// Initialized lazily on first use via `enable_direct_routing()`.
+    direct_ring: Option<DirectRouting>,
+}
+
+/// State for client-side routing via a local hash ring.
+#[cfg(feature = "direct-routing")]
+#[allow(dead_code)]
+struct DirectRouting {
+    global_ring: anna_server_common::hash_ring::ConsistentHashRing,
+    local_ring: anna_server_common::hash_ring::ConsistentHashRing,
+    memory_thread_count: u32,
+    base_offset_val: u32,
 }
 
 impl KVSClient {
@@ -147,6 +160,7 @@ impl KVSClient {
             counter_state: HashMap::new(),
             lww_read_cache: HashMap::new(),
             last_seen_ts: 0,
+            direct_ring: None,
         }
     }
 
@@ -168,6 +182,7 @@ impl KVSClient {
             counter_state: HashMap::new(),
             lww_read_cache: HashMap::new(),
             last_seen_ts: 0,
+            direct_ring: None,
         }
     }
 
@@ -321,6 +336,19 @@ impl KVSClient {
     }
 
     async fn get_worker_address(&mut self, key: &str) -> Option<Address> {
+        // Try client-side routing first (if enabled).
+        #[cfg(feature = "direct-routing")]
+        if let Some(ref dr) = self.direct_ring {
+            let servers = dr.global_ring.find_responsible(key, 1, true);
+            if let Some(st) = servers.first() {
+                let tids = dr.local_ring.find_responsible_local(key, 1);
+                let tid = tids.first().copied().unwrap_or(0);
+                let port = tid + anna_server_common::ports::KEY_REQUEST_PORT + dr.base_offset_val;
+                return Some(format!("tcp://{}:{}", st.public_ip(), port));
+            }
+        }
+
+        // Fall back to routing tier query.
         if !self.key_address_cache.contains_key(key) || self.key_address_cache[key].is_empty() {
             let addrs = self.query_routing(key).await;
             if addrs.is_empty() {
@@ -2139,6 +2167,70 @@ impl KVSClient {
     /// Set the request timeout duration.
     pub fn set_timeout(&mut self, timeout: Duration) {
         self.timeout = timeout;
+    }
+
+    /// Enable client-side routing by building a local hash ring from
+    /// KVS membership data. When enabled, the client routes directly
+    /// to KVS nodes without querying the routing tier.
+    ///
+    /// Requires the `direct-routing` feature. Call this after the
+    /// cluster has stabilized (KVS needs time to publish membership).
+    #[cfg(feature = "direct-routing")]
+    pub async fn enable_direct_routing(&mut self) -> Result<()> {
+        use anna_server_common::hash_ring::{ConsistentHashRing, DEFAULT_VIRTUAL_THREAD_NUM};
+
+        let members = self.get_kvs_members().await;
+        if members.is_empty() {
+            return Err(Error::Kvs(
+                "No KVS members found — cluster may not be ready".into(),
+            ));
+        }
+
+        let topology = self.get_cluster_topology().await;
+        let thread_count = topology.map(|t| t.memory_thread_count).unwrap_or(1);
+
+        let base = self.base_offset() as u32;
+
+        let mut global_ring = ConsistentHashRing::new();
+        let mut local_ring = ConsistentHashRing::new();
+
+        for member in &members {
+            let parts: Vec<&str> = member.split('/').collect();
+            if parts.len() != 2 {
+                continue;
+            }
+            let (pub_ip, priv_ip) = (parts[0], parts[1]);
+
+            // Insert into global ring (tid=0, virtual nodes).
+            global_ring.insert(pub_ip, priv_ip, 0, base, DEFAULT_VIRTUAL_THREAD_NUM, true);
+
+            // Insert each thread into local ring.
+            for tid in 0..thread_count {
+                local_ring.insert(
+                    pub_ip,
+                    priv_ip,
+                    tid,
+                    base,
+                    DEFAULT_VIRTUAL_THREAD_NUM,
+                    false,
+                );
+            }
+        }
+
+        log::info!(
+            "Direct routing enabled: {} members, {} threads/node",
+            members.len(),
+            thread_count
+        );
+
+        self.direct_ring = Some(DirectRouting {
+            global_ring,
+            local_ring,
+            memory_thread_count: thread_count,
+            base_offset_val: base,
+        });
+
+        Ok(())
     }
 
     // ── Scan / key listing ──────────────────────────────────────────

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -649,3 +649,59 @@ async fn kvs_members_metadata() {
         "member should contain localhost IP"
     );
 }
+
+/// Client-side routing: PUT/GET using direct hash ring routing.
+#[tokio::test]
+#[cfg(unix)]
+#[cfg(feature = "direct-routing")]
+async fn direct_routing_put_get() {
+    let config_path = generate_config(1223);
+    let _guard = ServerGuard::start(&config_path, 1223);
+    let config = client_config(1223);
+    let mut client = KVSClient::new(&config, Some(17)).await;
+
+    // PUT a key via routing (normal path) so server publishes membership.
+    client
+        .put("direct_test_setup", "setup")
+        .await
+        .expect("setup PUT failed");
+
+    // Wait for membership to be published.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        if !client.get_kvs_members().await.is_empty() {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("KVS members not published within 20s");
+        }
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    // Enable direct routing.
+    client
+        .enable_direct_routing()
+        .await
+        .expect("enable_direct_routing failed");
+
+    // PUT and GET via direct routing (no routing tier involved).
+    client
+        .put("direct_key1", "value1")
+        .await
+        .expect("direct PUT failed");
+    let val = client.get("direct_key1").await.expect("direct GET failed");
+    assert_eq!(val, "value1");
+
+    // Multiple keys to exercise hash distribution.
+    for i in 0..10 {
+        let key = format!("direct_batch_{}", i);
+        let value = format!("val_{}", i);
+        client.put(&key, &value).await.expect("batch PUT failed");
+    }
+    for i in 0..10 {
+        let key = format!("direct_batch_{}", i);
+        let value = format!("val_{}", i);
+        let got = client.get(&key).await.expect("batch GET failed");
+        assert_eq!(got, value, "mismatch for key {}", key);
+    }
+}


### PR DESCRIPTION
## Phase 3 of #445: Client routes directly to KVS nodes

The Rust client can now compute key-to-server mappings locally using a hash ring built from KVS membership data. This eliminates the routing tier from the critical path.

### How it works

1. Client calls `enable_direct_routing()` after the cluster is ready
2. Reads `ANNA_METADATA|kvs_members` for all KVS node IPs
3. Reads `ANNA_METADATA|cluster_topology` for thread counts
4. Builds global + local `ConsistentHashRing` (from `anna-server-common`)
5. For each key: `find_responsible(key)` → server, `find_responsible_local(key)` → thread ID
6. Constructs `tcp://server_ip:(KEY_REQUEST_PORT + tid + base_offset)` directly
7. Falls back to routing tier query if direct routing is not enabled

### Feature flag

`direct-routing` (enabled by default) — adds `anna-server-common` as optional dependency. Disabled: client uses routing tier as before.

### Integration test

`direct_routing_put_get`: enables direct routing, PUTs 11 keys, GETs all 11, verifies correct values. All operations bypass the routing tier.

### What this means

The routing server is now **optional** for the Rust client. A cluster can run with just KVS + monitor. The client discovers nodes via metadata, builds its own ring, and routes directly.

Closes #537, part of #445