### PR TITLE
Update docs: client-side routing, anna-route deprecated

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -21,5 +21,7 @@
 Anna has four client implementations (C++, Rust, Python, Go), each with a
 library and CLI. All clients support the same operations (GET, PUT, GET_SET,
 PUT_SET, GET_CAUSAL, PUT_CAUSAL) and are tested against the same shared
-golden files.
+golden files. Clients discover KVS nodes via `ANNA_METADATA|kvs_members`
+and compute key-to-server mappings locally using the shared `anna-hashring`
+library (the legacy `anna-route` routing server is optional and deprecated).
 

--- a/docs/api-comparison.md
+++ b/docs/api-comparison.md
@@ -46,7 +46,7 @@ All items from the original comparison have been implemented or classified as ar
 ## Hardest to emulate (architecture mismatch)
 
 - **Conditional writes / CAS**: Anna's eventual consistency model conflicts with strong CAS. The causal lattice types provide partial ordering but not compare-and-swap semantics.
-- **Range queries**: Anna uses hash-based key distribution (consistent hashing). Range queries require sequential key layout, which would need a fundamentally different routing strategy.
+- **Range queries**: Anna uses hash-based key distribution (consistent hashing). Range queries require sequential key layout, which would need a fundamentally different key distribution strategy.
 - **Secondary indexes**: Would require a server-side index maintenance layer that doesn't exist.
 
 ## Which store's API is closest to Anna?

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,15 +19,33 @@ Anna's design rests on four requirements:
 
 ## System Components
 
-An Anna deployment consists of four types of nodes:
+An Anna deployment consists of three required component types (storage,
+monitoring, and cluster management) plus an optional legacy routing tier:
 
 ![Anna Architecture](images/architecture.svg)
 
-### Routing Tier (anna-route)
+### Client-Side Routing
 
-The routing service isolates clients from the storage layer. A client asks
-the routing tier where to find a key and receives valid server addresses.
-Routing nodes:
+Clients now build a local hash ring from KVS membership data and compute
+key-to-server mappings locally, without requiring a separate routing server.
+The flow is:
+
+1. The client reads `ANNA_METADATA|kvs_members` from any KVS node to discover
+   cluster membership
+2. The client builds a local hash ring using the shared `anna-hashring` library
+3. For each request, the client hashes the key and sends it directly to the
+   responsible KVS node
+4. If a `WRONG_THREAD` error is returned (e.g., during cluster reconfiguration),
+   the client refreshes its hash ring and retries
+
+In the Rust client, call `enable_direct_routing()` to activate client-side
+routing. All client libraries support this mode.
+
+### Routing Tier (anna-route) — Optional, Deprecated
+
+The `anna-route` process is a legacy routing server kept for backward
+compatibility. It is **optional** — clients using client-side routing do not
+need it. When used, routing nodes:
 
 - Cache the storage tiers' hash rings and replication vectors
 - Return memory-tier addresses when available (for performance)
@@ -89,8 +107,10 @@ Anna uses ZeroMQ for all communication:
   with shared memory buffers for zero-copy messaging
 - **Inter-node** (between machines): ZeroMQ `tcp` transport with Protocol
   Buffer serialization
-- **Client-to-routing**: PUSH/PULL sockets on port 6450
-- **Client-to-KVS**: PUSH/PULL sockets on configurable ports (6600/6650)
+- **Client-to-routing** (optional, legacy): PUSH/PULL sockets on port 6450
+- **Client-to-KVS**: PUSH/PULL sockets on configurable ports (6600/6650).
+  With client-side routing, clients send requests directly to KVS nodes
+  without going through the routing tier.
 
 See [Port Layout](ports.md) for the complete port map (26 port groups across
 6000-7200).
@@ -113,4 +133,6 @@ Anna guarantees k-fault tolerance by ensuring k+1 replicas are live:
 - Data is automatically repartitioned using the updated hash ring
 - The management system spawns a replacement node
 - Key migration is interleaved with request handling (no downtime)
-- Routing and monitoring nodes are stateless and recover by querying peers
+- Monitoring nodes are stateless and recover by querying peers
+- With client-side routing, the routing tier is not required for fault
+  tolerance — clients refresh their local hash ring on `WRONG_THREAD` errors

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -102,9 +102,12 @@ config keys, defaults, and valid ranges.
 
 ## Port Configuration for Multi-Node Deployments
 
-When a new node joins the cluster it contacts the routing tier's seed
-port, announces itself, and begins accepting requests on the same set
-of well-known ports as every other node. Port conflicts between nodes
+When a new node joins the cluster it contacts the seed node (via the
+routing tier's seed port, or discovered through KVS metadata), announces
+itself, and begins accepting requests on the same set of well-known
+ports as every other node. Clients using client-side routing automatically
+discover new nodes by refreshing their local hash ring from
+`ANNA_METADATA|kvs_members`. Port conflicts between nodes
 are avoided because ZMQ sockets bind to each node's specific IP address
 rather than `0.0.0.0`. In production each node has a distinct IP, so all
 nodes share the same port numbers.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -79,11 +79,16 @@ disk-tier threads read/write files on mounted volumes.
 Client proxies serve user requests:
 
 - Support GET, PUT, and DELETE operations
-- Query the routing tier to find key locations
-- Cache key-address mappings locally
-- Handle cache invalidation when the cluster reconfigures
+- Build a local hash ring from KVS membership data
+  (`ANNA_METADATA|kvs_members`) and compute key-to-server mappings
+  client-side using the shared `anna-hashring` library
+- Handle `WRONG_THREAD` responses by refreshing the local hash ring and
+  retrying (safety net during cluster reconfiguration)
 - For advanced consistency levels, maintain a per-transaction state 
   (message buffers, read caches)
+
+Legacy clients may still query the optional `anna-route` routing tier
+to find key locations, but this mode is deprecated.
 
 ## Operations
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,12 +20,16 @@ the compiled-in default is used, preserving backward-compatible behavior.
 | `monitoring.ip` | Yes | — | IP address of the monitoring node |
 | `monitoring.scaling_alert_ip` | Yes | — | IP address of the scaling alert endpoint |
 
-### Routing (`routing:`)
+### Routing (`routing:`) — Optional
+
+> **Note:** The `routing:` section is only required when running the legacy
+> `anna-route` server. Clients using client-side routing (the recommended
+> approach) do not need a routing server.
 
 | Config Key | Required | Default | Meaning |
 |------------|----------|---------|---------|
-| `routing.ip` | Yes | — | IP address of this routing node |
-| `routing.monitoring` | Yes | — | List of monitoring node IPs |
+| `routing.ip` | Yes (if using anna-route) | — | IP address of this routing node |
+| `routing.monitoring` | Yes (if using anna-route) | — | List of monitoring node IPs |
 
 ### Server (`server:`)
 
@@ -35,7 +39,7 @@ the compiled-in default is used, preserving backward-compatible behavior.
 | `server.private_ip` | Yes | — | Private IP of this KVS node |
 | `server.seed_ip` | Yes | — | IP of the seed node to join |
 | `server.scaling_alert_ip` | Yes | — | Scaling alert endpoint IP (or "NULL" for standalone) |
-| `server.routing` | Yes | — | List of routing node IPs |
+| `server.routing` | No | — | List of routing node IPs (only needed when using the legacy `anna-route` server) |
 | `server.monitoring` | Yes | — | List of monitoring node IPs |
 
 ### Ports (`ports:`)
@@ -70,7 +74,7 @@ If both `-cap` and `-cap-kb` variants are present, the `-kb` variant takes prece
 |------------|-------------|---------|---------|
 | `threads.memory` | `kMemoryThreadCount` | — | Threads per memory-tier node |
 | `threads.disk` | `kDiskThreadCount` | — | Threads per disk-tier node |
-| `threads.routing` | `kRoutingThreadCount` | — | Threads per routing node |
+| `threads.routing` | `kRoutingThreadCount` | — | Threads per routing node (only relevant when using `anna-route`) |
 | `threads.benchmark` | — | — | Benchmark threads (not used by server) |
 
 ## Hashing Configuration (`hashing:`)

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -134,7 +134,7 @@ feature, not an autoscaling decision.
 | Node depart      | Node leaves, data redistributed                      | Yes           |
 | Self-depart      | Node gracefully removes itself, gossips all data out | Yes           |
 | Rejoin detection | Join counter distinguishes fresh joins from rejoins  | Yes           |
-| Seed node        | First routing node serves cluster membership         | Yes           |
+| Seed node        | First node serves cluster membership (via routing or KVS metadata) | Yes           |
 
 ### Fault Tolerance
 
@@ -155,7 +155,19 @@ feature, not an autoscaling decision.
 | CRC32 hashing                   | Hash function for key-to-ring mapping        | Yes           |
 | Thread responsibility lookup    | Determines which threads handle a key        | Yes           |
 
-### Routing Tier
+### Client-Side Routing
+
+| Feature                        | Description                                                            | System Tested |
+|--------------------------------|------------------------------------------------------------------------|---------------|
+| Client-side hash ring          | Clients build a local hash ring from `ANNA_METADATA\|kvs_members`      | Yes           |
+| Direct KVS routing             | Clients compute key-to-server mappings locally via `anna-hashring`     | Yes           |
+| `enable_direct_routing()`      | Rust client method to activate client-side routing                     | Yes           |
+| WRONG_THREAD retry             | Safety net: client refreshes hash ring on misrouted requests           | Yes           |
+
+### Routing Tier — Optional, Deprecated (`anna-route`)
+
+The `anna-route` process is kept for backward compatibility but is not
+required when clients use client-side routing.
 
 | Feature                   | Description                                              | System Tested |
 |---------------------------|----------------------------------------------------------|---------------|
@@ -254,8 +266,9 @@ can use the client library helpers to implement their own scaling logic.
 | Error Handling                         | `anna-kvs`     | 5     | 5      | 100%     | —      |
 | Multi-Tiered Storage                   | `anna-kvs`     | 5     | 5      | 100%     | —      |
 | Multi-Node Features                    | `anna-kvs`     | 25    | 25     | 100%     | —      |
-| Routing Tier                           | `anna-route`   | 6     | 6      | 100%     | —      |
+| Client-Side Routing                    | all clients    | 4     | 4      | 100%     | —      |
+| Routing Tier (optional, deprecated)    | `anna-route`   | 6     | 6      | 100%     | —      |
 | Monitoring                             | `anna-monitor` | 6     | 6      | 100%     | —      |
 | Autoscaling (server primitives)        | `anna-monitor` | 4     | 4      | 100%     | —      |
 | Client library helpers                 | all clients    | 7     | 7      | 100%     | —      |
-| **Total**                              |                | **88**| **88** | **100%** |        |
+| **Total**                              |                | **92**| **92** | **100%** |        |

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -32,7 +32,10 @@ spacing (6000-6900), followed by 7 singleton ports (6950-6956).
 | 6800 | `kManagementNodeResponsePort` | Receive management node responses (function node lists) |
 | 6900 | `kCacheRegistrationPort` | Receive cache registration messages from ValueChangeSubscriber clients |
 
-### Routing Server (5 per-thread ports)
+### Routing Server (5 per-thread ports) — Optional
+
+These ports are only used when running the legacy `anna-route` server.
+Clients using client-side routing do not need these ports.
 
 | Base Port | Constant | Purpose |
 |-----------|----------|---------|
@@ -47,7 +50,7 @@ spacing (6000-6900), followed by 7 singleton ports (6950-6956).
 | Base Port | Constant | Purpose |
 |-----------|----------|---------|
 | 6600 | `kUserResponsePort` | Receive GET/PUT responses from KVS |
-| 6650 | `kUserKeyAddressPort` | Receive key-address responses from routing |
+| 6650 | `kUserKeyAddressPort` | Receive key-address responses from routing (only used with `anna-route`) |
 
 ### Other per-thread ports
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -13,8 +13,11 @@ If you have not installed it, then you can build and run the development version
 > cargo run -- start
 ```
 
-By default, the `server/conf/anna-config.yml` config file is used, which only specifies one routing thread and one storage
-thread.
+By default, the `server/conf/anna-config.yml` config file is used, which specifies one routing thread and one storage
+thread. The routing thread (`anna-route`) is **optional** — clients using
+client-side routing connect directly to KVS nodes and do not need a routing
+server. The `anna start` command still launches `anna-route` by default for
+backward compatibility, but it is not required.
 
 You are welcome to modify this file if you would like, but we generally do not recommend running more than one
 thread per process in local mode.


### PR DESCRIPTION
Updates all documentation to reflect the new client-side routing architecture from #445.

### Key changes

All 9 docs files updated to describe:
- Clients build a local hash ring from `ANNA_METADATA|kvs_members` using the `anna-hashring` library
- `anna-route` is optional and deprecated (kept for backward compatibility)
- Rust client has `enable_direct_routing()` method
- `WRONG_THREAD` retry remains as safety net for stale rings

### Files changed

| File | Changes |
|---|---|
| `architecture.md` | New Client-Side Routing section, routing tier marked optional/deprecated |
| `concepts.md` | Client proxy updated to describe local hash ring |
| `config.md` | Routing config fields marked optional |
| `running.md` | anna-route noted as optional |
| `feature-list.md` | 4 new features, routing section marked deprecated |
| `ports.md` | Routing ports (6350-6550) marked optional |
| `api-comparison.md` | Wording clarification |
| `autoscaling.md` | Node join via metadata noted |
| `SUMMARY.md` | Clients section updated |

Part of #445