### PR TITLE
Extend server-common with KVS routing infrastructure (#550)

### DIFF
--- a/server/rust/server-common/src/hash_ring.rs
+++ b/server/rust/server-common/src/hash_ring.rs
@@ -159,6 +159,16 @@ impl ConsistentHashRing {
     pub fn is_empty(&self) -> bool {
         self.ring.is_empty()
     }
+
+    /// Get the base port offset from the first entry in the ring.
+    /// Returns 0 if the ring is empty.
+    pub fn base_offset(&self) -> u32 {
+        self.ring
+            .values()
+            .next()
+            .map(|st| st.base_offset())
+            .unwrap_or(0)
+    }
 }
 
 impl Default for ConsistentHashRing {

--- a/server/rust/server-common/src/lib.rs
+++ b/server/rust/server-common/src/lib.rs
@@ -15,6 +15,7 @@ pub mod hash_ring;
 pub mod metadata;
 pub mod ports;
 pub mod proto;
+pub mod routing;
 pub mod signal;
 pub mod threads;
 pub mod types;

--- a/server/rust/server-common/src/metadata.rs
+++ b/server/rust/server-common/src/metadata.rs
@@ -59,6 +59,49 @@ impl KeyProperty {
     }
 }
 
+/// Metadata type discriminator — mirrors C++ `MetadataType` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetadataType {
+    Replication,
+    ServerStats,
+    KeyAccess,
+    KeySize,
+}
+
+impl MetadataType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            MetadataType::Replication => "replication",
+            MetadataType::ServerStats => "stats",
+            MetadataType::KeyAccess => "access",
+            MetadataType::KeySize => "size",
+        }
+    }
+}
+
+/// All tiers that store user data.
+pub const ALL_DATA_TIERS: &[Tier] = &[Tier::Memory, Tier::Disk];
+
+/// Initialize a key's replication factors to the defaults from tier metadata.
+pub fn init_replication(
+    key_replication_map: &mut HashMap<Key, KeyReplication>,
+    key: &Key,
+    tier_metadata: &HashMap<Tier, TierMetadata>,
+    default_local_replication: u32,
+) {
+    let kr = key_replication_map.entry(key.clone()).or_default();
+    for tier in ALL_DATA_TIERS {
+        if let Some(tm) = tier_metadata.get(tier) {
+            kr.global_replication
+                .entry(*tier)
+                .or_insert(tm.default_replication);
+        }
+        kr.local_replication
+            .entry(*tier)
+            .or_insert(default_local_replication);
+    }
+}
+
 /// Check if a key is an internal metadata key.
 pub fn is_metadata(key: &str) -> bool {
     key.starts_with(METADATA_IDENTIFIER)
@@ -67,11 +110,60 @@ pub fn is_metadata(key: &str) -> bool {
 }
 
 /// Build a metadata key for a given type and data key.
+/// Example: `get_metadata_key("mykey", "replication")` → `"ANNA_METADATA|replication|mykey"`
 pub fn get_metadata_key(key: &str, metadata_type: &str) -> Key {
     format!(
         "{}{}{}{}{}",
         METADATA_IDENTIFIER, METADATA_DELIMITER, metadata_type, METADATA_DELIMITER, key
     )
+}
+
+/// Build a server-stats metadata key for a specific server thread.
+/// Example: `"ANNA_METADATA|stats|1.2.3.4|10.0.0.1|2|MEMORY"`
+pub fn get_server_metadata_key(
+    st: &crate::threads::ServerThread,
+    tier: Tier,
+    thread_num: u32,
+    metadata_type: MetadataType,
+) -> Key {
+    match metadata_type {
+        MetadataType::Replication => String::new(), // use get_metadata_key instead
+        _ => format!(
+            "{}{}{}{}{}{}{}{}{}{}{}",
+            METADATA_IDENTIFIER,
+            METADATA_DELIMITER,
+            metadata_type.as_str(),
+            METADATA_DELIMITER,
+            st.public_ip(),
+            METADATA_DELIMITER,
+            st.private_ip(),
+            METADATA_DELIMITER,
+            thread_num,
+            METADATA_DELIMITER,
+            tier_name(tier),
+        ),
+    }
+}
+
+/// Extract the data key from a replication metadata key.
+/// Returns `None` for non-replication metadata keys.
+pub fn get_key_from_metadata(metadata_key: &str) -> Option<&str> {
+    // Format: ANNA_METADATA|replication|<data_key>
+    let rest = metadata_key.strip_prefix(METADATA_IDENTIFIER)?;
+    let rest = rest.strip_prefix(METADATA_DELIMITER)?;
+    if let Some(data_key) = rest.strip_prefix("replication") {
+        Some(data_key.strip_prefix(METADATA_DELIMITER).unwrap_or(""))
+    } else {
+        None
+    }
+}
+
+fn tier_name(tier: Tier) -> &'static str {
+    match tier {
+        Tier::Memory => "MEMORY",
+        Tier::Disk => "DISK",
+        Tier::Routing => "ROUTING",
+    }
 }
 
 #[cfg(test)]
@@ -97,6 +189,68 @@ mod tests {
             get_metadata_key("mykey", "replication"),
             "ANNA_METADATA|replication|mykey"
         );
+    }
+
+    #[test]
+    fn get_server_metadata_key_stats() {
+        let st = crate::threads::ServerThread::new("1.2.3.4", "10.0.0.1", 0, 0);
+        let key = get_server_metadata_key(&st, Tier::Memory, 2, MetadataType::ServerStats);
+        assert_eq!(key, "ANNA_METADATA|stats|1.2.3.4|10.0.0.1|2|MEMORY");
+    }
+
+    #[test]
+    fn get_server_metadata_key_replication_returns_empty() {
+        let st = crate::threads::ServerThread::new("1.2.3.4", "10.0.0.1", 0, 0);
+        let key = get_server_metadata_key(&st, Tier::Memory, 0, MetadataType::Replication);
+        assert!(key.is_empty());
+    }
+
+    #[test]
+    fn get_key_from_metadata_replication() {
+        assert_eq!(
+            get_key_from_metadata("ANNA_METADATA|replication|mykey"),
+            Some("mykey")
+        );
+    }
+
+    #[test]
+    fn get_key_from_metadata_non_replication() {
+        assert_eq!(
+            get_key_from_metadata("ANNA_METADATA|stats|1.2.3.4|10.0.0.1|0|MEMORY"),
+            None
+        );
+    }
+
+    #[test]
+    fn get_key_from_metadata_not_metadata() {
+        assert_eq!(get_key_from_metadata("user_key"), None);
+    }
+
+    #[test]
+    fn init_replication_sets_defaults() {
+        let mut kr_map = std::collections::HashMap::new();
+        let mut tier_metadata = std::collections::HashMap::new();
+        tier_metadata.insert(
+            Tier::Memory,
+            TierMetadata {
+                id: Tier::Memory,
+                thread_number: 1,
+                default_replication: 2,
+                node_capacity: 1024,
+            },
+        );
+        init_replication(&mut kr_map, &"test_key".to_string(), &tier_metadata, 1);
+        let kr = &kr_map["test_key"];
+        assert_eq!(kr.global_replication[&Tier::Memory], 2);
+        assert_eq!(kr.local_replication[&Tier::Memory], 1);
+    }
+
+    #[test]
+    fn metadata_type_as_str() {
+        assert_eq!(MetadataType::Replication.as_str(), "replication");
+        assert_eq!(MetadataType::ServerStats.as_str(), "stats");
+        assert_eq!(MetadataType::KeyAccess.as_str(), "access");
+        assert_eq!(MetadataType::KeySize.as_str(), "size");
     }
 
     #[test]

--- a/server/rust/server-common/src/metadata.rs
+++ b/server/rust/server-common/src/metadata.rs
@@ -151,11 +151,8 @@ pub fn get_key_from_metadata(metadata_key: &str) -> Option<&str> {
     // Format: ANNA_METADATA|replication|<data_key>
     let rest = metadata_key.strip_prefix(METADATA_IDENTIFIER)?;
     let rest = rest.strip_prefix(METADATA_DELIMITER)?;
-    if let Some(data_key) = rest.strip_prefix("replication") {
-        Some(data_key.strip_prefix(METADATA_DELIMITER).unwrap_or(""))
-    } else {
-        None
-    }
+    let (metadata_type, data_key) = rest.split_once(METADATA_DELIMITER)?;
+    (metadata_type == MetadataType::Replication.as_str()).then_some(data_key)
 }
 
 fn tier_name(tier: Tier) -> &'static str {

--- a/server/rust/server-common/src/routing.rs
+++ b/server/rust/server-common/src/routing.rs
@@ -171,7 +171,7 @@ pub fn replication_request_target(
     threads.into_iter().next().map(|t| (t, rep_key))
 }
 
-/// Find the target thread for a metadata request and return its address.
+/// Find the target server thread for a metadata request.
 /// Returns `None` if no memory-tier servers exist.
 pub fn metadata_request_target(
     key: &str,

--- a/server/rust/server-common/src/routing.rs
+++ b/server/rust/server-common/src/routing.rs
@@ -1,0 +1,322 @@
+//! Routing utilities for determining which server threads are responsible
+//! for a given key, based on the consistent hash ring and replication factors.
+//!
+//! Mirrors `server/cpp/src/hash_ring/hash_ring.cpp`.
+
+use std::collections::HashMap;
+
+use crate::hash_ring::ConsistentHashRing;
+use crate::metadata::{
+    get_metadata_key, is_metadata, KeyReplication, Tier, TierMetadata, ALL_DATA_TIERS,
+};
+use crate::threads::ServerThread;
+use crate::types::{GlobalRingMap, Key, LocalRingMap, ServerThreadList};
+
+/// Default metadata replication factor.
+pub const DEFAULT_METADATA_REPLICATION_FACTOR: u32 = 1;
+
+/// Default local replication factor.
+pub const DEFAULT_LOCAL_REPLICATION: u32 = 1;
+
+/// Result of `get_responsible_threads`.
+#[derive(Debug)]
+pub enum ResponsibleResult {
+    /// Successfully determined the responsible threads.
+    Ok(ServerThreadList),
+    /// The replication factor for this key is not known; a replication
+    /// factor request should be issued. Contains the replication metadata
+    /// key that should be fetched.
+    NeedReplicationFactor(Key),
+}
+
+/// Find the first tier that has nodes in the global hash ring.
+pub fn first_tier_with_nodes(global_hash_rings: &GlobalRingMap) -> Option<Tier> {
+    for tier in ALL_DATA_TIERS {
+        if let Some(ring) = global_hash_rings.get(tier) {
+            if !ring.is_empty() {
+                return Some(*tier);
+            }
+        }
+    }
+    None
+}
+
+/// Determine which server threads are responsible for the given key.
+///
+/// For metadata keys, uses `metadata_replication_factor` and the memory
+/// tier ring. For data keys, looks up the key's per-key replication
+/// factors from `key_replication_map`.
+///
+/// Returns `ResponsibleResult::NeedReplicationFactor` if the replication
+/// factor is not known for a data key.
+pub fn get_responsible_threads(
+    key: &str,
+    is_meta: bool,
+    global_hash_rings: &GlobalRingMap,
+    local_hash_rings: &LocalRingMap,
+    key_replication_map: &HashMap<Key, KeyReplication>,
+    metadata_replication_factor: u32,
+    default_local_replication: u32,
+) -> ResponsibleResult {
+    if is_meta {
+        let threads = get_responsible_threads_metadata(
+            key,
+            global_hash_rings,
+            local_hash_rings,
+            metadata_replication_factor,
+            default_local_replication,
+        );
+        return ResponsibleResult::Ok(threads);
+    }
+
+    // Data key: look up per-key replication factors.
+    let kr = match key_replication_map.get(key) {
+        Some(kr) => kr,
+        None => {
+            let rep_key = get_metadata_key(key, "replication");
+            return ResponsibleResult::NeedReplicationFactor(rep_key);
+        }
+    };
+
+    let mut result = Vec::new();
+
+    for tier in ALL_DATA_TIERS {
+        let global_ring = match global_hash_rings.get(tier) {
+            Some(r) if !r.is_empty() => r,
+            _ => continue,
+        };
+        let local_ring = match local_hash_rings.get(tier) {
+            Some(r) => r,
+            None => continue,
+        };
+
+        let global_rep = kr.global_replication.get(tier).copied().unwrap_or(1);
+        let local_rep = kr
+            .local_replication
+            .get(tier)
+            .copied()
+            .unwrap_or(default_local_replication);
+
+        let servers = global_ring.find_responsible(key, global_rep, true);
+        for st in servers {
+            let tids = local_ring.find_responsible_local(key, local_rep);
+            for tid in tids {
+                result.push(ServerThread::new(
+                    st.public_ip(),
+                    st.private_ip(),
+                    tid,
+                    global_ring.base_offset(),
+                ));
+            }
+        }
+    }
+
+    ResponsibleResult::Ok(result)
+}
+
+/// Determine responsible threads for a metadata key.
+/// Uses the memory tier ring with fixed replication factors.
+fn get_responsible_threads_metadata(
+    key: &str,
+    global_hash_rings: &GlobalRingMap,
+    local_hash_rings: &LocalRingMap,
+    metadata_replication_factor: u32,
+    default_local_replication: u32,
+) -> ServerThreadList {
+    let global_ring = match global_hash_rings.get(&Tier::Memory) {
+        Some(r) => r,
+        None => return vec![],
+    };
+    let local_ring = match local_hash_rings.get(&Tier::Memory) {
+        Some(r) => r,
+        None => return vec![],
+    };
+
+    let servers = global_ring.find_responsible(key, metadata_replication_factor, true);
+    let mut result = Vec::new();
+    for st in servers {
+        let tids = local_ring.find_responsible_local(key, default_local_replication);
+        for tid in tids {
+            result.push(ServerThread::new(
+                st.public_ip(),
+                st.private_ip(),
+                tid,
+                global_ring.base_offset(),
+            ));
+        }
+    }
+    result
+}
+
+/// Build a replication factor GET request key for the given data key,
+/// and find which server thread should receive it.
+///
+/// Returns `(target_thread, replication_metadata_key)` or `None` if no
+/// servers are available.
+pub fn replication_request_target(
+    key: &str,
+    global_hash_rings: &GlobalRingMap,
+    local_hash_rings: &LocalRingMap,
+    metadata_replication_factor: u32,
+    default_local_replication: u32,
+) -> Option<(ServerThread, Key)> {
+    let rep_key = get_metadata_key(key, "replication");
+    let threads = get_responsible_threads_metadata(
+        &rep_key,
+        global_hash_rings,
+        local_hash_rings,
+        metadata_replication_factor,
+        default_local_replication,
+    );
+    threads.into_iter().next().map(|t| (t, rep_key))
+}
+
+/// Find the target thread for a metadata request and return its address.
+/// Returns `None` if no memory-tier servers exist.
+pub fn metadata_request_target(
+    key: &str,
+    global_hash_rings: &GlobalRingMap,
+    local_hash_rings: &LocalRingMap,
+    metadata_replication_factor: u32,
+    default_local_replication: u32,
+) -> Option<ServerThread> {
+    let threads = get_responsible_threads_metadata(
+        key,
+        global_hash_rings,
+        local_hash_rings,
+        metadata_replication_factor,
+        default_local_replication,
+    );
+    threads.into_iter().next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash_ring::{ConsistentHashRing, DEFAULT_VIRTUAL_THREAD_NUM};
+
+    fn make_single_node_rings() -> (GlobalRingMap, LocalRingMap) {
+        let mut global = HashMap::new();
+        let mut local = HashMap::new();
+
+        let mut g_ring = ConsistentHashRing::new();
+        g_ring.insert(
+            "1.2.3.4",
+            "10.0.0.1",
+            0,
+            0,
+            DEFAULT_VIRTUAL_THREAD_NUM,
+            true,
+        );
+
+        let mut l_ring = ConsistentHashRing::new();
+        l_ring.insert(
+            "1.2.3.4",
+            "10.0.0.1",
+            0,
+            0,
+            DEFAULT_VIRTUAL_THREAD_NUM,
+            false,
+        );
+
+        global.insert(Tier::Memory, g_ring);
+        local.insert(Tier::Memory, l_ring);
+
+        (global, local)
+    }
+
+    #[test]
+    fn metadata_key_routes_to_memory_tier() {
+        let (global, local) = make_single_node_rings();
+        let kr_map = HashMap::new();
+
+        match get_responsible_threads(
+            "ANNA_METADATA|replication|mykey",
+            true,
+            &global,
+            &local,
+            &kr_map,
+            1,
+            1,
+        ) {
+            ResponsibleResult::Ok(threads) => {
+                assert!(!threads.is_empty());
+                assert_eq!(threads[0].private_ip(), "10.0.0.1");
+            }
+            _ => panic!("Expected Ok"),
+        }
+    }
+
+    #[test]
+    fn data_key_without_replication_factor() {
+        let (global, local) = make_single_node_rings();
+        let kr_map = HashMap::new();
+
+        match get_responsible_threads("user_key", false, &global, &local, &kr_map, 1, 1) {
+            ResponsibleResult::NeedReplicationFactor(rep_key) => {
+                assert_eq!(rep_key, "ANNA_METADATA|replication|user_key");
+            }
+            _ => panic!("Expected NeedReplicationFactor"),
+        }
+    }
+
+    #[test]
+    fn data_key_with_replication_factor() {
+        let (global, local) = make_single_node_rings();
+        let mut kr_map = HashMap::new();
+        let mut kr = KeyReplication::default();
+        kr.global_replication.insert(Tier::Memory, 1);
+        kr.local_replication.insert(Tier::Memory, 1);
+        kr_map.insert("user_key".to_string(), kr);
+
+        match get_responsible_threads("user_key", false, &global, &local, &kr_map, 1, 1) {
+            ResponsibleResult::Ok(threads) => {
+                assert!(!threads.is_empty());
+                assert_eq!(threads[0].private_ip(), "10.0.0.1");
+            }
+            _ => panic!("Expected Ok"),
+        }
+    }
+
+    #[test]
+    fn replication_request_target_returns_thread() {
+        let (global, local) = make_single_node_rings();
+        let result = replication_request_target("user_key", &global, &local, 1, 1);
+        assert!(result.is_some());
+        let (thread, rep_key) = result.unwrap();
+        assert_eq!(thread.private_ip(), "10.0.0.1");
+        assert_eq!(rep_key, "ANNA_METADATA|replication|user_key");
+    }
+
+    #[test]
+    fn empty_ring_returns_empty() {
+        let global = HashMap::new();
+        let local = HashMap::new();
+        let kr_map = HashMap::new();
+
+        match get_responsible_threads(
+            "ANNA_METADATA|stats|key",
+            true,
+            &global,
+            &local,
+            &kr_map,
+            1,
+            1,
+        ) {
+            ResponsibleResult::Ok(threads) => assert!(threads.is_empty()),
+            _ => panic!("Expected Ok with empty list"),
+        }
+    }
+
+    #[test]
+    fn first_tier_with_nodes_finds_memory() {
+        let (global, _) = make_single_node_rings();
+        assert_eq!(first_tier_with_nodes(&global), Some(Tier::Memory));
+    }
+
+    #[test]
+    fn first_tier_with_nodes_empty() {
+        let global = HashMap::new();
+        assert_eq!(first_tier_with_nodes(&global), None);
+    }
+}

--- a/server/rust/server-common/src/threads.rs
+++ b/server/rust/server-common/src/threads.rs
@@ -62,6 +62,9 @@ impl ServerThread {
     pub fn virtual_num(&self) -> u32 {
         self.virtual_num
     }
+    pub fn base_offset(&self) -> u32 {
+        self.base_offset
+    }
 
     pub fn id(&self) -> String {
         format!("{}:{}", self.private_ip, self.tid)
@@ -223,6 +226,42 @@ pub fn scaling_alert_address(scaling_alert_ip: &str, base_offset: u32) -> Addres
     )
 }
 
+/// Represents a cache node thread.
+/// Mirrors `CacheThread` in `server/cpp/src/threads.hpp`.
+#[derive(Debug, Clone)]
+pub struct CacheThread {
+    ip: Address,
+    tid: u32,
+    base_offset: u32,
+}
+
+impl CacheThread {
+    pub fn new(ip: &str, tid: u32, base_offset: u32) -> Self {
+        assert!(tid < MAX_TID, "tid {} exceeds maximum {}", tid, MAX_TID - 1);
+        CacheThread {
+            ip: ip.to_string(),
+            tid,
+            base_offset,
+        }
+    }
+
+    pub fn ip(&self) -> &str {
+        &self.ip
+    }
+
+    pub fn tid(&self) -> u32 {
+        self.tid
+    }
+
+    pub fn cache_update_connect_address(&self) -> Address {
+        format!(
+            "tcp://{}:{}",
+            self.ip,
+            self.tid + CACHE_UPDATE_PORT + self.base_offset
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,6 +331,12 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn cache_thread_update_address() {
+        let ct = CacheThread::new("10.0.0.1", 0, 0);
+        assert_eq!(ct.cache_update_connect_address(), "tcp://10.0.0.1:6850");
+    }
+
     #[should_panic(expected = "tid 50 exceeds maximum")]
     fn routing_thread_tid_too_large() {
         RoutingThread::new("10.0.0.1", 50, 0);

--- a/server/rust/server-common/src/threads.rs
+++ b/server/rust/server-common/src/threads.rs
@@ -331,7 +331,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn cache_thread_update_address() {
         let ct = CacheThread::new("10.0.0.1", 0, 0);
         assert_eq!(ct.cache_update_connect_address(), "tcp://10.0.0.1:6850");

--- a/server/rust/server-common/src/types.rs
+++ b/server/rust/server-common/src/types.rs
@@ -15,3 +15,12 @@ pub type ThreadID = u32;
 
 /// Hash map type alias.
 pub type Map<K, V> = HashMap<K, V>;
+
+/// Map from tier → global hash ring.
+pub type GlobalRingMap = HashMap<crate::metadata::Tier, crate::hash_ring::ConsistentHashRing>;
+
+/// Map from tier → local hash ring.
+pub type LocalRingMap = HashMap<crate::metadata::Tier, crate::hash_ring::ConsistentHashRing>;
+
+/// List of server threads (result of `get_responsible_threads`).
+pub type ServerThreadList = Vec<crate::threads::ServerThread>;


### PR DESCRIPTION
Phase 0 of the anna-kvs Rust port (#339, #550).

Adds shared infrastructure to server-common needed by the KVS handlers (Phase 2, #552).

### New modules and types

**routing.rs** — Key routing via consistent hash ring
- `get_responsible_threads()`: combines global + local ring lookup with replication factor handling
- `replication_request_target()` / `metadata_request_target()`: find target threads for metadata operations
- `first_tier_with_nodes()`: finds first tier with servers
- `ResponsibleResult` enum signals when replication factors need fetching

**metadata.rs** — Extended metadata helpers
- `MetadataType` enum (Replication, ServerStats, KeyAccess, KeySize)
- `get_server_metadata_key()`: per-server stats metadata keys
- `get_key_from_metadata()`: extract data key from replication metadata
- `init_replication()`: initialize per-key replication defaults
- `ALL_DATA_TIERS` constant

**types.rs** — Type aliases
- `GlobalRingMap`, `LocalRingMap` (HashMap<Tier, ConsistentHashRing>)
- `ServerThreadList`

**threads.rs** — CacheThread struct + ServerThread::base_offset() accessor

**hash_ring.rs** — ConsistentHashRing::base_offset() accessor

### Testing
- 15 new unit tests (47 total in server-common)
- All existing tests pass

Closes #550