### PR TITLE
Rust KVS event loop and main entry point (Phase 3, #553)

### DIFF
--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -89,12 +89,12 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: cargo test
 
-    - name: Upload Rust client coverage
+    - name: Upload Rust workspace coverage
       if: matrix.os == 'macos-latest'
       uses: codecov/codecov-action@v6
       with:
         files: rust_workspace.info
-        flags: rust-client
+        flags: rust-client,rust-server
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -89,11 +89,17 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: cargo test
 
+    - name: Split and upload Rust coverage
+      if: matrix.os == 'macos-latest'
+      run: |
+        lcov --extract rust_workspace.info '*/clients/rust/*' -o rust_client.info --ignore-errors unused 2>/dev/null || true
+        lcov --extract rust_workspace.info '*/server/rust/*' -o rust_server.info --ignore-errors unused 2>/dev/null || true
+
     - name: Upload Rust client coverage
       if: matrix.os == 'macos-latest'
       uses: codecov/codecov-action@v6
       with:
-        files: rust_workspace.info
+        files: rust_client.info
         flags: rust-client
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
@@ -102,7 +108,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       uses: codecov/codecov-action@v6
       with:
-        files: rust_workspace.info
+        files: rust_server.info
         flags: rust-server
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -89,12 +89,21 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: cargo test
 
-    - name: Upload Rust workspace coverage
+    - name: Upload Rust client coverage
       if: matrix.os == 'macos-latest'
       uses: codecov/codecov-action@v6
       with:
         files: rust_workspace.info
-        flags: rust-client,rust-server
+        flags: rust-client
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+
+    - name: Upload Rust server coverage
+      if: matrix.os == 'macos-latest'
+      uses: codecov/codecov-action@v6
+      with:
+        files: rust_workspace.info
+        flags: rust-server
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ client-python-tests: client-python-dependencies
 workspace-rust-tests:
 	@echo "Running rust tests with coverage"
 	@find clients/cpp/build -name "*.gcda" -delete 2>/dev/null || true
-	@$(CARGO_ENV) cargo llvm-cov test --lcov --output-path rust_workspace.info
+	@$(CARGO_ENV) cargo llvm-cov test --workspace --lcov --output-path rust_workspace.info -- --skip docker
 	@lcov --remove rust_workspace.info '/Applications/*' '/usr*' '*/build/*' '**/build.rs' '*/cpp/hash_ring/*' '*/cpp/zmq/*' '**/errors.rs' '**/*.pb.*' '*tests/*' '*/protobuf/*' '*/incremental/*' -o rust_workspace.info --ignore-errors inconsistent,format,unused
 
 MDBOOK := $(shell command -v mdbook 2> /dev/null)

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,10 @@ component_management:
       name: Rust Client
       paths:
         - clients/rust/
+    - component_id: rust-server
+      name: Rust Server
+      paths:
+        - server/rust/
     - component_id: cpp-client
       name: C++ Client
       paths:
@@ -58,6 +62,10 @@ flags:
   go-client:
     paths:
       - clients/go/
+    carryforward: true
+  rust-server:
+    paths:
+      - server/rust/
     carryforward: true
   server-system-tests:
     paths:

--- a/server/rust/anna-kvs/src/kvs_server.rs
+++ b/server/rust/anna-kvs/src/kvs_server.rs
@@ -1,0 +1,452 @@
+//! KVS event loop — receives and dispatches requests via ZMQ.
+//!
+//! Mirrors `server/cpp/src/kvs/server.cpp` `run()` function.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use anna_server_common::config::Config;
+use anna_server_common::hash_ring::{ConsistentHashRing, DEFAULT_VIRTUAL_THREAD_NUM};
+use anna_server_common::metadata::{is_metadata, Tier, TierMetadata};
+use anna_server_common::proto::kvs::{KeyRequest, LatticeType, RequestType};
+use anna_server_common::routing::{DEFAULT_LOCAL_REPLICATION, DEFAULT_METADATA_REPLICATION_FACTOR};
+use anna_server_common::signal;
+use anna_server_common::threads::ServerThread;
+use anna_server_common::types::Address;
+use omq_tokio::{Context, Message as ZmqMessage, Options, SocketType};
+use prost::Message;
+
+use crate::context::KvsContext;
+use crate::handlers;
+use crate::storage::memory;
+use crate::storage::SerializerMap;
+
+/// ZMQ PUSH socket cache — lazily connects on first send.
+struct SocketCache {
+    ctx: Context,
+    sockets: HashMap<Address, omq_tokio::Socket>,
+}
+
+impl SocketCache {
+    fn new(ctx: Context) -> Self {
+        Self {
+            ctx,
+            sockets: HashMap::new(),
+        }
+    }
+
+    async fn send(&mut self, addr: &str, data: &[u8]) -> Result<(), String> {
+        if !self.sockets.contains_key(addr) {
+            let sock = self.ctx.socket(SocketType::Push, Options::default());
+            let endpoint = addr
+                .parse()
+                .map_err(|e| format!("Invalid address {}: {}", addr, e))?;
+            sock.connect(endpoint)
+                .await
+                .map_err(|e| format!("Failed to connect to {}: {}", addr, e))?;
+            self.sockets.insert(addr.to_string(), sock);
+        }
+        let sock = self.sockets.get_mut(addr).expect("socket just inserted");
+        sock.send(ZmqMessage::from(data.to_vec()))
+            .await
+            .map_err(|e| format!("Failed to send to {}: {}", addr, e))
+    }
+}
+
+/// Extract message bytes from an omq-tokio Message.
+fn msg_bytes(msg: &ZmqMessage) -> Vec<u8> {
+    msg.iter().flat_map(|f| f.to_vec()).collect()
+}
+
+/// Run the KVS event loop for a single thread.
+pub async fn run(
+    thread_id: u32,
+    config: &Config,
+    public_ip: &str,
+    private_ip: &str,
+    seed_ip: &str,
+    self_tier: Tier,
+    thread_count: u32,
+    self_join_count: i32,
+    routing_ips: Vec<Address>,
+    monitoring_ips: Vec<Address>,
+) {
+    let base_offset = config.ports.base_offset;
+    let wt = ServerThread::new(public_ip, private_ip, thread_id, base_offset);
+
+    let log_name = format!("kvs_{}", thread_id);
+    log::info!("[{}] Starting KVS thread", log_name);
+
+    // ── ZMQ context and sockets ──
+    let ctx = Context::new();
+
+    let join_puller = ctx.socket(SocketType::Pull, Options::default());
+    join_puller
+        .bind(wt.node_join_connect_address().parse().unwrap())
+        .await
+        .expect("bind join_puller");
+
+    let depart_puller = ctx.socket(SocketType::Pull, Options::default());
+    depart_puller
+        .bind(wt.node_depart_connect_address().parse().unwrap())
+        .await
+        .expect("bind depart_puller");
+
+    let self_depart_puller = ctx.socket(SocketType::Pull, Options::default());
+    self_depart_puller
+        .bind(wt.self_depart_connect_address().parse().unwrap())
+        .await
+        .expect("bind self_depart_puller");
+
+    let request_puller = ctx.socket(SocketType::Pull, Options::default());
+    request_puller
+        .bind(wt.key_request_bind_address().parse().unwrap())
+        .await
+        .expect("bind request_puller");
+
+    let gossip_puller = ctx.socket(SocketType::Pull, Options::default());
+    gossip_puller
+        .bind(wt.gossip_connect_address().parse().unwrap())
+        .await
+        .expect("bind gossip_puller");
+
+    let replication_response_puller = ctx.socket(SocketType::Pull, Options::default());
+    replication_response_puller
+        .bind(wt.replication_response_connect_address().parse().unwrap())
+        .await
+        .expect("bind replication_response_puller");
+
+    let replication_change_puller = ctx.socket(SocketType::Pull, Options::default());
+    replication_change_puller
+        .bind(wt.replication_change_connect_address().parse().unwrap())
+        .await
+        .expect("bind replication_change_puller");
+
+    let cache_ip_response_puller = ctx.socket(SocketType::Pull, Options::default());
+    cache_ip_response_puller
+        .bind(wt.cache_ip_response_connect_address().parse().unwrap())
+        .await
+        .expect("bind cache_ip_response_puller");
+
+    let management_node_response_puller = ctx.socket(SocketType::Pull, Options::default());
+    management_node_response_puller
+        .bind(
+            wt.management_node_response_connect_address()
+                .parse()
+                .unwrap(),
+        )
+        .await
+        .expect("bind management_node_response_puller");
+
+    let cache_registration_puller = ctx.socket(SocketType::Pull, Options::default());
+    cache_registration_puller
+        .bind(wt.cache_registration_connect_address().parse().unwrap())
+        .await
+        .expect("bind cache_registration_puller");
+
+    let mut pushers = SocketCache::new(ctx.clone());
+
+    // ── Initialize hash rings ──
+    let mut global_hash_rings = HashMap::new();
+    let mut local_hash_rings = HashMap::new();
+
+    // Add self to global ring.
+    let mut g_ring = ConsistentHashRing::new();
+    g_ring.insert(
+        public_ip,
+        private_ip,
+        0,
+        base_offset,
+        DEFAULT_VIRTUAL_THREAD_NUM,
+        true,
+    );
+    global_hash_rings.insert(self_tier, g_ring);
+
+    // Form local hash ring.
+    let mut l_ring = ConsistentHashRing::new();
+    for tid in 0..thread_count {
+        l_ring.insert(
+            public_ip,
+            private_ip,
+            tid,
+            base_offset,
+            DEFAULT_VIRTUAL_THREAD_NUM,
+            false,
+        );
+    }
+    local_hash_rings.insert(self_tier, l_ring);
+
+    // ── Initialize serializers ──
+    let mut serializers: SerializerMap = HashMap::new();
+    serializers.insert(
+        LatticeType::Lww as i32,
+        Box::new(memory::LwwSerializer::new()),
+    );
+    serializers.insert(
+        LatticeType::Set as i32,
+        Box::new(memory::SetSerializer::new()),
+    );
+    // OrderedSet uses the same wire format as Set.
+    serializers.insert(
+        LatticeType::OrderedSet as i32,
+        Box::new(memory::SetSerializer::new()),
+    );
+    serializers.insert(
+        LatticeType::SingleCausal as i32,
+        Box::new(memory::SingleCausalSerializer::new()),
+    );
+    serializers.insert(
+        LatticeType::MultiCausal as i32,
+        Box::new(memory::MultiCausalSerializer::new()),
+    );
+    serializers.insert(
+        LatticeType::Priority as i32,
+        Box::new(memory::PrioritySerializer::new()),
+    );
+    serializers.insert(
+        LatticeType::Counter as i32,
+        Box::new(memory::CounterSerializer::new()),
+    );
+    serializers.insert(
+        LatticeType::OrSet as i32,
+        Box::new(memory::OrSetSerializer::new()),
+    );
+
+    // ── Initialize tier metadata ──
+    let mut tier_metadata = HashMap::new();
+    tier_metadata.insert(
+        Tier::Memory,
+        TierMetadata {
+            id: Tier::Memory,
+            thread_number: config.threads.memory,
+            default_replication: config.replication.memory,
+            node_capacity: config.memory_capacity_bytes(),
+        },
+    );
+    tier_metadata.insert(
+        Tier::Disk,
+        TierMetadata {
+            id: Tier::Disk,
+            thread_number: config.threads.disk,
+            default_replication: config.replication.disk,
+            node_capacity: config.disk_capacity_bytes(),
+        },
+    );
+
+    // ── Build KVS context ──
+    let mut ctx_state = KvsContext {
+        thread_id,
+        public_ip: public_ip.to_string(),
+        private_ip: private_ip.to_string(),
+        wt: wt.clone(),
+        self_tier,
+        thread_count,
+        global_hash_rings,
+        local_hash_rings,
+        stored_key_map: HashMap::new(),
+        serializers,
+        key_replication_map: HashMap::new(),
+        tier_metadata,
+        default_local_replication: config.replication.local,
+        metadata_replication_factor: DEFAULT_METADATA_REPLICATION_FACTOR,
+        self_join_count,
+        pending_requests: HashMap::new(),
+        pending_gossip: HashMap::new(),
+        key_access_tracker: HashMap::new(),
+        local_changeset: Default::default(),
+        access_count: 0,
+        join_gossip_map: HashMap::new(),
+        join_remove_set: Default::default(),
+        extant_caches: Default::default(),
+        cache_ip_to_keys: HashMap::new(),
+        key_to_cache_ips: HashMap::new(),
+        routing_ips,
+        monitoring_ips,
+        rid: 0,
+        seed: 42 + thread_id,
+    };
+
+    // ── Timers ──
+    let poll_timeout = Duration::from_millis(100);
+    let gossip_period = Duration::from_secs(config.timings.gossip_epoch.into());
+    let report_period = Duration::from_secs(config.timings.server_report_period.into());
+    let mut gossip_start = Instant::now();
+    let mut gc_start = Instant::now();
+    let mut report_start = Instant::now();
+
+    log::info!("[{}] Entering event loop", log_name);
+
+    // ── Event loop ──
+    while !signal::shutdown_requested() {
+        if signal::self_depart_requested() {
+            let depart_done_addr = if !ctx_state.monitoring_ips.is_empty() {
+                anna_server_common::threads::MonitoringThread::new(
+                    &ctx_state.monitoring_ips[0],
+                    base_offset,
+                )
+                .depart_done_connect_address()
+            } else {
+                String::new()
+            };
+
+            let msgs = handlers::self_depart::handle(&mut ctx_state, &depart_done_addr);
+            for (addr, data) in &msgs {
+                let _ = pushers.send(addr, data).await;
+            }
+            // Allow ZMQ to deliver depart notifications.
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            break;
+        }
+
+        // Socket 0: node_join — first socket gets poll_timeout.
+        if let Ok(Ok(msg)) = tokio::time::timeout(poll_timeout, join_puller.recv()).await {
+            let data = msg_bytes(&msg);
+            let serialized = String::from_utf8_lossy(&data);
+            let msgs = handlers::node_join::handle(&mut ctx_state, &serialized);
+            for (addr, data) in &msgs {
+                let _ = pushers.send(addr, data).await;
+            }
+        }
+
+        // Socket 1: node_depart — non-blocking.
+        if let Ok(Ok(msg)) = tokio::time::timeout(Duration::ZERO, depart_puller.recv()).await {
+            let data = msg_bytes(&msg);
+            let serialized = String::from_utf8_lossy(&data);
+            let msgs = handlers::node_depart::handle(&mut ctx_state, &serialized);
+            for (addr, data) in &msgs {
+                let _ = pushers.send(addr, data).await;
+            }
+        }
+
+        // Socket 2: self_depart — trigger from other threads.
+        if let Ok(Ok(_)) = tokio::time::timeout(Duration::ZERO, self_depart_puller.recv()).await {
+            // self_depart_requested flag is already set by the signal handler.
+            // This socket is for relay from thread 0 to worker threads.
+            continue; // re-check self_depart_requested at top of loop.
+        }
+
+        // Socket 3: user requests (GET/PUT/SCAN).
+        if let Ok(Ok(msg)) = tokio::time::timeout(Duration::ZERO, request_puller.recv()).await {
+            let data = msg_bytes(&msg);
+            // Peek at request type to dispatch to scan or user_request.
+            if let Ok(req) = KeyRequest::decode(data.as_slice()) {
+                let msgs = if req.r#type == RequestType::Scan as i32 {
+                    handlers::scan::handle(&ctx_state, &data)
+                } else {
+                    handlers::user_request::handle(&mut ctx_state, &data)
+                };
+                for (addr, d) in &msgs {
+                    let _ = pushers.send(addr, d).await;
+                }
+            }
+        }
+
+        // Socket 4: gossip.
+        if let Ok(Ok(msg)) = tokio::time::timeout(Duration::ZERO, gossip_puller.recv()).await {
+            let data = msg_bytes(&msg);
+            let msgs = handlers::gossip::handle(&mut ctx_state, &data);
+            for (addr, d) in &msgs {
+                let _ = pushers.send(addr, d).await;
+            }
+        }
+
+        // Socket 5: replication response.
+        if let Ok(Ok(msg)) =
+            tokio::time::timeout(Duration::ZERO, replication_response_puller.recv()).await
+        {
+            let data = msg_bytes(&msg);
+            let msgs = handlers::replication_response::handle(&mut ctx_state, &data);
+            for (addr, d) in &msgs {
+                let _ = pushers.send(addr, d).await;
+            }
+        }
+
+        // Socket 6: replication change.
+        if let Ok(Ok(msg)) =
+            tokio::time::timeout(Duration::ZERO, replication_change_puller.recv()).await
+        {
+            let data = msg_bytes(&msg);
+            let msgs = handlers::replication_change::handle(&mut ctx_state, &data);
+            for (addr, d) in &msgs {
+                let _ = pushers.send(addr, d).await;
+            }
+        }
+
+        // Socket 7: cache IP response.
+        if let Ok(Ok(msg)) =
+            tokio::time::timeout(Duration::ZERO, cache_ip_response_puller.recv()).await
+        {
+            let data = msg_bytes(&msg);
+            handlers::cache_ip_response::handle(&mut ctx_state, &data);
+        }
+
+        // Socket 8: management node response.
+        if let Ok(Ok(msg)) =
+            tokio::time::timeout(Duration::ZERO, management_node_response_puller.recv()).await
+        {
+            let data = msg_bytes(&msg);
+            let msgs = handlers::management_node_response::handle(&mut ctx_state, &data);
+            for (addr, d) in &msgs {
+                let _ = pushers.send(addr, d).await;
+            }
+        }
+
+        // Socket 9: cache registration.
+        if let Ok(Ok(msg)) =
+            tokio::time::timeout(Duration::ZERO, cache_registration_puller.recv()).await
+        {
+            let data = msg_bytes(&msg);
+            handlers::cache_registration::handle(&mut ctx_state, &data);
+        }
+
+        // ── Periodic: gossip ──
+        if gossip_start.elapsed() >= gossip_period {
+            // TODO: gossip local changeset to peers + cache update push
+            gossip_start = Instant::now();
+        }
+
+        // ── Periodic: GC ──
+        if gc_start.elapsed() >= gossip_period {
+            let reaped = handlers::utils::gc_reap_expired_keys(
+                &mut ctx_state.stored_key_map,
+                &mut ctx_state.serializers,
+            );
+            if reaped > 0 {
+                log::debug!("[{}] GC reaped {} expired keys", log_name, reaped);
+            }
+            gc_start = Instant::now();
+        }
+
+        // ── Periodic: stats report ──
+        if report_start.elapsed() >= report_period {
+            // TODO: report storage stats, key access, cluster topology, kvs_members
+            report_start = Instant::now();
+        }
+
+        // ── Join gossip drain ──
+        if !ctx_state.join_gossip_map.is_empty() {
+            let msgs = handlers::utils::build_gossip_messages(
+                &ctx_state.join_gossip_map,
+                &ctx_state.serializers,
+                &ctx_state.stored_key_map,
+            );
+            for (addr, data) in &msgs {
+                let _ = pushers.send(addr, data).await;
+            }
+            ctx_state.join_gossip_map.clear();
+
+            // Remove keys this node is no longer responsible for.
+            for key in ctx_state.join_remove_set.drain() {
+                if let Some(kp) = ctx_state.stored_key_map.get(&key) {
+                    let lt = kp.lattice_type() as i32;
+                    if let Some(s) = ctx_state.serializers.get_mut(&lt) {
+                        s.remove(&key);
+                    }
+                }
+                ctx_state.stored_key_map.remove(&key);
+            }
+        }
+    }
+
+    log::info!("[{}] Event loop exited", log_name);
+}

--- a/server/rust/anna-kvs/src/kvs_server.rs
+++ b/server/rust/anna-kvs/src/kvs_server.rs
@@ -7,9 +7,9 @@ use std::time::{Duration, Instant};
 
 use anna_server_common::config::Config;
 use anna_server_common::hash_ring::{ConsistentHashRing, DEFAULT_VIRTUAL_THREAD_NUM};
-use anna_server_common::metadata::{is_metadata, Tier, TierMetadata};
-use anna_server_common::proto::kvs::{KeyRequest, LatticeType, RequestType};
-use anna_server_common::routing::{DEFAULT_LOCAL_REPLICATION, DEFAULT_METADATA_REPLICATION_FACTOR};
+use anna_server_common::metadata::{Tier, TierMetadata};
+use anna_server_common::proto::kvs::{KeyRequest, RequestType};
+use anna_server_common::routing::DEFAULT_METADATA_REPLICATION_FACTOR;
 use anna_server_common::signal;
 use anna_server_common::threads::ServerThread;
 use anna_server_common::types::Address;
@@ -18,8 +18,7 @@ use prost::Message;
 
 use crate::context::KvsContext;
 use crate::handlers;
-use crate::storage::memory;
-use crate::storage::SerializerMap;
+use crate::storage;
 
 /// ZMQ PUSH socket cache — lazily connects on first send.
 struct SocketCache {
@@ -58,19 +57,31 @@ fn msg_bytes(msg: &ZmqMessage) -> Vec<u8> {
     msg.iter().flat_map(|f| f.to_vec()).collect()
 }
 
+/// Bind a PULL socket to the given address, returning a descriptive error.
+async fn bind_pull(ctx: &Context, addr: &str, name: &str) -> Result<omq_tokio::Socket, String> {
+    let sock = ctx.socket(SocketType::Pull, Options::default());
+    let endpoint = addr
+        .parse()
+        .map_err(|e| format!("Invalid address for {}: {} ({})", name, addr, e))?;
+    sock.bind(endpoint)
+        .await
+        .map_err(|e| format!("Failed to bind {} on {}: {}", name, addr, e))?;
+    Ok(sock)
+}
+
 /// Run the KVS event loop for a single thread.
 pub async fn run(
     thread_id: u32,
     config: &Config,
     public_ip: &str,
     private_ip: &str,
-    seed_ip: &str,
+    _seed_ip: &str,
     self_tier: Tier,
     thread_count: u32,
     self_join_count: i32,
     routing_ips: Vec<Address>,
     monitoring_ips: Vec<Address>,
-) {
+) -> Result<(), String> {
     let base_offset = config.ports.base_offset;
     let wt = ServerThread::new(public_ip, private_ip, thread_id, base_offset);
 
@@ -80,69 +91,34 @@ pub async fn run(
     // ── ZMQ context and sockets ──
     let ctx = Context::new();
 
-    let join_puller = ctx.socket(SocketType::Pull, Options::default());
-    join_puller
-        .bind(wt.node_join_connect_address().parse().unwrap())
-        .await
-        .expect("bind join_puller");
-
-    let depart_puller = ctx.socket(SocketType::Pull, Options::default());
-    depart_puller
-        .bind(wt.node_depart_connect_address().parse().unwrap())
-        .await
-        .expect("bind depart_puller");
-
-    let self_depart_puller = ctx.socket(SocketType::Pull, Options::default());
-    self_depart_puller
-        .bind(wt.self_depart_connect_address().parse().unwrap())
-        .await
-        .expect("bind self_depart_puller");
-
-    let request_puller = ctx.socket(SocketType::Pull, Options::default());
-    request_puller
-        .bind(wt.key_request_bind_address().parse().unwrap())
-        .await
-        .expect("bind request_puller");
-
-    let gossip_puller = ctx.socket(SocketType::Pull, Options::default());
-    gossip_puller
-        .bind(wt.gossip_connect_address().parse().unwrap())
-        .await
-        .expect("bind gossip_puller");
-
-    let replication_response_puller = ctx.socket(SocketType::Pull, Options::default());
-    replication_response_puller
-        .bind(wt.replication_response_connect_address().parse().unwrap())
-        .await
-        .expect("bind replication_response_puller");
-
-    let replication_change_puller = ctx.socket(SocketType::Pull, Options::default());
-    replication_change_puller
-        .bind(wt.replication_change_connect_address().parse().unwrap())
-        .await
-        .expect("bind replication_change_puller");
-
-    let cache_ip_response_puller = ctx.socket(SocketType::Pull, Options::default());
-    cache_ip_response_puller
-        .bind(wt.cache_ip_response_connect_address().parse().unwrap())
-        .await
-        .expect("bind cache_ip_response_puller");
-
-    let management_node_response_puller = ctx.socket(SocketType::Pull, Options::default());
-    management_node_response_puller
-        .bind(
-            wt.management_node_response_connect_address()
-                .parse()
-                .unwrap(),
-        )
-        .await
-        .expect("bind management_node_response_puller");
-
-    let cache_registration_puller = ctx.socket(SocketType::Pull, Options::default());
-    cache_registration_puller
-        .bind(wt.cache_registration_connect_address().parse().unwrap())
-        .await
-        .expect("bind cache_registration_puller");
+    let join_puller = bind_pull(&ctx, &wt.node_join_connect_address(), "join").await?;
+    let depart_puller = bind_pull(&ctx, &wt.node_depart_connect_address(), "depart").await?;
+    let self_depart_puller =
+        bind_pull(&ctx, &wt.self_depart_connect_address(), "self_depart").await?;
+    let request_puller = bind_pull(&ctx, &wt.key_request_bind_address(), "request").await?;
+    let gossip_puller = bind_pull(&ctx, &wt.gossip_connect_address(), "gossip").await?;
+    let replication_response_puller = bind_pull(
+        &ctx,
+        &wt.replication_response_connect_address(),
+        "rep_response",
+    )
+    .await?;
+    let replication_change_puller =
+        bind_pull(&ctx, &wt.replication_change_connect_address(), "rep_change").await?;
+    let cache_ip_response_puller = bind_pull(
+        &ctx,
+        &wt.cache_ip_response_connect_address(),
+        "cache_ip_response",
+    )
+    .await?;
+    let management_node_response_puller = bind_pull(
+        &ctx,
+        &wt.management_node_response_connect_address(),
+        "mgmt_response",
+    )
+    .await?;
+    let cache_registration_puller =
+        bind_pull(&ctx, &wt.cache_registration_connect_address(), "cache_reg").await?;
 
     let mut pushers = SocketCache::new(ctx.clone());
 
@@ -176,41 +152,8 @@ pub async fn run(
     }
     local_hash_rings.insert(self_tier, l_ring);
 
-    // ── Initialize serializers ──
-    let mut serializers: SerializerMap = HashMap::new();
-    serializers.insert(
-        LatticeType::Lww as i32,
-        Box::new(memory::LwwSerializer::new()),
-    );
-    serializers.insert(
-        LatticeType::Set as i32,
-        Box::new(memory::SetSerializer::new()),
-    );
-    // OrderedSet uses the same wire format as Set.
-    serializers.insert(
-        LatticeType::OrderedSet as i32,
-        Box::new(memory::SetSerializer::new()),
-    );
-    serializers.insert(
-        LatticeType::SingleCausal as i32,
-        Box::new(memory::SingleCausalSerializer::new()),
-    );
-    serializers.insert(
-        LatticeType::MultiCausal as i32,
-        Box::new(memory::MultiCausalSerializer::new()),
-    );
-    serializers.insert(
-        LatticeType::Priority as i32,
-        Box::new(memory::PrioritySerializer::new()),
-    );
-    serializers.insert(
-        LatticeType::Counter as i32,
-        Box::new(memory::CounterSerializer::new()),
-    );
-    serializers.insert(
-        LatticeType::OrSet as i32,
-        Box::new(memory::OrSetSerializer::new()),
-    );
+    // ── Initialize serializers (all lattice types including compounds) ──
+    let serializers = storage::create_memory_serializers();
 
     // ── Initialize tier metadata ──
     let mut tier_metadata = HashMap::new();
@@ -269,6 +212,12 @@ pub async fn run(
     // ── Timers ──
     let poll_timeout = Duration::from_millis(100);
     let gossip_period = Duration::from_secs(config.timings.gossip_epoch.into());
+    let gc_period = Duration::from_micros(
+        config
+            .timings
+            .garbage_collect_period_us
+            .unwrap_or(config.timings.gossip_epoch as u64 * 1_000_000),
+    );
     let report_period = Duration::from_secs(config.timings.server_report_period.into());
     let mut gossip_start = Instant::now();
     let mut gc_start = Instant::now();
@@ -298,8 +247,25 @@ pub async fn run(
             break;
         }
 
-        // Socket 0: node_join — first socket gets poll_timeout.
-        if let Ok(Ok(msg)) = tokio::time::timeout(poll_timeout, join_puller.recv()).await {
+        // Socket 3: user requests (GET/PUT/SCAN) — gets poll_timeout as the
+        // loop's sleep. This is the hot path; all other sockets drain with
+        // Duration::ZERO so they never add latency to user requests.
+        if let Ok(Ok(msg)) = tokio::time::timeout(poll_timeout, request_puller.recv()).await {
+            let data = msg_bytes(&msg);
+            if let Ok(req) = KeyRequest::decode(data.as_slice()) {
+                let msgs = if req.r#type == RequestType::Scan as i32 {
+                    handlers::scan::handle(&ctx_state, &data)
+                } else {
+                    handlers::user_request::handle(&mut ctx_state, &data)
+                };
+                for (addr, d) in &msgs {
+                    let _ = pushers.send(addr, d).await;
+                }
+            }
+        }
+
+        // Socket 0: node_join — non-blocking.
+        if let Ok(Ok(msg)) = tokio::time::timeout(Duration::ZERO, join_puller.recv()).await {
             let data = msg_bytes(&msg);
             let serialized = String::from_utf8_lossy(&data);
             let msgs = handlers::node_join::handle(&mut ctx_state, &serialized);
@@ -318,27 +284,10 @@ pub async fn run(
             }
         }
 
-        // Socket 2: self_depart — trigger from other threads.
+        // Socket 2: self_depart relay from thread 0 to workers.
         if let Ok(Ok(_)) = tokio::time::timeout(Duration::ZERO, self_depart_puller.recv()).await {
-            // self_depart_requested flag is already set by the signal handler.
-            // This socket is for relay from thread 0 to worker threads.
+            signal::request_self_depart();
             continue; // re-check self_depart_requested at top of loop.
-        }
-
-        // Socket 3: user requests (GET/PUT/SCAN).
-        if let Ok(Ok(msg)) = tokio::time::timeout(Duration::ZERO, request_puller.recv()).await {
-            let data = msg_bytes(&msg);
-            // Peek at request type to dispatch to scan or user_request.
-            if let Ok(req) = KeyRequest::decode(data.as_slice()) {
-                let msgs = if req.r#type == RequestType::Scan as i32 {
-                    handlers::scan::handle(&ctx_state, &data)
-                } else {
-                    handlers::user_request::handle(&mut ctx_state, &data)
-                };
-                for (addr, d) in &msgs {
-                    let _ = pushers.send(addr, d).await;
-                }
-            }
         }
 
         // Socket 4: gossip.
@@ -405,8 +354,8 @@ pub async fn run(
             gossip_start = Instant::now();
         }
 
-        // ── Periodic: GC ──
-        if gc_start.elapsed() >= gossip_period {
+        // ── Periodic: GC (expired key reaping) ──
+        if gc_start.elapsed() >= gc_period {
             let reaped = handlers::utils::gc_reap_expired_keys(
                 &mut ctx_state.stored_key_map,
                 &mut ctx_state.serializers,
@@ -449,4 +398,5 @@ pub async fn run(
     }
 
     log::info!("[{}] Event loop exited", log_name);
+    Ok(())
 }

--- a/server/rust/anna-kvs/src/main.rs
+++ b/server/rust/anna-kvs/src/main.rs
@@ -25,10 +25,13 @@ async fn main() {
 
     let cli = Cli::parse();
 
-    let config = Config::load(std::path::Path::new(&cli.config)).unwrap_or_else(|e| {
+    let mut config = Config::load(std::path::Path::new(&cli.config)).unwrap_or_else(|e| {
         eprintln!("Failed to load config {}: {}", cli.config, e);
         std::process::exit(1);
     });
+
+    // Resolve auto thread counts (0 = hardware_concurrency).
+    config.threads.resolve_auto();
 
     // Determine tier from SERVER_TYPE env var (default: memory).
     let self_tier = match std::env::var("SERVER_TYPE")
@@ -73,7 +76,7 @@ async fn main() {
         let routing_ips = routing_ips.clone();
         let monitoring_ips = monitoring_ips.clone();
         handles.push(tokio::spawn(async move {
-            kvs_server::run(
+            if let Err(e) = kvs_server::run(
                 tid,
                 &config,
                 &public_ip,
@@ -85,12 +88,16 @@ async fn main() {
                 routing_ips,
                 monitoring_ips,
             )
-            .await;
+            .await
+            {
+                log::error!("Worker thread {} failed: {}", tid, e);
+                std::process::exit(1);
+            }
         }));
     }
 
     // Thread 0 runs on the main task.
-    kvs_server::run(
+    if let Err(e) = kvs_server::run(
         0,
         &config,
         &public_ip,
@@ -102,10 +109,17 @@ async fn main() {
         routing_ips,
         monitoring_ips,
     )
-    .await;
+    .await
+    {
+        log::error!("Thread 0 failed: {}", e);
+        std::process::exit(1);
+    }
 
     // Wait for worker threads.
     for handle in handles {
-        let _ = handle.await;
+        if let Err(e) = handle.await {
+            log::error!("Worker task panicked: {}", e);
+            std::process::exit(1);
+        }
     }
 }

--- a/server/rust/anna-kvs/src/main.rs
+++ b/server/rust/anna-kvs/src/main.rs
@@ -1,9 +1,111 @@
 //! Anna KVS server (Rust port).
+//!
+//! Usage: `anna-kvs-rs --config <config.yml>`
 
 mod context;
 mod handlers;
+mod kvs_server;
 mod storage;
 
-fn main() {
-    println!("anna-kvs-rs: not yet implemented");
+use anna_server_common::config::Config;
+use anna_server_common::metadata::Tier;
+use anna_server_common::signal;
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "anna-kvs-rs", about = "Anna KVS server (Rust)")]
+struct Cli {
+    #[arg(long)]
+    config: String,
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let cli = Cli::parse();
+
+    let config = Config::load(std::path::Path::new(&cli.config)).unwrap_or_else(|e| {
+        eprintln!("Failed to load config {}: {}", cli.config, e);
+        std::process::exit(1);
+    });
+
+    // Determine tier from SERVER_TYPE env var (default: memory).
+    let self_tier = match std::env::var("SERVER_TYPE")
+        .unwrap_or_default()
+        .to_lowercase()
+        .as_str()
+    {
+        "disk" => Tier::Disk,
+        _ => Tier::Memory,
+    };
+
+    let thread_count = match self_tier {
+        Tier::Memory => config.threads.memory,
+        Tier::Disk => config.threads.disk,
+        _ => 1,
+    };
+
+    let public_ip = config.server.public_ip.clone();
+    let private_ip = config.server.private_ip.clone();
+    let seed_ip = config.server.seed_ip.clone();
+    let routing_ips = config.server.routing.clone();
+    let monitoring_ips = config.server.monitoring.clone();
+
+    if self_tier == Tier::Memory {
+        log::info!(
+            "Starting anna-kvs-rs (memory tier, {} threads)",
+            thread_count
+        );
+    } else {
+        log::info!("Starting anna-kvs-rs (disk tier, {} threads)", thread_count);
+    }
+
+    signal::install_shutdown_handler();
+
+    // Spawn worker threads 1..N as tokio tasks.
+    let mut handles = Vec::new();
+    for tid in 1..thread_count {
+        let config = config.clone();
+        let public_ip = public_ip.clone();
+        let private_ip = private_ip.clone();
+        let seed_ip = seed_ip.clone();
+        let routing_ips = routing_ips.clone();
+        let monitoring_ips = monitoring_ips.clone();
+        handles.push(tokio::spawn(async move {
+            kvs_server::run(
+                tid,
+                &config,
+                &public_ip,
+                &private_ip,
+                &seed_ip,
+                self_tier,
+                thread_count,
+                0,
+                routing_ips,
+                monitoring_ips,
+            )
+            .await;
+        }));
+    }
+
+    // Thread 0 runs on the main task.
+    kvs_server::run(
+        0,
+        &config,
+        &public_ip,
+        &private_ip,
+        &seed_ip,
+        self_tier,
+        thread_count,
+        0,
+        routing_ips,
+        monitoring_ips,
+    )
+    .await;
+
+    // Wait for worker threads.
+    for handle in handles {
+        let _ = handle.await;
+    }
 }

--- a/server/rust/server-common/src/config.rs
+++ b/server/rust/server-common/src/config.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use std::path::Path;
 
 /// Top-level configuration structure.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub monitoring: MonitoringConfig,
@@ -32,7 +32,7 @@ pub struct Config {
     pub disk: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct MonitoringConfig {
     #[serde(default)]
     pub ip: String,
@@ -40,7 +40,7 @@ pub struct MonitoringConfig {
     pub scaling_alert_ip: String,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct RoutingConfig {
     #[serde(default)]
     pub ip: String,
@@ -48,7 +48,7 @@ pub struct RoutingConfig {
     pub monitoring: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct ServerConfig {
     #[serde(default)]
     pub public_ip: String,
@@ -64,7 +64,7 @@ pub struct ServerConfig {
     pub monitoring: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct UserConfig {
     #[serde(default)]
     pub ip: String,
@@ -74,13 +74,13 @@ pub struct UserConfig {
     pub monitoring: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct PortsConfig {
     #[serde(default)]
     pub base_offset: u32,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct ThreadsConfig {
     #[serde(default)]
     pub memory: u32,
@@ -114,7 +114,7 @@ impl ThreadsConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct CapacitiesConfig {
     #[serde(default, rename = "memory-cap")]
     pub memory_cap_gb: u64,
@@ -126,7 +126,7 @@ pub struct CapacitiesConfig {
     pub disk_cap_kb: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct ReplicationConfig {
     #[serde(default)]
     pub memory: u32,
@@ -138,7 +138,7 @@ pub struct ReplicationConfig {
     pub minimum: u32,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct TimingsConfig {
     #[serde(default)]
     pub server_report_period: u32,
@@ -158,7 +158,7 @@ pub struct TimingsConfig {
     pub monitoring_response_timeout_ms: u32,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct PolicyConfig {
     #[serde(default)]
     pub elasticity: bool,

--- a/server/rust/server-common/src/config.rs
+++ b/server/rust/server-common/src/config.rs
@@ -156,6 +156,8 @@ pub struct TimingsConfig {
     pub grace_period: u32,
     #[serde(default)]
     pub monitoring_response_timeout_ms: u32,
+    #[serde(default)]
+    pub garbage_collect_period_us: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/server/rust/server-common/src/signal.rs
+++ b/server/rust/server-common/src/signal.rs
@@ -43,6 +43,11 @@ pub fn self_depart_requested() -> bool {
     SELF_DEPART_REQUESTED.load(Ordering::SeqCst)
 }
 
+/// Programmatically request self-departure (e.g., relayed from thread 0).
+pub fn request_self_depart() {
+    SELF_DEPART_REQUESTED.store(true, Ordering::SeqCst);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Phase 3 of anna-kvs Rust port (#339, #553).

### Event loop (`kvs_server.rs`)
- 10 ZMQ PULL sockets bound for handler dispatch
- SocketCache for outgoing PUSH messages (lazy connect)
- Sequential recv with timeout pattern (same as anna-monitor)
- All 11 handlers wired up to their sockets
- Request puller dispatches to `scan_handler` or `user_request_handler` based on request type
- Periodic timers: gossip, GC (key expiry), stats report
- Join gossip drain: redistributes data after node joins
- Self-depart: triggered by SIGUSR1 signal flag

### Entry point (`main.rs`)
- CLI: `--config <config.yml>` via clap
- `SERVER_TYPE` env var for tier selection (memory/disk)
- Tokio tasks for worker threads 1..N, thread 0 on main task
- Signal handler (SIGTERM, SIGINT, SIGUSR1)

### Config (`server-common/config.rs`)
- Added `Clone` derive to all config structs (needed for thread spawning)

### Serializers
- 8 memory serializers initialized: LWW, Set, OrderedSet (=Set), SingleCausal, MultiCausal, Priority, Counter, OrSet

### Testing
- 86 tests pass (40 anna-kvs + 46 server-common)
- No integration tests yet (Phase 4, #554)

### TODO (deferred to Phase 4)
- Gossip periodic: push local changeset to peers + cache update
- Stats report periodic: storage stats, key access, cluster topology, kvs_members metadata
- Seed bootstrap: request membership from seed node on startup
- Disk serializers (currently memory-only)

Closes #553