### PR TITLE
Rust KVS dual testing (Phase 4, #554)

### DIFF
--- a/.claude/skills/start-new-issue/SKILL.md
+++ b/.claude/skills/start-new-issue/SKILL.md
@@ -28,13 +28,21 @@ Then a branch name could be `analyse_on_config_change_103`
 As we work on the branch, we will commit changes once pre-commit checks pass and then later
 push the branch and create a PR from it.
 
-## Pre-commit checks
+## Pre-push checks
 
-Before committing new work to a branch, the following checks should pass:
+Before pushing any commit, run the FULL `make test` target — not individual
+test commands that approximate it. `make test` is the single source of truth
+for what CI runs. If new tests are added, they must be wired into `make test`
+so they are always validated locally before pushing.
+
+Run these in order:
 
 - `make clippy`
 - `make fmt`
 - `make test`
+
+Do NOT push until all three pass. Running individual `cargo test` commands
+is useful during development but does NOT replace `make test` before pushing.
 
 Expect the PR checks to check for:
 - non-reducing code coverage of the project and the patch (lines changed), add tests to reduce the possibility

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -81,6 +81,9 @@ jobs:
     - name: docker-test
       if: matrix.os == 'ubuntu-latest'
       run: |
+        # Kill any leftover server processes from make test to avoid port conflicts.
+        pkill -9 anna-kvs anna-monitor anna-route 2>/dev/null || true
+        sleep 2
         docker info > /dev/null 2>&1 || { echo "Docker not available"; exit 1; }
         docker build -t anna-test .
         cargo test --test docker -- --ignored --nocapture

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -83,9 +83,11 @@ jobs:
       run: |
         # Kill any leftover server processes from make test to avoid port conflicts
         # with the Docker container which uses --network host on the same ports.
-        pkill -9 -f anna-kvs 2>/dev/null || true
-        pkill -9 -f anna-monitor 2>/dev/null || true
-        pkill -9 -f anna-route 2>/dev/null || true
+        pkill -9 -x anna-kvs 2>/dev/null || true
+        pkill -9 -x anna-kvs-rs 2>/dev/null || true
+        pkill -9 -x anna-monitor 2>/dev/null || true
+        pkill -9 -x anna-monitor-rs 2>/dev/null || true
+        pkill -9 -x anna-route 2>/dev/null || true
         sleep 5
         docker info > /dev/null 2>&1 || { echo "Docker not available"; exit 1; }
         docker build -t anna-test .

--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -81,9 +81,12 @@ jobs:
     - name: docker-test
       if: matrix.os == 'ubuntu-latest'
       run: |
-        # Kill any leftover server processes from make test to avoid port conflicts.
-        pkill -9 anna-kvs anna-monitor anna-route 2>/dev/null || true
-        sleep 2
+        # Kill any leftover server processes from make test to avoid port conflicts
+        # with the Docker container which uses --network host on the same ports.
+        pkill -9 -f anna-kvs 2>/dev/null || true
+        pkill -9 -f anna-monitor 2>/dev/null || true
+        pkill -9 -f anna-route 2>/dev/null || true
+        sleep 5
         docker info > /dev/null 2>&1 || { echo "Docker not available"; exit 1; }
         docker build -t anna-test .
         cargo test --test docker -- --ignored --nocapture

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ rust-kvs-tests:
 	@echo "=== Rust client tests with Rust KVS (instrumented) ==="
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
 		CARGO_LLVM_COV=1 \
-		$(CARGO_ENV) cargo test --target-dir target/llvm-cov-target --test lattice_types -- --skip disk_tier
+		$(CARGO_ENV) cargo test --target-dir target/llvm-cov-target --test lattice_types -- --skip disk_tier --test-threads=1
 	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
 		CARGO_LLVM_COV=1 \

--- a/Makefile
+++ b/Makefile
@@ -168,14 +168,26 @@ rust-monitor-tests: server-rust
 	@echo "Running monitor integration tests with Rust monitor (anna-monitor-rs)"
 	@ANNA_MONITOR_BIN=$(shell pwd)/target/debug/anna-monitor-rs cargo test --test monitor
 
+# Dual-KVS testing: run all black-box / client tests against the Rust KVS.
+# These are the same tests that workspace-rust-tests, client-cpp-tests, etc.
+# run against the C++ KVS — duplicated here to ensure compatibility.
 .PHONY: rust-kvs-tests
 rust-kvs-tests: server-rust
 	@echo "Building instrumented Rust KVS binary for subprocess coverage"
 	@cargo llvm-cov run --no-report -p anna-kvs -- --help 2>/dev/null
-	@echo "Running lattice type tests with Rust KVS (anna-kvs-rs)"
+	@echo "=== Rust client tests with Rust KVS ==="
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs cargo test --test lattice_types -- --skip disk_tier
-	@echo "Running consistency tests with Rust KVS (anna-kvs-rs)"
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs cargo test --test consistency -- --skip disk
+	@echo "=== C++ client system tests with Rust KVS ==="
+	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R system_tests --output-on-failure
+	@echo "=== C++ CLI smoke test with Rust KVS ==="
+	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R CliSmokeTest --output-on-failure
+	@echo "=== Python client system tests with Rust KVS ==="
+	@cd clients/python && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs python3 -m pytest tests/test_system.py -x
+	@echo "=== Go client system tests with Rust KVS ==="
+	@cd clients/go && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs go test ./tests/ -run TestSystem -count=1 -timeout 60s
+	@echo "=== Shared CLI smoke tests with Rust KVS ==="
+	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs python3 tests/shared/cli/run_smoke_test.py $(shell pwd)/target/debug/anna --config server/conf/anna-local.yml cli
 
 .PHONY: server-system-coverage
 server-system-coverage:

--- a/Makefile
+++ b/Makefile
@@ -170,10 +170,12 @@ rust-monitor-tests: server-rust
 
 .PHONY: rust-kvs-tests
 rust-kvs-tests: server-rust
+	@echo "Building instrumented Rust KVS binary for subprocess coverage"
+	@cargo llvm-cov run --no-report -p anna-kvs -- --help 2>/dev/null
 	@echo "Running lattice type tests with Rust KVS (anna-kvs-rs)"
-	@ANNA_KVS_BIN=$(shell pwd)/target/debug/anna-kvs-rs cargo test --test lattice_types -- --skip disk_tier
+	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs cargo test --test lattice_types -- --skip disk_tier
 	@echo "Running consistency tests with Rust KVS (anna-kvs-rs)"
-	@ANNA_KVS_BIN=$(shell pwd)/target/debug/anna-kvs-rs cargo test --test consistency -- --skip disk
+	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs cargo test --test consistency -- --skip disk
 
 .PHONY: server-system-coverage
 server-system-coverage:
@@ -219,10 +221,7 @@ client-python-tests: client-python-dependencies
 workspace-rust-tests:
 	@echo "Running rust tests with coverage"
 	@find clients/cpp/build -name "*.gcda" -delete 2>/dev/null || true
-	@echo "Building instrumented Rust KVS binary for subprocess coverage"
-	@cargo llvm-cov run --no-report -p anna-kvs -- --help 2>/dev/null
-	@$(CARGO_ENV) ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs cargo llvm-cov test --workspace --no-report -- --skip docker
-	@cargo llvm-cov report --workspace --lcov --output-path rust_workspace.info
+	@$(CARGO_ENV) cargo llvm-cov test --workspace --lcov --output-path rust_workspace.info -- --skip docker
 	@lcov --remove rust_workspace.info '/Applications/*' '/usr*' '*/build/*' '**/build.rs' '*/cpp/hash_ring/*' '*/cpp/zmq/*' '**/errors.rs' '**/*.pb.*' '*tests/*' '*/protobuf/*' '*/incremental/*' -o rust_workspace.info --ignore-errors inconsistent,format,unused
 
 MDBOOK := $(shell command -v mdbook 2> /dev/null)

--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,10 @@ client-go:
 
 .PHONY: client-go-tests
 client-go-tests:
-	@echo "Running Go client tests with coverage"
+	@echo "Running Go client unit tests with coverage"
 	@cd clients/go/annalib && go test -v -coverprofile=coverage.out -coverpkg=github.com/andrewdavidmackenzie/anna/clients/go/annalib ./... 2>&1
+	@echo "Running Go client system tests"
+	@cd clients/go/tests && go test -run TestSystem -count=1 -timeout 60s
 
 .PHONY: coverage
 coverage: test
@@ -185,7 +187,7 @@ rust-kvs-tests: server-rust
 	@echo "=== Python client system tests with Rust KVS ==="
 	@cd clients/python && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs python3 -m pytest tests/test_system.py -x
 	@echo "=== Go client system tests with Rust KVS ==="
-	@echo "SKIP: Go system tests have broken config path (clients/go/tests/)"
+	@cd clients/go/tests && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs go test -run TestSystem -count=1 -timeout 60s
 
 .PHONY: server-system-coverage
 server-system-coverage:

--- a/Makefile
+++ b/Makefile
@@ -163,23 +163,33 @@ coverage: test
 	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info || true
 
 .PHONY: test
-test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage rust-monitor-tests rust-kvs-tests docs
+test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage rust-monitor-tests rust-kvs-tests rust-coverage-report docs
+
+# Generate combined Rust coverage report from all accumulated profraw files
+# (unit tests + Rust KVS subprocess + Rust monitor subprocess).
+.PHONY: rust-coverage-report
+rust-coverage-report:
+	@echo "Generating combined Rust coverage report"
+	@cargo llvm-cov report --lcov --output-path rust_workspace.info
+	@lcov --remove rust_workspace.info '/Applications/*' '/usr*' '*/build/*' '**/build.rs' '*/cpp/hash_ring/*' '*/cpp/zmq/*' '**/errors.rs' '**/*.pb.*' '*tests/*' '*/protobuf/*' '*/incremental/*' -o rust_workspace.info --ignore-errors inconsistent,format,unused
 
 .PHONY: rust-monitor-tests
-rust-monitor-tests: server-rust
-	@echo "Running monitor integration tests with Rust monitor (anna-monitor-rs)"
-	@ANNA_MONITOR_BIN=$(shell pwd)/target/debug/anna-monitor-rs cargo test --test monitor
+rust-monitor-tests:
+	@echo "Running monitor integration tests with Rust monitor (instrumented)"
+	@ANNA_MONITOR_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-monitor-rs \
+		cargo llvm-cov test --no-report -p anna --test monitor
 
 # Dual-KVS testing: run all black-box / client tests against the Rust KVS.
 # These are the same tests that workspace-rust-tests, client-cpp-tests, etc.
 # run against the C++ KVS — duplicated here to ensure compatibility.
+# Disk-tier tests are excluded because the Rust KVS only has memory serializers.
 .PHONY: rust-kvs-tests
-rust-kvs-tests: server-rust
-	@echo "Building instrumented Rust KVS binary for subprocess coverage"
-	@cargo llvm-cov run --no-report -p anna-kvs -- --help 2>/dev/null
-	@echo "=== Rust client tests with Rust KVS ==="
-	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs cargo test --test lattice_types -- --skip disk_tier
-	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs cargo test --test consistency -- --skip disk
+rust-kvs-tests:
+	@echo "=== Rust client tests with Rust KVS (instrumented) ==="
+	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
+		cargo llvm-cov test --no-report -p anna --test lattice_types -- --skip disk_tier
+	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
+		cargo llvm-cov test --no-report -p anna --test consistency -- --skip disk
 	@echo "=== C++ client system tests with Rust KVS ==="
 	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R system_tests --output-on-failure
 	@echo "=== C++ CLI smoke test with Rust KVS ==="
@@ -233,8 +243,11 @@ client-python-tests: client-python-dependencies
 workspace-rust-tests:
 	@echo "Running rust tests with coverage"
 	@find clients/cpp/build -name "*.gcda" -delete 2>/dev/null || true
-	@$(CARGO_ENV) cargo llvm-cov test --workspace --lcov --output-path rust_workspace.info -- --skip docker
-	@lcov --remove rust_workspace.info '/Applications/*' '/usr*' '*/build/*' '**/build.rs' '*/cpp/hash_ring/*' '*/cpp/zmq/*' '**/errors.rs' '**/*.pb.*' '*tests/*' '*/protobuf/*' '*/incremental/*' -o rust_workspace.info --ignore-errors inconsistent,format,unused
+	@echo "Building instrumented Rust server binaries for subprocess coverage"
+	@cargo llvm-cov run --no-report -p anna-kvs -- --help 2>/dev/null
+	@cargo llvm-cov run --no-report -p anna-monitor -- --help 2>/dev/null
+	@echo "Running workspace tests with C++ KVS (profraw accumulated)"
+	@$(CARGO_ENV) cargo llvm-cov test --workspace --no-report -- --skip docker
 
 MDBOOK := $(shell command -v mdbook 2> /dev/null)
 LYCHEE := $(shell command -v lychee 2> /dev/null)

--- a/Makefile
+++ b/Makefile
@@ -166,14 +166,14 @@ test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests 
 .PHONY: rust-monitor-tests
 rust-monitor-tests: server-rust
 	@echo "Running monitor integration tests with Rust monitor (anna-monitor-rs)"
-	@ANNA_MONITOR_BIN=$(shell pwd)/target/debug/anna-monitor-rs cargo test --test monitor 2>&1 | tail -5
+	@ANNA_MONITOR_BIN=$(shell pwd)/target/debug/anna-monitor-rs cargo test --test monitor
 
 .PHONY: rust-kvs-tests
 rust-kvs-tests: server-rust
 	@echo "Running lattice type tests with Rust KVS (anna-kvs-rs)"
-	@ANNA_KVS_BIN=$(shell pwd)/target/debug/anna-kvs-rs cargo test --test lattice_types -- --skip disk_tier 2>&1 | tail -5
+	@ANNA_KVS_BIN=$(shell pwd)/target/debug/anna-kvs-rs cargo test --test lattice_types -- --skip disk_tier
 	@echo "Running consistency tests with Rust KVS (anna-kvs-rs)"
-	@ANNA_KVS_BIN=$(shell pwd)/target/debug/anna-kvs-rs cargo test --test consistency 2>&1 | tail -5
+	@ANNA_KVS_BIN=$(shell pwd)/target/debug/anna-kvs-rs cargo test --test consistency -- --skip disk
 
 .PHONY: server-system-coverage
 server-system-coverage:
@@ -219,7 +219,10 @@ client-python-tests: client-python-dependencies
 workspace-rust-tests:
 	@echo "Running rust tests with coverage"
 	@find clients/cpp/build -name "*.gcda" -delete 2>/dev/null || true
-	@$(CARGO_ENV) cargo llvm-cov test --workspace --lcov --output-path rust_workspace.info -- --skip docker
+	@echo "Building instrumented Rust KVS binary for subprocess coverage"
+	@cargo llvm-cov run --no-report -p anna-kvs -- --help 2>/dev/null
+	@$(CARGO_ENV) ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs cargo llvm-cov test --workspace --no-report -- --skip docker
+	@cargo llvm-cov report --workspace --lcov --output-path rust_workspace.info
 	@lcov --remove rust_workspace.info '/Applications/*' '/usr*' '*/build/*' '**/build.rs' '*/cpp/hash_ring/*' '*/cpp/zmq/*' '**/errors.rs' '**/*.pb.*' '*tests/*' '*/protobuf/*' '*/incremental/*' -o rust_workspace.info --ignore-errors inconsistent,format,unused
 
 MDBOOK := $(shell command -v mdbook 2> /dev/null)

--- a/Makefile
+++ b/Makefile
@@ -161,12 +161,19 @@ coverage: test
 	@genhtml -o coverage --quiet rust_workspace.info server/cpp/build/server.info clients/cpp/build/client.info || true
 
 .PHONY: test
-test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage rust-monitor-tests docs
+test: client-cpp-tests client-python-tests workspace-rust-tests client-go-tests server-system-coverage server-cpp-tests merge-server-coverage rust-monitor-tests rust-kvs-tests docs
 
 .PHONY: rust-monitor-tests
 rust-monitor-tests: server-rust
 	@echo "Running monitor integration tests with Rust monitor (anna-monitor-rs)"
 	@ANNA_MONITOR_BIN=$(shell pwd)/target/debug/anna-monitor-rs cargo test --test monitor 2>&1 | tail -5
+
+.PHONY: rust-kvs-tests
+rust-kvs-tests: server-rust
+	@echo "Running lattice type tests with Rust KVS (anna-kvs-rs)"
+	@ANNA_KVS_BIN=$(shell pwd)/target/debug/anna-kvs-rs cargo test --test lattice_types -- --skip disk_tier 2>&1 | tail -5
+	@echo "Running consistency tests with Rust KVS (anna-kvs-rs)"
+	@ANNA_KVS_BIN=$(shell pwd)/target/debug/anna-kvs-rs cargo test --test consistency 2>&1 | tail -5
 
 .PHONY: server-system-coverage
 server-system-coverage:

--- a/Makefile
+++ b/Makefile
@@ -188,14 +188,19 @@ rust-kvs-tests:
 	@echo "=== Rust client tests with Rust KVS (instrumented) ==="
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
 		cargo llvm-cov test --no-report -p anna --test lattice_types -- --skip disk_tier
+	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
 		cargo llvm-cov test --no-report -p anna --test consistency -- --skip disk
+	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@echo "=== C++ client system tests with Rust KVS ==="
 	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R system_tests --output-on-failure
+	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@echo "=== C++ CLI smoke test with Rust KVS ==="
 	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R CliSmokeTest --output-on-failure
+	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@echo "=== Python client system tests with Rust KVS ==="
 	@cd clients/python && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs python3 -m pytest tests/test_system.py -x
+	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@echo "=== Go client system tests with Rust KVS ==="
 	@cd clients/go/tests && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs go test -run TestSystem -count=1 -timeout 60s
 

--- a/Makefile
+++ b/Makefile
@@ -185,9 +185,7 @@ rust-kvs-tests: server-rust
 	@echo "=== Python client system tests with Rust KVS ==="
 	@cd clients/python && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs python3 -m pytest tests/test_system.py -x
 	@echo "=== Go client system tests with Rust KVS ==="
-	@cd clients/go && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs go test ./tests/ -run TestSystem -count=1 -timeout 60s
-	@echo "=== Shared CLI smoke tests with Rust KVS ==="
-	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs python3 tests/shared/cli/run_smoke_test.py $(shell pwd)/target/debug/anna --config server/conf/anna-local.yml cli
+	@echo "SKIP: Go system tests have broken config path (clients/go/tests/)"
 
 .PHONY: server-system-coverage
 server-system-coverage:

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,8 @@ rust-coverage-report:
 rust-monitor-tests:
 	@echo "Running monitor integration tests with Rust monitor (instrumented)"
 	@ANNA_MONITOR_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-monitor-rs \
-		$(CARGO_ENV) cargo llvm-cov test --no-report -p anna --test monitor
+		CARGO_LLVM_COV=1 \
+		$(CARGO_ENV) cargo test --target-dir target/llvm-cov-target --test monitor
 
 # Dual-KVS testing: run all black-box / client tests against the Rust KVS.
 # These are the same tests that workspace-rust-tests, client-cpp-tests, etc.
@@ -187,10 +188,12 @@ rust-monitor-tests:
 rust-kvs-tests:
 	@echo "=== Rust client tests with Rust KVS (instrumented) ==="
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
-		$(CARGO_ENV) cargo llvm-cov test --no-report -p anna --test lattice_types -- --skip disk_tier
+		CARGO_LLVM_COV=1 \
+		$(CARGO_ENV) cargo test --target-dir target/llvm-cov-target --test lattice_types -- --skip disk_tier
 	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
-		$(CARGO_ENV) cargo llvm-cov test --no-report -p anna --test consistency -- --skip disk
+		CARGO_LLVM_COV=1 \
+		$(CARGO_ENV) cargo test --target-dir target/llvm-cov-target --test consistency -- --skip disk
 	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@echo "=== C++ client system tests with Rust KVS ==="
 	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R system_tests --output-on-failure

--- a/Makefile
+++ b/Makefile
@@ -189,21 +189,21 @@ rust-kvs-tests:
 	@echo "=== Rust client tests with Rust KVS (instrumented) ==="
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
 		CARGO_LLVM_COV=1 \
-		$(CARGO_ENV) cargo test --target-dir target/llvm-cov-target --test lattice_types -- --skip disk_tier --test-threads=1
-	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
+		$(CARGO_ENV) cargo test --target-dir target/llvm-cov-target --test lattice_types -- --skip disk_tier
+	@pkill -9 -x anna-kvs 2>/dev/null; pkill -9 -x anna-kvs-rs 2>/dev/null; pkill -9 -x anna-monitor 2>/dev/null; pkill -9 -x anna-route 2>/dev/null; sleep 1; true
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
 		CARGO_LLVM_COV=1 \
 		$(CARGO_ENV) cargo test --target-dir target/llvm-cov-target --test consistency -- --skip disk
-	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
+	@pkill -9 -x anna-kvs 2>/dev/null; pkill -9 -x anna-kvs-rs 2>/dev/null; pkill -9 -x anna-monitor 2>/dev/null; pkill -9 -x anna-route 2>/dev/null; sleep 1; true
 	@echo "=== C++ client system tests with Rust KVS ==="
 	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R system_tests --output-on-failure
-	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
+	@pkill -9 -x anna-kvs 2>/dev/null; pkill -9 -x anna-kvs-rs 2>/dev/null; pkill -9 -x anna-monitor 2>/dev/null; pkill -9 -x anna-route 2>/dev/null; sleep 1; true
 	@echo "=== C++ CLI smoke test with Rust KVS ==="
 	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R CliSmokeTest --output-on-failure
-	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
+	@pkill -9 -x anna-kvs 2>/dev/null; pkill -9 -x anna-kvs-rs 2>/dev/null; pkill -9 -x anna-monitor 2>/dev/null; pkill -9 -x anna-route 2>/dev/null; sleep 1; true
 	@echo "=== Python client system tests with Rust KVS ==="
 	@cd clients/python && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs python3 -m pytest tests/test_system.py -x
-	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
+	@pkill -9 -x anna-kvs 2>/dev/null; pkill -9 -x anna-kvs-rs 2>/dev/null; pkill -9 -x anna-monitor 2>/dev/null; pkill -9 -x anna-route 2>/dev/null; sleep 1; true
 	@echo "=== Go client system tests with Rust KVS ==="
 	@cd clients/go/tests && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs go test -run TestSystem -count=1 -timeout 60s
 

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ rust-coverage-report:
 rust-monitor-tests:
 	@echo "Running monitor integration tests with Rust monitor (instrumented)"
 	@ANNA_MONITOR_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-monitor-rs \
-		cargo llvm-cov test --no-report -p anna --test monitor
+		$(CARGO_ENV) cargo llvm-cov test --no-report -p anna --test monitor
 
 # Dual-KVS testing: run all black-box / client tests against the Rust KVS.
 # These are the same tests that workspace-rust-tests, client-cpp-tests, etc.
@@ -187,10 +187,10 @@ rust-monitor-tests:
 rust-kvs-tests:
 	@echo "=== Rust client tests with Rust KVS (instrumented) ==="
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
-		cargo llvm-cov test --no-report -p anna --test lattice_types -- --skip disk_tier
+		$(CARGO_ENV) cargo llvm-cov test --no-report -p anna --test lattice_types -- --skip disk_tier
 	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs \
-		cargo llvm-cov test --no-report -p anna --test consistency -- --skip disk
+		$(CARGO_ENV) cargo llvm-cov test --no-report -p anna --test consistency -- --skip disk
 	@pkill -9 -f anna-kvs 2>/dev/null; pkill -9 -f anna-monitor 2>/dev/null; pkill -9 -f anna-route 2>/dev/null; sleep 1; true
 	@echo "=== C++ client system tests with Rust KVS ==="
 	@cd clients/cpp/build && ANNA_KVS_BIN=$(shell pwd)/target/llvm-cov-target/debug/anna-kvs-rs ctest -R system_tests --output-on-failure

--- a/clients/cpp/tests/system/test_system_runner.py
+++ b/clients/cpp/tests/system/test_system_runner.py
@@ -123,7 +123,13 @@ policy:
     for bin_name in binaries:
         override_var = env_overrides.get(bin_name)
         override_path = os.environ.get(override_var) if override_var else None
-        bin_path = override_path if override_path and os.path.exists(override_path) else os.path.join(server_dir, bin_name)
+        if override_path:
+            if not os.path.exists(override_path):
+                print(f"Error: {override_var}={override_path} does not exist")
+                sys.exit(1)
+            bin_path = override_path
+        else:
+            bin_path = os.path.join(server_dir, bin_name)
         if not os.path.exists(bin_path):
             print(f"Warning: {bin_path} not found. Skipping.")
             continue

--- a/clients/cpp/tests/system/test_system_runner.py
+++ b/clients/cpp/tests/system/test_system_runner.py
@@ -113,14 +113,25 @@ policy:
     binaries = ["anna-monitor", "anna-route", "anna-kvs"]
     procs = []
 
+    # Support ANNA_KVS_BIN override for dual-KVS testing.
+    env_overrides = {
+        "anna-kvs": "ANNA_KVS_BIN",
+        "anna-monitor": "ANNA_MONITOR_BIN",
+    }
+
     print(f"Starting servers in {server_dir}...")
     for bin_name in binaries:
-        bin_path = os.path.join(server_dir, bin_name)
+        override_var = env_overrides.get(bin_name)
+        override_path = os.environ.get(override_var) if override_var else None
+        bin_path = override_path if override_path and os.path.exists(override_path) else os.path.join(server_dir, bin_name)
         if not os.path.exists(bin_path):
             print(f"Warning: {bin_path} not found. Skipping.")
             continue
 
-        print(f"Starting {bin_name}...")
+        if override_path and os.path.exists(override_path):
+            print(f"Starting {bin_name} (override: {bin_path})...")
+        else:
+            print(f"Starting {bin_name}...")
         proc = subprocess.Popen(
             [bin_path, "--config", test_config],
             stdout=open(log_file, "a"),

--- a/clients/go/tests/system_test.go
+++ b/clients/go/tests/system_test.go
@@ -75,6 +75,11 @@ func startServers(t *testing.T) {
 
 func stopServers() {
 	annalib.Stop()
+	// Also kill override binaries (e.g., anna-kvs-rs) that annalib.Stop()
+	// won't find by the default process name.
+	for _, name := range []string{"anna-kvs-rs", "anna-monitor-rs"} {
+		exec.Command("pkill", "-9", "-f", name).Run()
+	}
 	time.Sleep(2 * time.Second)
 }
 

--- a/clients/go/tests/system_test.go
+++ b/clients/go/tests/system_test.go
@@ -19,7 +19,7 @@ func serverBinaryDir() string {
 
 func serverConfigFile() string {
 	root := filepath.Join("..", "..", "..")
-	return filepath.Join(root, "conf", "anna-config.yml")
+	return filepath.Join(root, "server", "conf", "anna-local.yml")
 }
 
 func startServers(t *testing.T) {

--- a/clients/go/tests/system_test.go
+++ b/clients/go/tests/system_test.go
@@ -33,8 +33,21 @@ func startServers(t *testing.T) {
 	path := fmt.Sprintf("%s:%s", os.Getenv("PATH"), binDir)
 	config := serverConfigFile()
 
+	// Support ANNA_KVS_BIN / ANNA_MONITOR_BIN overrides for dual testing.
+	envOverrides := map[string]string{
+		"anna-kvs":     "ANNA_KVS_BIN",
+		"anna-monitor": "ANNA_MONITOR_BIN",
+	}
 	for _, proc := range []string{"anna-monitor", "anna-route", "anna-kvs"} {
-		cmd := exec.Command(proc, "--config", config)
+		binPath := proc
+		if envVar, ok := envOverrides[proc]; ok {
+			if override := os.Getenv(envVar); override != "" {
+				if _, err := os.Stat(override); err == nil {
+					binPath = override
+				}
+			}
+		}
+		cmd := exec.Command(binPath, "--config", config)
 		cmd.Env = append(os.Environ(), "PATH="+path)
 		if err := cmd.Start(); err != nil {
 			stopServers()

--- a/clients/go/tests/system_test.go
+++ b/clients/go/tests/system_test.go
@@ -75,10 +75,11 @@ func startServers(t *testing.T) {
 
 func stopServers() {
 	annalib.Stop()
-	// Also kill override binaries (e.g., anna-kvs-rs) that annalib.Stop()
-	// won't find by the default process name.
+	// Also kill override binaries by exact process name (-x), not by
+	// command line match (-f), to avoid killing make/cargo/shell processes
+	// that have ANNA_KVS_BIN in their environment.
 	for _, name := range []string{"anna-kvs-rs", "anna-monitor-rs"} {
-		exec.Command("pkill", "-9", "-f", name).Run()
+		exec.Command("pkill", "-9", "-x", name).Run()
 	}
 	time.Sleep(2 * time.Second)
 }

--- a/clients/go/tests/system_test.go
+++ b/clients/go/tests/system_test.go
@@ -42,9 +42,10 @@ func startServers(t *testing.T) {
 		binPath := proc
 		if envVar, ok := envOverrides[proc]; ok {
 			if override := os.Getenv(envVar); override != "" {
-				if _, err := os.Stat(override); err == nil {
-					binPath = override
+				if _, err := os.Stat(override); err != nil {
+					t.Fatalf("%s=%s does not exist: %v", envVar, override, err)
 				}
+				binPath = override
 			}
 		}
 		cmd := exec.Command(binPath, "--config", config)

--- a/clients/go/tests/system_test.go
+++ b/clients/go/tests/system_test.go
@@ -39,7 +39,7 @@ func startServers(t *testing.T) {
 		"anna-monitor": "ANNA_MONITOR_BIN",
 	}
 	for _, proc := range []string{"anna-monitor", "anna-route", "anna-kvs"} {
-		binPath := proc
+		binPath := filepath.Join(binDir, proc)
 		if envVar, ok := envOverrides[proc]; ok {
 			if override := os.Getenv(envVar); override != "" {
 				if _, err := os.Stat(override); err != nil {

--- a/clients/python/tests/test_system.py
+++ b/clients/python/tests/test_system.py
@@ -89,8 +89,13 @@ def live_server(tmp_path_factory):
     log_path = str(work_dir / "server.log")
     procs = []
 
+    # Support ANNA_KVS_BIN / ANNA_MONITOR_BIN overrides for dual testing.
+    env_overrides = {"anna-kvs": "ANNA_KVS_BIN", "anna-monitor": "ANNA_MONITOR_BIN"}
     for name in ["anna-monitor", "anna-route", "anna-kvs"]:
-        bin_path = os.path.join(server_dir, name)
+        override = os.environ.get(env_overrides.get(name, ""))
+        bin_path = override if override and os.path.exists(override) else os.path.join(server_dir, name)
+        if not os.path.exists(bin_path):
+            pytest.skip(f"Server binary {bin_path} not found")
         proc = subprocess.Popen(
             [bin_path, "--config", config_path],
             stdout=open(log_path, "a"),

--- a/clients/python/tests/test_system.py
+++ b/clients/python/tests/test_system.py
@@ -93,7 +93,12 @@ def live_server(tmp_path_factory):
     env_overrides = {"anna-kvs": "ANNA_KVS_BIN", "anna-monitor": "ANNA_MONITOR_BIN"}
     for name in ["anna-monitor", "anna-route", "anna-kvs"]:
         override = os.environ.get(env_overrides.get(name, ""))
-        bin_path = override if override and os.path.exists(override) else os.path.join(server_dir, name)
+        if override:
+            if not os.path.exists(override):
+                pytest.fail(f"{env_overrides[name]}={override} does not exist")
+            bin_path = override
+        else:
+            bin_path = os.path.join(server_dir, name)
         if not os.path.exists(bin_path):
             pytest.skip(f"Server binary {bin_path} not found")
         proc = subprocess.Popen(

--- a/clients/rust/tests/common/mod.rs
+++ b/clients/rust/tests/common/mod.rs
@@ -143,18 +143,25 @@ pub fn wait_for_routing(base_offset: u16) {
 }
 
 /// Resolve the binary path for a server component, checking for
-/// ANNA_MONITOR_BIN override for the monitor binary.
+/// Resolve the binary path for a server component, checking for
+/// ANNA_MONITOR_BIN and ANNA_KVS_BIN overrides.
 pub fn resolve_server_binary(name: &str, default_dir: &Path) -> PathBuf {
-    if name == "anna-monitor" {
-        if let Ok(alt) = std::env::var("ANNA_MONITOR_BIN") {
+    let env_var = match name {
+        "anna-monitor" => Some("ANNA_MONITOR_BIN"),
+        "anna-kvs" => Some("ANNA_KVS_BIN"),
+        _ => None,
+    };
+
+    if let Some(var) = env_var {
+        if let Ok(alt) = std::env::var(var) {
             let alt_bin = PathBuf::from(&alt);
             if alt_bin.exists() {
-                eprintln!("Using Rust monitor binary: {}", alt_bin.display());
+                eprintln!("Using override binary for {}: {}", name, alt_bin.display());
                 return alt_bin;
             }
             eprintln!(
-                "WARNING: ANNA_MONITOR_BIN={} not found, falling back to C++ monitor",
-                alt
+                "WARNING: {}={} not found, falling back to C++ {}",
+                var, alt, name
             );
         }
     }

--- a/clients/rust/tests/common/mod.rs
+++ b/clients/rust/tests/common/mod.rs
@@ -200,6 +200,25 @@ impl ServerGuard {
                 .env("PATH", &extra_path)
                 .stdout(Stdio::null())
                 .stderr(Stdio::null());
+            // Forward LLVM coverage profiling to subprocess so integration
+            // test coverage of server binaries is captured.
+            // Forward LLVM coverage profiling to subprocess so integration
+            // test coverage of server binaries is captured.
+            if std::env::var("CARGO_LLVM_COV").is_ok() || std::env::var("LLVM_PROFILE_FILE").is_ok()
+            {
+                // Use absolute path — subprocess working dir may differ.
+                let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+                let profraw_dir = manifest_dir.join("../../target/llvm-cov-target");
+                cmd.env(
+                    "LLVM_PROFILE_FILE",
+                    profraw_dir.join(format!(
+                        "{}-{}-{}.profraw",
+                        name,
+                        base_offset,
+                        std::process::id()
+                    )),
+                );
+            }
             if name == "anna-kvs" {
                 if let Some(st) = server_type {
                     cmd.env("SERVER_TYPE", st);

--- a/clients/rust/tests/lattice_types.rs
+++ b/clients/rust/tests/lattice_types.rs
@@ -537,10 +537,11 @@ async fn ttl_stress_many_keys() {
 
     let key_count = 50;
 
-    // PUT many keys with 2-second TTL
+    // PUT many keys with 5-second TTL (must be long enough for all PUTs
+    // and GETs to complete before expiry, even on loaded CI runners).
     for i in 0..key_count {
         client
-            .put_with_ttl(&format!("stress_{}", i), &format!("val_{}", i), 2)
+            .put_with_ttl(&format!("stress_{}", i), &format!("val_{}", i), 5)
             .await
             .unwrap_or_else(|e| panic!("PUT_TTL stress_{} failed: {}", i, e));
     }
@@ -555,7 +556,7 @@ async fn ttl_stress_many_keys() {
     }
 
     // Wait for expiry
-    tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(7)).await;
 
     // Fresh client — verify all expired
     let mut client2 = KVSClient::new(&config, Some(8)).await;

--- a/clients/rust/tests/multi_node.rs
+++ b/clients/rust/tests/multi_node.rs
@@ -183,6 +183,17 @@ fn spawn_server_with_env(
         .env("PATH", extra_path)
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    // Forward LLVM coverage profiling to subprocess.
+    if std::env::var("CARGO_LLVM_COV").is_ok() || std::env::var("LLVM_PROFILE_FILE").is_ok() {
+        cmd.env(
+            "LLVM_PROFILE_FILE",
+            format!(
+                "target/llvm-cov-target/{}-mn-{}.profraw",
+                name,
+                std::process::id()
+            ),
+        );
+    }
     for (k, v) in env_vars {
         cmd.env(k, v);
     }

--- a/server/rust/anna-kvs/src/handlers/replication_change.rs
+++ b/server/rust/anna-kvs/src/handlers/replication_change.rs
@@ -172,6 +172,152 @@ mod tests {
     use super::*;
     use anna_server_common::proto::metadata::ReplicationFactor;
 
+    use crate::storage::memory::LwwSerializer;
+    use anna_server_common::metadata::KeyProperty;
+    use anna_server_common::proto::kvs::LatticeType;
+
+    fn ctx_with_stored_key(key: &str) -> KvsContext {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        ctx.serializers
+            .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
+        // Store a key.
+        let mut kp = KeyProperty::default();
+        kp.set_size(10);
+        kp.set_type(LatticeType::Lww);
+        ctx.stored_key_map.insert(key.to_string(), kp);
+        // Set replication factor.
+        let mut kr = anna_server_common::metadata::KeyReplication::default();
+        kr.global_replication.insert(Tier::Memory, 1);
+        kr.local_replication.insert(Tier::Memory, 1);
+        ctx.key_replication_map.insert(key.to_string(), kr);
+        ctx
+    }
+
+    #[test]
+    fn thread0_relays_to_workers() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        ctx.thread_id = 0;
+        ctx.thread_count = 3;
+        let update = ReplicationFactorUpdate {
+            updates: vec![ReplicationFactor {
+                key: "k".into(),
+                global: vec![ReplicationValue {
+                    tier: Tier::Memory as i32,
+                    value: 1,
+                }],
+                local: vec![],
+            }],
+        };
+        let msgs = handle(&mut ctx, &update.encode_to_vec());
+        // Should relay to threads 1 and 2.
+        assert_eq!(msgs.len(), 2);
+    }
+
+    #[test]
+    fn decode_failure_returns_early() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let msgs = handle(&mut ctx, b"garbage");
+        // Only relay messages (if thread 0), no crash.
+        assert!(msgs.is_empty() || msgs.iter().all(|(_, d)| d == b"garbage"));
+    }
+
+    #[test]
+    fn stored_key_replication_update() {
+        let mut ctx = ctx_with_stored_key("stored_k");
+        let update = ReplicationFactorUpdate {
+            updates: vec![ReplicationFactor {
+                key: "stored_k".into(),
+                global: vec![ReplicationValue {
+                    tier: Tier::Memory as i32,
+                    value: 2,
+                }],
+                local: vec![ReplicationValue {
+                    tier: Tier::Memory as i32,
+                    value: 1,
+                }],
+            }],
+        };
+        let _ = handle(&mut ctx, &update.encode_to_vec());
+        assert_eq!(
+            ctx.key_replication_map["stored_k"].global_replication[&Tier::Memory],
+            2
+        );
+    }
+
+    #[test]
+    fn replication_decrement_removes_key() {
+        let mut ctx = ctx_with_stored_key("dec_k");
+        // Add a second node so the key can move.
+        ctx.global_hash_rings
+            .get_mut(&Tier::Memory)
+            .unwrap()
+            .insert(
+                "2.2.2.2",
+                "10.0.0.2",
+                0,
+                0,
+                anna_server_common::hash_ring::DEFAULT_VIRTUAL_THREAD_NUM,
+                true,
+            );
+        // Set high replication so we're initially responsible.
+        ctx.key_replication_map
+            .get_mut("dec_k")
+            .unwrap()
+            .global_replication
+            .insert(Tier::Memory, 2);
+
+        let update = ReplicationFactorUpdate {
+            updates: vec![ReplicationFactor {
+                key: "dec_k".into(),
+                global: vec![ReplicationValue {
+                    tier: Tier::Memory as i32,
+                    value: 1, // decrease
+                }],
+                local: vec![],
+            }],
+        };
+        let _ = handle(&mut ctx, &update.encode_to_vec());
+        // Key may have been removed if no longer responsible.
+        // Either stored or removed — both are valid outcomes depending on hash.
+    }
+
+    #[test]
+    fn invalid_tier_ignored() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let update = ReplicationFactorUpdate {
+            updates: vec![ReplicationFactor {
+                key: "bad_tier_k".into(),
+                global: vec![ReplicationValue { tier: 99, value: 1 }],
+                local: vec![],
+            }],
+        };
+        let _ = handle(&mut ctx, &update.encode_to_vec());
+        // No crash, no entry for invalid tier.
+        if let Some(kr) = ctx.key_replication_map.get("bad_tier_k") {
+            assert!(kr.global_replication.is_empty());
+        }
+    }
+
+    #[test]
+    fn local_replication_update() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let update = ReplicationFactorUpdate {
+            updates: vec![ReplicationFactor {
+                key: "local_k".into(),
+                global: vec![],
+                local: vec![ReplicationValue {
+                    tier: Tier::Memory as i32,
+                    value: 3,
+                }],
+            }],
+        };
+        let _ = handle(&mut ctx, &update.encode_to_vec());
+        assert_eq!(
+            ctx.key_replication_map["local_k"].local_replication[&Tier::Memory],
+            3
+        );
+    }
+
     #[test]
     fn updates_replication_factor() {
         let mut ctx = crate::context::tests::make_test_ctx();

--- a/server/rust/anna-kvs/src/handlers/replication_change.rs
+++ b/server/rust/anna-kvs/src/handlers/replication_change.rs
@@ -277,8 +277,11 @@ mod tests {
             }],
         };
         let _ = handle(&mut ctx, &update.encode_to_vec());
-        // Key may have been removed if no longer responsible.
-        // Either stored or removed — both are valid outcomes depending on hash.
+        // Replication factor should be updated to 1.
+        assert_eq!(
+            ctx.key_replication_map["dec_k"].global_replication[&Tier::Memory],
+            1
+        );
     }
 
     #[test]

--- a/server/rust/anna-kvs/src/handlers/replication_response.rs
+++ b/server/rust/anna-kvs/src/handlers/replication_response.rs
@@ -282,6 +282,167 @@ mod tests {
     }
 
     #[test]
+    fn decode_failure_returns_empty() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let msgs = handle(&mut ctx, b"garbage");
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn empty_tuples_returns_empty() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let response = KeyResponse::default();
+        let msgs = handle(&mut ctx, &response.encode_to_vec());
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn bad_metadata_key_returns_empty() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let response = KeyResponse {
+            tuples: vec![KeyTuple {
+                key: "not_metadata".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let msgs = handle(&mut ctx, &response.encode_to_vec());
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn wrong_thread_returns_empty() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let response = KeyResponse {
+            tuples: vec![KeyTuple {
+                key: "ANNA_METADATA|replication|wt_key".into(),
+                error: AnnaError::WrongThread as i32,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let msgs = handle(&mut ctx, &response.encode_to_vec());
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn unexpected_error_returns_empty() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let response = KeyResponse {
+            tuples: vec![KeyTuple {
+                key: "ANNA_METADATA|replication|err_key".into(),
+                error: 99,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let msgs = handle(&mut ctx, &response.encode_to_vec());
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn pending_get_returns_value() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        ctx.serializers
+            .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
+
+        // Store a value first.
+        let lww_val = LwwValue {
+            timestamp: 1,
+            value: b"stored".to_vec(),
+        };
+        if let Some(s) = ctx.serializers.get_mut(&(LatticeType::Lww as i32)) {
+            crate::handlers::utils::process_put(
+                "get_key",
+                LatticeType::Lww,
+                &lww_val.encode_to_vec(),
+                s.as_mut(),
+                &mut ctx.stored_key_map,
+                0,
+            );
+        }
+
+        // Add a pending GET.
+        ctx.pending_requests.insert(
+            "get_key".into(),
+            vec![PendingRequest {
+                r#type: RequestType::Get as i32,
+                lattice_type: LatticeType::Lww as i32,
+                payload: vec![],
+                addr: "tcp://127.0.0.1:9999".into(),
+                response_id: "req_1".into(),
+                expiry_epoch_ms: 0,
+            }],
+        );
+
+        let data = make_rep_response("get_key", 1);
+        let msgs = handle(&mut ctx, &data);
+        assert!(!msgs.is_empty());
+        // Response should go to the client address.
+        assert!(msgs.iter().any(|(addr, _)| addr == "tcp://127.0.0.1:9999"));
+    }
+
+    #[test]
+    fn pending_not_responsible_sends_wrong_thread() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        // Add a second node and set replication=1 so we might not be responsible.
+        ctx.global_hash_rings
+            .get_mut(&Tier::Memory)
+            .unwrap()
+            .insert(
+                "2.2.2.2",
+                "10.0.0.2",
+                0,
+                0,
+                anna_server_common::hash_ring::DEFAULT_VIRTUAL_THREAD_NUM,
+                true,
+            );
+
+        ctx.pending_requests.insert(
+            "remote_key".into(),
+            vec![PendingRequest {
+                r#type: RequestType::Get as i32,
+                lattice_type: LatticeType::Lww as i32,
+                payload: vec![],
+                addr: "tcp://127.0.0.1:9999".into(),
+                response_id: "req_2".into(),
+                expiry_epoch_ms: 0,
+            }],
+        );
+
+        let data = make_rep_response("remote_key", 1);
+        let msgs = handle(&mut ctx, &data);
+        // Either WRONG_THREAD response or processed — depends on hash.
+        assert!(!ctx.pending_requests.contains_key("remote_key"));
+    }
+
+    #[test]
+    fn pending_gossip_applied_when_responsible() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        ctx.serializers
+            .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
+
+        let lww = LwwValue {
+            timestamp: 1,
+            value: b"gossip_val".to_vec(),
+        };
+        ctx.pending_gossip.insert(
+            "gossip_k".into(),
+            vec![crate::context::PendingGossip {
+                lattice_type: LatticeType::Lww as i32,
+                payload: lww.encode_to_vec(),
+                expiry_epoch_ms: 0,
+            }],
+        );
+
+        let data = make_rep_response("gossip_k", 1);
+        let _ = handle(&mut ctx, &data);
+
+        assert!(!ctx.pending_gossip.contains_key("gossip_k"));
+        assert!(ctx.stored_key_map.contains_key("gossip_k"));
+    }
+
+    #[test]
     fn updates_replication_map() {
         let mut ctx = crate::context::tests::make_test_ctx();
         let data = make_rep_response("my_key", 2);

--- a/server/rust/anna-kvs/src/handlers/replication_response.rs
+++ b/server/rust/anna-kvs/src/handlers/replication_response.rs
@@ -212,6 +212,10 @@ fn process_pending_request(
             Some(kp) if kp.lattice_type() == LatticeType::None => {
                 tp.error = AnnaError::KeyDne as i32;
             }
+            Some(kp) if kp.size() == 0 => {
+                // Tombstone (deleted key).
+                tp.error = AnnaError::KeyDne as i32;
+            }
             Some(kp) => {
                 let lt = kp.lattice_type();
                 if let Some(serializer) = ctx.serializers.get(&(lt as i32)) {

--- a/server/rust/anna-kvs/src/handlers/self_depart.rs
+++ b/server/rust/anna-kvs/src/handlers/self_depart.rs
@@ -118,6 +118,114 @@ mod tests {
     use super::*;
     use anna_server_common::metadata::Tier;
 
+    use crate::storage::memory::LwwSerializer;
+    use anna_server_common::metadata::KeyProperty;
+    use anna_server_common::proto::kvs::LatticeType;
+
+    #[test]
+    fn notifies_routing_and_monitoring() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        ctx.routing_ips = vec!["10.0.0.5".into()];
+        ctx.monitoring_ips = vec!["10.0.0.6".into()];
+        let msgs = handle(&mut ctx, "tcp://monitor:6450");
+
+        // Should contain depart notification to routing.
+        assert!(msgs.iter().any(|(addr, _)| addr.contains("10.0.0.5")));
+        // Should contain depart notification to monitoring.
+        assert!(msgs.iter().any(|(addr, _)| addr.contains("10.0.0.6")));
+    }
+
+    #[test]
+    fn relays_to_worker_threads() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        ctx.thread_count = 3;
+        let msgs = handle(&mut ctx, "tcp://monitor:6450");
+
+        // Should relay to threads 1 and 2 (ports 6101, 6102).
+        let relay_count = msgs
+            .iter()
+            .filter(|(addr, _)| addr.contains("610")) // SELF_DEPART_PORT range
+            .count();
+        assert!(
+            relay_count >= 2,
+            "Expected at least 2 relays, got {}",
+            relay_count
+        );
+    }
+
+    #[test]
+    fn non_thread0_skips_notifications() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        ctx.thread_id = 1;
+        ctx.routing_ips = vec!["10.0.0.5".into()];
+        ctx.monitoring_ips = vec!["10.0.0.6".into()];
+        let msgs = handle(&mut ctx, "tcp://monitor:6450");
+
+        // Thread 1 should NOT notify routing/monitoring.
+        assert!(!msgs.iter().any(|(addr, _)| addr.contains("10.0.0.5")));
+        assert!(!msgs.iter().any(|(addr, _)| addr.contains("10.0.0.6")));
+        // But should still send depart-done.
+        assert!(msgs.iter().any(|(addr, _)| addr == "tcp://monitor:6450"));
+    }
+
+    #[test]
+    fn gossips_stored_data() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        ctx.serializers
+            .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
+
+        // Store a key.
+        let mut kp = KeyProperty::default();
+        kp.set_size(10);
+        kp.set_type(LatticeType::Lww);
+        ctx.stored_key_map.insert("depart_key".into(), kp);
+
+        let mut kr = anna_server_common::metadata::KeyReplication::default();
+        kr.global_replication.insert(Tier::Memory, 1);
+        kr.local_replication.insert(Tier::Memory, 1);
+        ctx.key_replication_map.insert("depart_key".into(), kr);
+
+        // Add a second node so gossip has a target.
+        ctx.global_hash_rings
+            .get_mut(&Tier::Memory)
+            .unwrap()
+            .insert(
+                "2.2.2.2",
+                "10.0.0.2",
+                0,
+                0,
+                anna_server_common::hash_ring::DEFAULT_VIRTUAL_THREAD_NUM,
+                true,
+            );
+
+        // Put actual data in serializer.
+        let lww = anna_server_common::proto::kvs::LwwValue {
+            timestamp: 1,
+            value: b"depart_val".to_vec(),
+        };
+        if let Some(s) = ctx.serializers.get_mut(&(LatticeType::Lww as i32)) {
+            s.put("depart_key", &prost::Message::encode_to_vec(&lww));
+        }
+
+        let msgs = handle(&mut ctx, "tcp://monitor:6450");
+
+        // Should have gossip messages (to remaining node) + depart-done.
+        assert!(msgs.len() >= 2);
+    }
+
+    #[test]
+    fn depart_done_message_format() {
+        let mut ctx = crate::context::tests::make_test_ctx();
+        let msgs = handle(&mut ctx, "tcp://monitor:6450");
+        let done = msgs
+            .iter()
+            .find(|(addr, _)| addr == "tcp://monitor:6450")
+            .unwrap();
+        let done_str = String::from_utf8_lossy(&done.1);
+        // Format: public_ip_private_ip_tier
+        assert!(done_str.contains("1.1.1.1_1.1.1.1_1"));
+    }
+
     #[test]
     fn removes_self_from_ring() {
         let mut ctx = crate::context::tests::make_test_ctx();

--- a/server/rust/anna-kvs/src/handlers/self_depart.rs
+++ b/server/rust/anna-kvs/src/handlers/self_depart.rs
@@ -209,8 +209,27 @@ mod tests {
 
         let msgs = handle(&mut ctx, "tcp://monitor:6450");
 
-        // Should have gossip messages (to remaining node) + depart-done.
-        assert!(msgs.len() >= 2);
+        // Should have depart-done message.
+        assert!(msgs.iter().any(|(addr, _)| addr == "tcp://monitor:6450"));
+
+        // Should have gossip to the remaining node's gossip address.
+        let gossip_addr =
+            anna_server_common::threads::ServerThread::new("2.2.2.2", "10.0.0.2", 0, 0)
+                .gossip_connect_address();
+        let gossip_msg = msgs.iter().find(|(addr, _)| addr == &gossip_addr);
+        assert!(
+            gossip_msg.is_some(),
+            "Expected gossip to remaining node at {}, got addrs: {:?}",
+            gossip_addr,
+            msgs.iter().map(|(a, _)| a).collect::<Vec<_>>()
+        );
+        // Verify the gossip payload contains depart_key.
+        let payload = &gossip_msg.unwrap().1;
+        let payload_str = String::from_utf8_lossy(payload);
+        assert!(
+            payload_str.contains("depart_key") || payload.len() > 10,
+            "Gossip payload should contain key data"
+        );
     }
 
     #[test]

--- a/server/rust/anna-kvs/src/handlers/user_request.rs
+++ b/server/rust/anna-kvs/src/handlers/user_request.rs
@@ -93,8 +93,42 @@ pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> 
                 }
             }
             ResponsibleResult::NeedReplicationFactor(_) => {
-                // Issue a replication factor request so the pending
-                // request can be drained when the response arrives.
+                // Initialize with defaults and retry immediately — avoids
+                // round-trip through the replication response handler for
+                // every new key.
+                anna_server_common::metadata::init_replication(
+                    &mut ctx.key_replication_map,
+                    &key.to_string(),
+                    &ctx.tier_metadata,
+                    ctx.default_local_replication,
+                );
+                // Retry routing with defaults now populated.
+                let retry = get_responsible_threads(
+                    key,
+                    is_meta,
+                    &ctx.global_hash_rings,
+                    &ctx.local_hash_rings,
+                    &ctx.key_replication_map,
+                    ctx.metadata_replication_factor,
+                    ctx.default_local_replication,
+                );
+                if let ResponsibleResult::Ok(ref threads) = retry {
+                    let am_responsible =
+                        is_own_metadata || threads.iter().any(|t| *t == ctx.wt);
+                    if am_responsible {
+                        let tp = process_tuple(ctx, key, tuple, request_type, threads);
+                        response.tuples.push(tp);
+                        ctx.key_access_tracker
+                            .entry(key.clone())
+                            .or_default()
+                            .insert(Instant::now());
+                        ctx.access_count += 1;
+                        continue; // Skip the pending path.
+                    }
+                }
+
+                // Still not responsible after defaults — issue a replication
+                // factor request so the pending request can be drained.
                 if let Some((target, rep_key)) = replication_request_target(
                     key,
                     &ctx.global_hash_rings,
@@ -350,21 +384,22 @@ mod tests {
     }
 
     #[test]
-    fn request_without_rep_factor_goes_pending() {
+    fn request_without_rep_factor_uses_defaults() {
         let mut ctx = crate::context::tests::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
-        // No replication factor for "pending_key".
+        // No replication factor — handler should init with defaults and process.
 
-        let data = make_get_request("pending_key");
-        let msgs = handle(&mut ctx, &data);
+        // PUT a value first so GET can find it.
+        let put_data = make_put_request("default_key", 1, b"value");
+        let _ = handle(&mut ctx, &put_data);
 
-        // Request is pending, and a replication factor request is sent.
-        assert!(ctx.pending_requests.contains_key("pending_key"));
-        // The outgoing messages include the rep factor request (no client response).
-        assert!(
-            msgs.iter().all(|(addr, _)| !addr.contains("6600")),
-            "Should not send client response, only rep factor request"
-        );
+        // GET should succeed using default replication.
+        let get_data = make_get_request("default_key");
+        let msgs = handle(&mut ctx, &get_data);
+        assert!(!msgs.is_empty(), "Should get a response with defaults");
+
+        // Replication map should have defaults now.
+        assert!(ctx.key_replication_map.contains_key("default_key"));
     }
 }

--- a/server/rust/anna-kvs/src/handlers/user_request.rs
+++ b/server/rust/anna-kvs/src/handlers/user_request.rs
@@ -113,8 +113,7 @@ pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> 
                     ctx.default_local_replication,
                 );
                 if let ResponsibleResult::Ok(ref threads) = retry {
-                    let am_responsible =
-                        is_own_metadata || threads.iter().any(|t| *t == ctx.wt);
+                    let am_responsible = is_own_metadata || threads.iter().any(|t| *t == ctx.wt);
                     if am_responsible {
                         let tp = process_tuple(ctx, key, tuple, request_type, threads);
                         response.tuples.push(tp);

--- a/server/rust/anna-kvs/src/handlers/user_request.rs
+++ b/server/rust/anna-kvs/src/handlers/user_request.rs
@@ -8,7 +8,9 @@ use anna_server_common::metadata::is_metadata;
 use anna_server_common::proto::kvs::{
     AnnaError, KeyRequest, KeyResponse, KeyTuple, LatticeType, RequestType,
 };
-use anna_server_common::routing::{get_responsible_threads, ResponsibleResult};
+use anna_server_common::routing::{
+    get_responsible_threads, replication_request_target, ResponsibleResult,
+};
 use prost::Message;
 
 use crate::context::{KvsContext, OutgoingMessage, PendingRequest};
@@ -30,6 +32,7 @@ pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> 
         ..Default::default()
     };
 
+    let mut outgoing: Vec<OutgoingMessage> = Vec::new();
     let request_type = request.r#type;
     let response_address = request.response_address.clone();
 
@@ -90,6 +93,33 @@ pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> 
                 }
             }
             ResponsibleResult::NeedReplicationFactor(_) => {
+                // Issue a replication factor request so the pending
+                // request can be drained when the response arrives.
+                if let Some((target, rep_key)) = replication_request_target(
+                    key,
+                    &ctx.global_hash_rings,
+                    &ctx.local_hash_rings,
+                    ctx.metadata_replication_factor,
+                    ctx.default_local_replication,
+                ) {
+                    let rep_req = KeyRequest {
+                        request_id: format!("rep_{}_{}", ctx.rid, key),
+                        response_address: ctx.wt.replication_response_connect_address(),
+                        r#type: RequestType::Get as i32,
+                        tuples: vec![KeyTuple {
+                            key: rep_key,
+                            lattice_type: LatticeType::Lww as i32,
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    };
+                    ctx.rid += 1;
+                    outgoing.push((
+                        target.key_request_connect_address(),
+                        rep_req.encode_to_vec(),
+                    ));
+                }
+
                 ctx.pending_requests
                     .entry(key.clone())
                     .or_default()
@@ -106,10 +136,9 @@ pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> 
     }
 
     if !response.tuples.is_empty() && !response_address.is_empty() {
-        vec![(response_address, response.encode_to_vec())]
-    } else {
-        vec![]
+        outgoing.push((response_address, response.encode_to_vec()));
     }
+    outgoing
 }
 
 /// Process a single key tuple (GET or PUT).
@@ -135,6 +164,11 @@ fn process_tuple(
                 tp.error = AnnaError::KeyDne as i32;
             }
             Some(kp) if kp.expiry_epoch_s > 0 && now_epoch_s() >= kp.expiry_epoch_s => {
+                // Expired (TTL or tombstone past GC threshold).
+                tp.error = AnnaError::KeyDne as i32;
+            }
+            Some(kp) if kp.size() == 0 => {
+                // Tombstone (deleted key, not yet GC'd).
                 tp.error = AnnaError::KeyDne as i32;
             }
             Some(kp) => {
@@ -325,8 +359,12 @@ mod tests {
         let data = make_get_request("pending_key");
         let msgs = handle(&mut ctx, &data);
 
-        // No response sent (request is pending).
-        assert!(msgs.is_empty());
+        // Request is pending, and a replication factor request is sent.
         assert!(ctx.pending_requests.contains_key("pending_key"));
+        // The outgoing messages include the rep factor request (no client response).
+        assert!(
+            msgs.iter().all(|(addr, _)| !addr.contains("6600")),
+            "Should not send client response, only rep factor request"
+        );
     }
 }

--- a/server/rust/anna-kvs/src/kvs_server.rs
+++ b/server/rust/anna-kvs/src/kvs_server.rs
@@ -262,7 +262,7 @@ pub async fn run(
         let topology = anna_server_common::proto::metadata::ClusterTopology {
             memory_thread_count: config.threads.memory,
             disk_thread_count: config.threads.disk,
-            ..Default::default()
+            routing_thread_count: config.threads.routing,
         };
         let topo_payload = topology.encode_to_vec();
         let ts = handlers::utils::generate_timestamp(0);

--- a/server/rust/anna-kvs/src/kvs_server.rs
+++ b/server/rust/anna-kvs/src/kvs_server.rs
@@ -223,6 +223,101 @@ pub async fn run(
     let mut gc_start = Instant::now();
     let mut report_start = Instant::now();
 
+    // ── Store initial membership metadata (thread 0 only) ──
+    // Clients using direct routing need this metadata immediately.
+    if thread_id == 0 {
+        use anna_server_common::proto::kvs::LatticeType;
+        use anna_server_common::proto::shared::StringSet;
+
+        // kvs_members
+        let mut members_set = StringSet::default();
+        for ring in ctx_state.global_hash_rings.values() {
+            for st in ring.get_unique_servers() {
+                members_set
+                    .keys
+                    .push(format!("{}/{}", st.public_ip(), st.private_ip()));
+            }
+        }
+        if !members_set.keys.is_empty() {
+            let members_payload = members_set.encode_to_vec();
+            let ts = handlers::utils::generate_timestamp(0);
+            let lww = anna_server_common::proto::kvs::LwwValue {
+                timestamp: ts,
+                value: members_payload,
+            };
+            let key = "ANNA_METADATA|kvs_members";
+            if let Some(s) = ctx_state.serializers.get_mut(&(LatticeType::Lww as i32)) {
+                handlers::utils::process_put(
+                    key,
+                    LatticeType::Lww,
+                    &lww.encode_to_vec(),
+                    s.as_mut(),
+                    &mut ctx_state.stored_key_map,
+                    0,
+                );
+            }
+        }
+
+        // cluster_topology
+        let topology = anna_server_common::proto::metadata::ClusterTopology {
+            memory_thread_count: config.threads.memory,
+            disk_thread_count: config.threads.disk,
+            ..Default::default()
+        };
+        let topo_payload = topology.encode_to_vec();
+        let ts = handlers::utils::generate_timestamp(0);
+        let lww = anna_server_common::proto::kvs::LwwValue {
+            timestamp: ts,
+            value: topo_payload,
+        };
+        let key = "ANNA_METADATA|cluster_topology";
+        if let Some(s) = ctx_state.serializers.get_mut(&(LatticeType::Lww as i32)) {
+            handlers::utils::process_put(
+                key,
+                LatticeType::Lww,
+                &lww.encode_to_vec(),
+                s.as_mut(),
+                &mut ctx_state.stored_key_map,
+                0,
+            );
+        }
+
+        log::info!("[{}] Stored initial membership metadata", log_name);
+    }
+
+    // ── Startup notifications (thread 0 only) ──
+    if thread_id == 0 {
+        let tier_name = match self_tier {
+            Tier::Memory => "MEMORY",
+            Tier::Disk => "DISK",
+            _ => "MEMORY",
+        };
+        let join_msg = format!(
+            "join:{}:{}:{}:{}",
+            tier_name, public_ip, private_ip, self_join_count
+        );
+
+        // Notify routing nodes.
+        for addr in &ctx_state.routing_ips {
+            let target = anna_server_common::threads::RoutingThread::new(addr, 0, base_offset)
+                .notify_connect_address();
+            if let Err(e) = pushers.send(&target, join_msg.as_bytes()).await {
+                log::warn!("[{}] Failed to notify routing {}: {}", log_name, addr, e);
+            }
+        }
+
+        // Notify monitoring nodes.
+        for addr in &ctx_state.monitoring_ips {
+            let target = anna_server_common::threads::MonitoringThread::new(addr, base_offset)
+                .notify_connect_address();
+            if let Err(e) = pushers.send(&target, join_msg.as_bytes()).await {
+                log::warn!("[{}] Failed to notify monitoring {}: {}", log_name, addr, e);
+            }
+        }
+
+        log::info!("[{}] Sent join notifications", log_name);
+    }
+
     log::info!("[{}] Entering event loop", log_name);
 
     // ── Event loop ──
@@ -258,9 +353,15 @@ pub async fn run(
                 } else {
                     handlers::user_request::handle(&mut ctx_state, &data)
                 };
+                log::debug!(
+                    "[{}] Handler produced {} outgoing messages",
+                    log_name,
+                    msgs.len()
+                );
                 for (addr, d) in &msgs {
-                    let _ = pushers.send(addr, d).await;
+                    if let Err(e) = pushers.send(addr, d).await {}
                 }
+            } else {
             }
         }
 

--- a/server/rust/anna-kvs/src/storage/memory.rs
+++ b/server/rust/anna-kvs/src/storage/memory.rs
@@ -66,7 +66,15 @@ impl Serializer for LwwSerializer {
 
     fn get(&self, key: &str) -> GetResult {
         match self.store.get(key) {
-            Some(v) => (v.clone(), 0),
+            Some(v) => {
+                // Check for tombstone: LWW with empty value.
+                if let Ok(lww) = LwwValue::decode(v.as_slice()) {
+                    if lww.value.is_empty() {
+                        return (vec![], 1); // KEY_DNE (tombstone)
+                    }
+                }
+                (v.clone(), 0)
+            }
             None => (vec![], 1), // KEY_DNE
         }
     }

--- a/server/rust/anna-kvs/src/storage/memory.rs
+++ b/server/rust/anna-kvs/src/storage/memory.rs
@@ -101,7 +101,7 @@ impl SetSerializer {
 impl Serializer for SetSerializer {
     fn put(&mut self, key: &str, payload: &[u8]) -> usize {
         let new = SetValue::decode(payload).unwrap_or_default();
-        let merged = if let Some(existing) = self.store.get(key) {
+        let mut merged = if let Some(existing) = self.store.get(key) {
             let mut old = SetValue::decode(existing.as_slice()).unwrap_or_default();
             // Union merge: add all new values to old.
             for v in new.values {
@@ -113,6 +113,9 @@ impl Serializer for SetSerializer {
         } else {
             new
         };
+        // Sort values for deterministic ordering (required for OrderedSet
+        // lattice type which shares this serializer).
+        merged.values.sort();
         let encoded = merged.encode_to_vec();
         let size = encoded.len();
         self.store.insert(key.to_string(), encoded);

--- a/tests/shared/cli/run_smoke_test.py
+++ b/tests/shared/cli/run_smoke_test.py
@@ -120,7 +120,13 @@ def start_servers(server_dir, config_path):
     env_overrides = {"anna-kvs": "ANNA_KVS_BIN", "anna-monitor": "ANNA_MONITOR_BIN"}
     for name in ["anna-monitor", "anna-route", "anna-kvs"]:
         override = os.environ.get(env_overrides.get(name, ""))
-        bin_path = override if override and os.path.exists(override) else os.path.join(server_dir, name)
+        if override:
+            if not os.path.exists(override):
+                print(f"Error: {env_overrides[name]}={override} does not exist")
+                sys.exit(1)
+            bin_path = override
+        else:
+            bin_path = os.path.join(server_dir, name)
         if not os.path.exists(bin_path):
             print(f"SKIP: Server binary {bin_path} not found")
             sys.exit(0)

--- a/tests/shared/cli/run_smoke_test.py
+++ b/tests/shared/cli/run_smoke_test.py
@@ -116,8 +116,11 @@ policy:
 
 def start_servers(server_dir, config_path):
     procs = []
+    # Support ANNA_KVS_BIN / ANNA_MONITOR_BIN overrides for dual testing.
+    env_overrides = {"anna-kvs": "ANNA_KVS_BIN", "anna-monitor": "ANNA_MONITOR_BIN"}
     for name in ["anna-monitor", "anna-route", "anna-kvs"]:
-        bin_path = os.path.join(server_dir, name)
+        override = os.environ.get(env_overrides.get(name, ""))
+        bin_path = override if override and os.path.exists(override) else os.path.join(server_dir, name)
         if not os.path.exists(bin_path):
             print(f"SKIP: Server binary {bin_path} not found")
             sys.exit(0)


### PR DESCRIPTION
Phase 4 of anna-kvs Rust port (#339, #554).

### Dual-KVS Testing
- `ANNA_KVS_BIN` env var support in `resolve_server_binary()`
- `rust-kvs-tests` Makefile target: runs lattice_types and consistency tests with Rust KVS
- Added to `make test` so both C++ and Rust KVS are tested on every build

### Integration Test Results (Rust KVS)
| Test | Result |
|------|--------|
| system_test_kvs_client | PASS |
| batch_put_and_get | PASS |
| counter_basic | PASS |
| counter_nonexistent_key | PASS |
| direct_routing_put_get | PASS |
| kvs_members_metadata | PASS |
| or_set_add_remove_get | PASS |
| scan_keys | PASS |
| no_ttl_key_persists | PASS |
| ttl_key_expires | PASS |
| ttl_stress_many_keys | PASS |
| disk_tier_lattice_types | SKIP (no disk serializer) |

### Bug Fixes
1. **Startup join notifications**: thread 0 now notifies routing/monitoring nodes (was missing)
2. **Replication factor defaults**: `init_replication()` called inline on `NeedReplicationFactor` instead of round-tripping through replication_response handler
3. **LWW tombstone detection**: `LwwSerializer::get()` returns KEY_DNE for empty-value LWW (tombstones)
4. **Initial membership metadata**: stores kvs_members and cluster_topology at startup

### Coverage Note
Subprocess coverage (kvs_server.rs, main.rs) is not captured by `cargo llvm-cov` since the Rust KVS runs as a child process. Unit-testable code averages 76% coverage.

Closes #554