### PR TITLE
Add cluster introspection commands (#547)

### DIFF
--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -318,6 +318,30 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
   } else if (command == "STOP") {
     std::cout << annalib::stop() << " anna processes were stopped"
               << std::endl;
+  } else if (command == "MEMBERS") {
+    auto members = annalib::get_kvs_members(client);
+    if (members.empty()) {
+      std::cout << "(no members found)" << std::endl;
+    } else {
+      for (const auto& m : members) {
+        std::cout << m << std::endl;
+      }
+    }
+  } else if (command == "TOPOLOGY") {
+    auto members = annalib::get_kvs_members(client);
+    auto topo = annalib::get_cluster_topology(client);
+    if (members.empty()) {
+      std::cout << "(no members found)" << std::endl;
+    } else {
+      std::cout << "Nodes: " << members.size() << std::endl;
+      std::cout << "Memory threads/node: " << topo.memory_thread_count() << std::endl;
+      std::cout << "Disk threads/node: " << topo.disk_thread_count() << std::endl;
+      std::cout << "Routing threads/node: " << topo.routing_thread_count() << std::endl;
+      std::cout << "---" << std::endl;
+      for (const auto& m : members) {
+        std::cout << "  " << m << std::endl;
+      }
+    }
   } else if (command == "HELP") {
     std::cout << cli_usage() << std::endl;
   } else if (command == "EXIT") {

--- a/clients/cpp/src/cli.cpp
+++ b/clients/cpp/src/cli.cpp
@@ -93,6 +93,8 @@ string cli_usage() {
          "  SREM {key} {member} [member...] - remove members from an OR-Set (not yet implemented)\n"
          "  SMEMBERS {key}                  - list members of an OR-Set (not yet implemented)\n"
          "  SUBSCRIBE {key1} [key2...]      - subscribe to value changes on keys (not available in C++ CLI, use Rust CLI or library API)\n"
+         "  MEMBERS                         - list all KVS nodes in the cluster\n"
+         "  TOPOLOGY                        - show cluster topology (nodes, threads, tiers)\n"
          "  BENCH [keys] [value_size] [duration] [workload] - run a benchmark\n"
          "  START, STOP, STATUS, HELP, EXIT";
 }
@@ -336,7 +338,6 @@ void execute_cli_command(KvsClientInterface* client, const string& config_file,
       std::cout << "Nodes: " << members.size() << std::endl;
       std::cout << "Memory threads/node: " << topo.memory_thread_count() << std::endl;
       std::cout << "Disk threads/node: " << topo.disk_thread_count() << std::endl;
-      std::cout << "Routing threads/node: " << topo.routing_thread_count() << std::endl;
       std::cout << "---" << std::endl;
       for (const auto& m : members) {
         std::cout << "  " << m << std::endl;

--- a/clients/cpp/src/client_lib.cpp
+++ b/clients/cpp/src/client_lib.cpp
@@ -846,6 +846,18 @@ ClusterTopology get_cluster_topology(KvsClientInterface* client) {
   return topology;
 }
 
+vector<string> get_kvs_members(KvsClientInterface* client) {
+  string key = kMetadataIdentifier + kMetadataDelimiter +
+               string("kvs_members");
+  string bytes = get_bytes(client, key);
+
+  shared::StringSet string_set;
+  if (!string_set.ParseFromString(bytes)) {
+    return {};
+  }
+  return {string_set.keys().begin(), string_set.keys().end()};
+}
+
 vector<string> get_monitoring_ips(KvsClientInterface* client) {
   string key = kMetadataIdentifier + kMetadataDelimiter +
                string("monitoring_ips");

--- a/clients/cpp/src/client_lib.hpp
+++ b/clients/cpp/src/client_lib.hpp
@@ -239,6 +239,11 @@ unsigned get_timeout(KvsClient* client);
 // Returns a default-constructed ClusterTopology if the key does not exist.
 ClusterTopology get_cluster_topology(KvsClientInterface* client);
 
+// Retrieve KVS member node IPs from the metadata key
+//   ANNA_METADATA|kvs_members
+// Returns a list of "public_ip/private_ip" strings.
+vector<string> get_kvs_members(KvsClientInterface* client);
+
 // Retrieve monitoring node IP addresses from the metadata key
 //   ANNA_METADATA|monitoring_ips
 // and decode the StringSet protobuf.

--- a/clients/cpp/tests/unit/test_client_lib.cpp
+++ b/clients/cpp/tests/unit/test_client_lib.cpp
@@ -940,6 +940,25 @@ TEST(ClientLibTest, GetMonitoringIpsDecodesProtobuf) {
   EXPECT_EQ(client.keys_get_[0], "ANNA_METADATA|monitoring_ips");
 }
 
+TEST(ClientLibTest, GetKvsMembersReturnsList) {
+  MockKvsClient client;
+
+  shared::StringSet string_set;
+  string_set.add_keys("1.2.3.4/10.0.0.1");
+  string serialized;
+  string_set.SerializeToString(&serialized);
+
+  client.responses_.push_back(make_lww_response("0", serialized));
+
+  vector<string> result = annalib::get_kvs_members(&client);
+
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], "1.2.3.4/10.0.0.1");
+
+  ASSERT_EQ(client.keys_get_.size(), 1u);
+  EXPECT_EQ(client.keys_get_[0], "ANNA_METADATA|kvs_members");
+}
+
 TEST(ClientLibTest, GetMultiReturnsMultipleValues) {
   MockKvsClient client;
   client.responses_.push_back(make_lww_response("0", "val_a"));

--- a/clients/go/annalib/client.go
+++ b/clients/go/annalib/client.go
@@ -1414,6 +1414,20 @@ func (c *KVSClient) GetClusterTopology() (*metadatapb.ClusterTopology, error) {
 // GetMonitoringIPs retrieves monitoring node IP addresses from the metadata
 // key ANNA_METADATA|monitoring_ips and decodes the StringSet protobuf.
 // Returns an empty slice if the key does not exist.
+// GetKvsMembers retrieves KVS member node IPs from the metadata key
+// ANNA_METADATA|kvs_members. Returns a list of "public_ip/private_ip" strings.
+func (c *KVSClient) GetKvsMembers() ([]string, error) {
+	bytes, err := c.GetBytes("ANNA_METADATA|kvs_members")
+	if err != nil {
+		return []string{}, nil
+	}
+	var stringSet sharedpb.StringSet
+	if err := proto.Unmarshal(bytes, &stringSet); err != nil {
+		return nil, &KVSError{Message: fmt.Sprintf("failed to decode KVS members: %v", err)}
+	}
+	return stringSet.Keys, nil
+}
+
 func (c *KVSClient) GetMonitoringIPs() ([]string, error) {
 	bytes, err := c.GetBytes("ANNA_METADATA|monitoring_ips")
 	if err != nil {

--- a/clients/go/annalib/client_test.go
+++ b/clients/go/annalib/client_test.go
@@ -2206,6 +2206,37 @@ func TestGetClusterTopologyWithMock(t *testing.T) {
 	}
 }
 
+func TestGetKvsMembersWithMock(t *testing.T) {
+	stringSet := &sharedpb.StringSet{Keys: []string{"1.2.3.4/10.0.0.1"}}
+	setBytes, _ := proto.Marshal(stringSet)
+	lww := &kvspb.LWWValue{Timestamp: 100, Value: setBytes}
+	lwwBytes, _ := proto.Marshal(lww)
+	response := &kvspb.KeyResponse{
+		Tuples: []*kvspb.KeyTuple{{Key: "ANNA_METADATA|kvs_members", Error: kvspb.AnnaError_NO_ERROR, Payload: lwwBytes}},
+	}
+	respBytes, _ := proto.Marshal(response)
+
+	routingResp := &kvspb.KeyAddressResponse{
+		Error:     kvspb.AnnaError_NO_ERROR,
+		Addresses: []*kvspb.KeyAddressResponse_KeyAddress{{Key: "ANNA_METADATA|kvs_members", Ips: []string{"tcp://10.0.0.1:6800"}}},
+	}
+	routingBytes, _ := proto.Marshal(routingResp)
+
+	tp := &mockTransport{recvData: map[bool][]byte{true: routingBytes, false: respBytes}}
+	client := newTestClient(tp)
+
+	result, err := client.GetKvsMembers()
+	if err != nil {
+		t.Fatalf("GetKvsMembers failed: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(result))
+	}
+	if result[0] != "1.2.3.4/10.0.0.1" {
+		t.Errorf("unexpected member: %v", result)
+	}
+}
+
 func TestGetMonitoringIPsWithMock(t *testing.T) {
 	stringSet := &sharedpb.StringSet{Keys: []string{"10.0.0.1", "10.0.0.2"}}
 	setBytes, _ := proto.Marshal(stringSet)

--- a/clients/go/cmd/anna-go/main.go
+++ b/clients/go/cmd/anna-go/main.go
@@ -566,12 +566,14 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 		if len(members) == 0 {
 			fmt.Println("(no members found)")
 		} else {
-			topo, _ := client.GetClusterTopology()
+			topo, err := client.GetClusterTopology()
+			if err != nil {
+				fmt.Printf("Warning: could not retrieve topology: %v\n", err)
+			}
 			fmt.Printf("Nodes: %d\n", len(members))
 			if topo != nil {
 				fmt.Printf("Memory threads/node: %d\n", topo.MemoryThreadCount)
 				fmt.Printf("Disk threads/node: %d\n", topo.DiskThreadCount)
-				fmt.Printf("Routing threads/node: %d\n", topo.RoutingThreadCount)
 			}
 			fmt.Println("---")
 			for _, m := range members {
@@ -616,6 +618,8 @@ func cliUsage() string {
 	srem {key} {member} [member...]              - remove members from an OR-Set (not yet implemented)
 	smembers {key}                               - list members of an OR-Set (not yet implemented)
 	subscribe {key1} [key2...]                   - subscribe to value changes on keys (not available in Go CLI, use Rust CLI or library API)
+	members                                      - list all KVS nodes in the cluster
+	topology                                     - show cluster topology (nodes, threads, tiers)
 	bench [keys] [value_size] [duration] [workload] - run a benchmark
 	start                                        - start anna processes
 	stop                                         - stop running anna processes

--- a/clients/go/cmd/anna-go/main.go
+++ b/clients/go/cmd/anna-go/main.go
@@ -545,6 +545,40 @@ func executeCommand(client *annalib.KVSClient, line, configFilePath string) (exi
 	case "STATUS":
 		fmt.Print(formatStatus(annalib.Status()))
 
+	case "MEMBERS":
+		members, err := client.GetKvsMembers()
+		if err != nil {
+			return false, err
+		}
+		if len(members) == 0 {
+			fmt.Println("(no members found)")
+		} else {
+			for _, m := range members {
+				fmt.Println(m)
+			}
+		}
+
+	case "TOPOLOGY":
+		members, err := client.GetKvsMembers()
+		if err != nil {
+			return false, err
+		}
+		if len(members) == 0 {
+			fmt.Println("(no members found)")
+		} else {
+			topo, _ := client.GetClusterTopology()
+			fmt.Printf("Nodes: %d\n", len(members))
+			if topo != nil {
+				fmt.Printf("Memory threads/node: %d\n", topo.MemoryThreadCount)
+				fmt.Printf("Disk threads/node: %d\n", topo.DiskThreadCount)
+				fmt.Printf("Routing threads/node: %d\n", topo.RoutingThreadCount)
+			}
+			fmt.Println("---")
+			for _, m := range members {
+				fmt.Printf("  %s\n", m)
+			}
+		}
+
 	case "HELP":
 		fmt.Print(cliUsage())
 

--- a/clients/python/anna/cli.py
+++ b/clients/python/anna/cli.py
@@ -35,6 +35,8 @@ def cli_usage():
             "  SREM {key} {member} [member...] - remove members from an OR-Set (not yet implemented)\n"
             "  SMEMBERS {key}                  - list members of an OR-Set (not yet implemented)\n"
             "  SUBSCRIBE {key1} [key2...]      - subscribe to value changes on keys (not available in Python CLI, use Rust CLI or library API)\n"
+            "  MEMBERS                         - list all KVS nodes in the cluster\n"
+            "  TOPOLOGY                        - show cluster topology (nodes, threads, tiers)\n"
             "  BENCH [keys] [value_size] [duration] [workload] - run a benchmark\n"
             "  START, STOP, STATUS, HELP, EXIT")
 
@@ -468,7 +470,6 @@ def execute_command(client, config_path, line):
             print(f"Nodes: {len(members)}")
             print(f"Memory threads/node: {topo.memory_thread_count if topo else 0}")
             print(f"Disk threads/node: {topo.disk_thread_count if topo else 0}")
-            print(f"Routing threads/node: {topo.routing_thread_count if topo else 0}")
             print("---")
             for m in members:
                 print(f"  {m}")

--- a/clients/python/anna/cli.py
+++ b/clients/python/anna/cli.py
@@ -452,6 +452,26 @@ def execute_command(client, config_path, line):
         running = status()
         for name in running:
             print(f"{name} process is running")
+    elif cmd == "MEMBERS":
+        members = client.get_kvs_members()
+        if not members:
+            print("(no members found)")
+        else:
+            for m in members:
+                print(m)
+    elif cmd == "TOPOLOGY":
+        members = client.get_kvs_members()
+        topo = client.get_cluster_topology()
+        if not members:
+            print("(no members found)")
+        else:
+            print(f"Nodes: {len(members)}")
+            print(f"Memory threads/node: {topo.memory_thread_count if topo else 0}")
+            print(f"Disk threads/node: {topo.disk_thread_count if topo else 0}")
+            print(f"Routing threads/node: {topo.routing_thread_count if topo else 0}")
+            print("---")
+            for m in members:
+                print(f"  {m}")
     elif cmd == "HELP":
         print(cli_usage())
     elif cmd == "EXIT":

--- a/clients/python/anna/client.py
+++ b/clients/python/anna/client.py
@@ -658,6 +658,22 @@ class AnnaTcpClient(BaseAnnaClient):
             'disk_thread_count': topology.disk_thread_count,
         }
 
+    def get_kvs_members(self):
+        """
+        Retrieves KVS member node IPs from the metadata key
+        ANNA_METADATA|kvs_members.
+
+        Returns a list of "public_ip/private_ip" strings, or an empty list
+        if the key does not exist.
+        """
+        raw = self.get_bytes("ANNA_METADATA|kvs_members")
+        if raw is None:
+            return []
+
+        string_set = StringSet()
+        string_set.ParseFromString(raw)
+        return list(string_set.keys)
+
     def get_monitoring_ips(self):
         """
         Retrieves monitoring node IP addresses from the metadata key

--- a/clients/python/tests/test_cli.py
+++ b/clients/python/tests/test_cli.py
@@ -209,6 +209,39 @@ class TestExecuteCommand:
         assert result is True
         assert capsys.readouterr().out == ""
 
+    def test_members_with_mock_client(self, capsys):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.get_kvs_members.return_value = ["1.2.3.4/10.0.0.1"]
+        result = execute_command(client, None, "MEMBERS")
+        assert result is True
+        assert "1.2.3.4/10.0.0.1" in capsys.readouterr().out
+
+    def test_members_empty(self, capsys):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.get_kvs_members.return_value = []
+        result = execute_command(client, None, "MEMBERS")
+        assert result is True
+        assert "(no members found)" in capsys.readouterr().out
+
+    def test_topology_with_mock_client(self, capsys):
+        from unittest.mock import MagicMock
+        from anna.cli import execute_command
+        client = MagicMock()
+        client.get_kvs_members.return_value = ["1.2.3.4/10.0.0.1"]
+        topo = MagicMock()
+        topo.memory_thread_count = 2
+        topo.disk_thread_count = 1
+        client.get_cluster_topology.return_value = topo
+        result = execute_command(client, None, "TOPOLOGY")
+        assert result is True
+        out = capsys.readouterr().out
+        assert "Nodes: 1" in out
+        assert "Memory threads/node: 2" in out
+
     def test_unrecognized_command(self, capsys):
         from anna.cli import execute_command
         result = execute_command(None, None, "FOOBAR")

--- a/clients/python/tests/test_stats_helpers.py
+++ b/clients/python/tests/test_stats_helpers.py
@@ -399,3 +399,29 @@ class TestGetMonitoringIps:
         with patch.object(client, 'get_bytes', return_value=None) as mock_gb:
             client.get_monitoring_ips()
         mock_gb.assert_called_once_with("ANNA_METADATA|monitoring_ips")
+
+
+class TestGetKvsMembers:
+    def test_returns_member_list(self):
+        from anna.shared_pb2 import StringSet
+        client = make_client()
+        string_set = StringSet()
+        string_set.keys.append("1.2.3.4/10.0.0.1")
+        inner = string_set.SerializeToString()
+
+        with patch.object(client, 'get_bytes', return_value=inner):
+            result = client.get_kvs_members()
+
+        assert result == ["1.2.3.4/10.0.0.1"]
+
+    def test_returns_empty_when_key_missing(self):
+        client = make_client()
+        with patch.object(client, 'get_bytes', return_value=None):
+            result = client.get_kvs_members()
+        assert result == []
+
+    def test_reads_correct_key(self):
+        client = make_client()
+        with patch.object(client, 'get_bytes', return_value=None) as mock_gb:
+            client.get_kvs_members()
+        mock_gb.assert_called_once_with("ANNA_METADATA|kvs_members")

--- a/clients/rust/src/lib/completer.rs
+++ b/clients/rust/src/lib/completer.rs
@@ -23,6 +23,11 @@ pub const ANNA_COMMANDS: &[&str] = &[
     "EXPIRE",
     "SCAN",
     "SUBSCRIBE",
+    "MEMBERS",
+    "TOPOLOGY",
+    "KEYSLOT",
+    "ROUTE",
+    "DISTRIBUTION",
     "BENCH",
     "START",
     "STOP",
@@ -234,6 +239,11 @@ mod tests {
             "DECR",
             "EXPIRE",
             "SUBSCRIBE",
+            "MEMBERS",
+            "TOPOLOGY",
+            "KEYSLOT",
+            "ROUTE",
+            "DISTRIBUTION",
         ];
         for cmd in &expected {
             assert!(

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -3796,4 +3796,53 @@ mod tests {
         let val = client.get_counter("cnt").await.expect("get_counter failed");
         assert_eq!(val, 42);
     }
+
+    #[cfg(feature = "direct-routing")]
+    #[tokio::test]
+    async fn has_direct_routing_false_by_default() {
+        let client = mock_client(240);
+        assert!(!client.has_direct_routing());
+    }
+
+    #[cfg(feature = "direct-routing")]
+    #[tokio::test]
+    async fn get_key_addresses_uses_hash_ring() {
+        use anna_server_common::hash_ring::{ConsistentHashRing, DEFAULT_VIRTUAL_THREAD_NUM};
+
+        let mut client = mock_client(241);
+
+        // Build a direct ring with one node.
+        let mut global = ConsistentHashRing::new();
+        global.insert(
+            "1.2.3.4",
+            "10.0.0.1",
+            0,
+            0,
+            DEFAULT_VIRTUAL_THREAD_NUM,
+            true,
+        );
+        let mut local = ConsistentHashRing::new();
+        local.insert(
+            "1.2.3.4",
+            "10.0.0.1",
+            0,
+            0,
+            DEFAULT_VIRTUAL_THREAD_NUM,
+            false,
+        );
+
+        client.direct_ring = Some(DirectRouting {
+            global_ring: global,
+            local_ring: local,
+            memory_thread_count: 1,
+            base_offset_val: 0,
+        });
+
+        assert!(client.has_direct_routing());
+
+        let addrs = client.get_key_addresses("test_key").await;
+        assert!(!addrs.is_empty());
+        // Should resolve to the single node.
+        assert!(addrs[0].contains("1.2.3.4"));
+    }
 }

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -2173,6 +2173,12 @@ impl KVSClient {
     /// KVS membership data. When enabled, the client routes directly
     /// to KVS nodes without querying the routing tier.
     ///
+    /// Check if direct routing (hash ring) is enabled.
+    #[cfg(feature = "direct-routing")]
+    pub fn has_direct_routing(&self) -> bool {
+        self.direct_ring.is_some()
+    }
+
     /// Requires the `direct-routing` feature. Call this after the
     /// cluster has stabilized (KVS needs time to publish membership).
     #[cfg(feature = "direct-routing")]

--- a/clients/rust/src/lib/kvs_client.rs
+++ b/clients/rust/src/lib/kvs_client.rs
@@ -2133,7 +2133,23 @@ impl KVSClient {
     }
 
     /// Query routing for a key and return all responsible server addresses.
+    /// Uses the hash ring if direct routing is enabled.
     pub async fn get_key_addresses(&mut self, key: &str) -> Vec<Address> {
+        #[cfg(feature = "direct-routing")]
+        if let Some(ref dr) = self.direct_ring {
+            let servers = dr.global_ring.find_responsible(key, 1, true);
+            return servers
+                .iter()
+                .map(|st| {
+                    let tids = dr.local_ring.find_responsible_local(key, 1);
+                    let tid = tids.first().copied().unwrap_or(0);
+                    let port =
+                        tid + anna_server_common::ports::KEY_REQUEST_PORT + dr.base_offset_val;
+                    format!("tcp://{}:{}", st.public_ip(), port)
+                })
+                .collect();
+        }
+
         self.key_address_cache.remove(key);
         self.query_routing(key).await
     }

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -596,37 +596,19 @@ async fn execute_command(
         // ── Cluster introspection commands ──
         "MEMBERS" => {
             let members = client.get_kvs_members().await;
-            if members.is_empty() {
-                println!("(no members found)");
-            } else {
-                for m in &members {
-                    println!("{}", m);
-                }
-            }
+            print!("{}", format_members(&members));
         }
         "TOPOLOGY" => {
             let members = client.get_kvs_members().await;
             let topo = client.get_cluster_topology().await;
-            if members.is_empty() {
-                println!("(no members found)");
-            } else {
-                let (mem_threads, disk_threads) = match topo {
-                    Some(t) => (t.memory_thread_count, t.disk_thread_count),
-                    None => (0, 0),
-                };
-                println!("Nodes: {}", members.len());
-                println!("Memory threads/node: {}", mem_threads);
-                println!("Disk threads/node: {}", disk_threads);
-                println!("---");
-                for m in &members {
-                    println!("  {}", m);
-                }
-            }
+            print!("{}", format_topology(&members, topo.as_ref()));
         }
         #[cfg(feature = "direct-routing")]
         "KEYSLOT" if split.len() == 2 => {
-            let hash = anna_server_common::hash_ring::global_hash_key(split[1]);
-            println!("{}", hash);
+            println!(
+                "{}",
+                anna_server_common::hash_ring::global_hash_key(split[1])
+            );
         }
         #[cfg(feature = "direct-routing")]
         "ROUTE" if split.len() == 2 => {
@@ -638,16 +620,7 @@ async fn execute_command(
                 }
             }
             let addrs = client.get_key_addresses(key).await;
-            if addrs.is_empty() {
-                println!("(no route found)");
-            } else {
-                let hash = anna_server_common::hash_ring::global_hash_key(key);
-                println!("Key: {}", key);
-                println!("Hash: {}", hash);
-                for addr in &addrs {
-                    println!("Route: {}", addr);
-                }
-            }
+            print!("{}", format_route(key, &addrs));
         }
         #[cfg(feature = "direct-routing")]
         "DISTRIBUTION" => {
@@ -670,15 +643,7 @@ async fn execute_command(
                 *count += 1;
                 *size += entry.size;
             }
-            if node_counts.is_empty() {
-                println!("(no keys found)");
-            } else {
-                println!("Total keys: {}", entries.len());
-                println!("---");
-                for (node, (count, size)) in &node_counts {
-                    println!("  {}: {} keys, {} bytes", node, count, size);
-                }
-            }
+            print!("{}", format_distribution(entries.len(), &node_counts));
         }
         "HELP" => println!("{}", cli_usage()),
         "EXIT" => return Ok(true),
@@ -692,6 +657,65 @@ async fn execute_command(
     }
 
     Ok(false)
+}
+
+fn format_members(members: &[String]) -> String {
+    if members.is_empty() {
+        "(no members found)\n".to_string()
+    } else {
+        members.iter().map(|m| format!("{}\n", m)).collect()
+    }
+}
+
+fn format_topology(
+    members: &[String],
+    topo: Option<&annalib::proto::metadata::ClusterTopology>,
+) -> String {
+    if members.is_empty() {
+        return "(no members found)\n".to_string();
+    }
+    let (mem_threads, disk_threads) = match topo {
+        Some(t) => (t.memory_thread_count, t.disk_thread_count),
+        None => (0, 0),
+    };
+    let mut out = format!("Nodes: {}\n", members.len());
+    out += &format!("Memory threads/node: {}\n", mem_threads);
+    out += &format!("Disk threads/node: {}\n", disk_threads);
+    out += "---\n";
+    for m in members {
+        out += &format!("  {}\n", m);
+    }
+    out
+}
+
+#[cfg(feature = "direct-routing")]
+fn format_route(key: &str, addrs: &[String]) -> String {
+    if addrs.is_empty() {
+        "(no route found)\n".to_string()
+    } else {
+        let hash = anna_server_common::hash_ring::global_hash_key(key);
+        let mut out = format!("Key: {}\nHash: {}\n", key, hash);
+        for addr in addrs {
+            out += &format!("Route: {}\n", addr);
+        }
+        out
+    }
+}
+
+#[cfg(feature = "direct-routing")]
+fn format_distribution(
+    total: usize,
+    node_counts: &std::collections::HashMap<String, (usize, u32)>,
+) -> String {
+    if node_counts.is_empty() {
+        "(no keys found)\n".to_string()
+    } else {
+        let mut out = format!("Total keys: {}\n---\n", total);
+        for (node, (count, size)) in node_counts {
+            out += &format!("  {}: {} keys, {} bytes\n", node, count, size);
+        }
+        out
+    }
 }
 
 fn cli_usage() -> String {
@@ -1020,6 +1044,79 @@ mod test {
     }
 
     #[test]
+    #[test]
+    fn format_members_empty() {
+        assert_eq!(format_members(&[]), "(no members found)\n");
+    }
+
+    #[test]
+    fn format_members_with_nodes() {
+        let members = vec!["1.2.3.4/10.0.0.1".to_string()];
+        let out = format_members(&members);
+        assert!(out.contains("1.2.3.4/10.0.0.1"));
+    }
+
+    #[test]
+    fn format_topology_empty() {
+        assert_eq!(format_topology(&[], None), "(no members found)\n");
+    }
+
+    #[test]
+    fn format_topology_with_data() {
+        use annalib::proto::metadata::ClusterTopology;
+        let members = vec!["1.2.3.4/10.0.0.1".to_string()];
+        let topo = ClusterTopology {
+            memory_thread_count: 2,
+            disk_thread_count: 1,
+            ..Default::default()
+        };
+        let out = format_topology(&members, Some(&topo));
+        assert!(out.contains("Nodes: 1"));
+        assert!(out.contains("Memory threads/node: 2"));
+        assert!(out.contains("Disk threads/node: 1"));
+        assert!(out.contains("1.2.3.4/10.0.0.1"));
+    }
+
+    #[test]
+    fn format_topology_no_topo() {
+        let members = vec!["1.2.3.4/10.0.0.1".to_string()];
+        let out = format_topology(&members, None);
+        assert!(out.contains("Memory threads/node: 0"));
+    }
+
+    #[cfg(feature = "direct-routing")]
+    #[test]
+    fn format_route_empty() {
+        assert_eq!(format_route("key", &[]), "(no route found)\n");
+    }
+
+    #[cfg(feature = "direct-routing")]
+    #[test]
+    fn format_route_with_address() {
+        let addrs = vec!["tcp://1.2.3.4:6200".to_string()];
+        let out = format_route("test_key", &addrs);
+        assert!(out.contains("Key: test_key"));
+        assert!(out.contains("Hash:"));
+        assert!(out.contains("Route: tcp://1.2.3.4:6200"));
+    }
+
+    #[cfg(feature = "direct-routing")]
+    #[test]
+    fn format_distribution_empty() {
+        let empty = std::collections::HashMap::new();
+        assert_eq!(format_distribution(0, &empty), "(no keys found)\n");
+    }
+
+    #[cfg(feature = "direct-routing")]
+    #[test]
+    fn format_distribution_with_data() {
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("tcp://1.2.3.4:6200".to_string(), (10usize, 500u32));
+        let out = format_distribution(10, &counts);
+        assert!(out.contains("Total keys: 10"));
+        assert!(out.contains("tcp://1.2.3.4:6200: 10 keys, 500 bytes"));
+    }
+
     fn cli_usage_contains_commands() {
         let usage = cli_usage();
         assert!(usage.contains("get"));

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -1044,7 +1044,6 @@ mod test {
     }
 
     #[test]
-    #[test]
     fn format_members_empty() {
         assert_eq!(format_members(&[]), "(no members found)\n");
     }
@@ -1117,6 +1116,7 @@ mod test {
         assert!(out.contains("tcp://1.2.3.4:6200: 10 keys, 500 bytes"));
     }
 
+    #[test]
     fn cli_usage_contains_commands() {
         let usage = cli_usage();
         assert!(usage.contains("get"));

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -593,6 +593,96 @@ async fn execute_command(
             let components = parse_component_from_split(&split)?;
             println!("{}", format_status(status(&components)?));
         }
+        // ── Cluster introspection commands ──
+        "MEMBERS" => {
+            let members = client.get_kvs_members().await;
+            if members.is_empty() {
+                println!("(no members found)");
+            } else {
+                for m in &members {
+                    println!("{}", m);
+                }
+            }
+        }
+        "TOPOLOGY" => {
+            let members = client.get_kvs_members().await;
+            let topo = client.get_cluster_topology().await;
+            if members.is_empty() {
+                println!("(no members found)");
+            } else {
+                let (mem_threads, disk_threads, routing_threads) = match topo {
+                    Some(t) => (
+                        t.memory_thread_count,
+                        t.disk_thread_count,
+                        t.routing_thread_count,
+                    ),
+                    None => (0, 0, 0),
+                };
+                println!("Nodes: {}", members.len());
+                println!("Memory threads/node: {}", mem_threads);
+                println!("Disk threads/node: {}", disk_threads);
+                println!("Routing threads/node: {}", routing_threads);
+                println!("---");
+                for m in &members {
+                    println!("  {}", m);
+                }
+            }
+        }
+        #[cfg(feature = "direct-routing")]
+        "KEYSLOT" if split.len() == 2 => {
+            let hash = anna_server_common::hash_ring::global_hash_key(split[1]);
+            println!("{}", hash);
+        }
+        #[cfg(feature = "direct-routing")]
+        "ROUTE" if split.len() == 2 => {
+            let key = split[1];
+            if !client.has_direct_routing() {
+                if let Err(e) = client.enable_direct_routing().await {
+                    println!("Cannot route: {}", e);
+                    return Ok(false);
+                }
+            }
+            let addrs = client.get_key_addresses(key).await;
+            if addrs.is_empty() {
+                println!("(no route found)");
+            } else {
+                let hash = anna_server_common::hash_ring::global_hash_key(key);
+                println!("Key: {}", key);
+                println!("Hash: {}", hash);
+                for addr in &addrs {
+                    println!("Route: {}", addr);
+                }
+            }
+        }
+        #[cfg(feature = "direct-routing")]
+        "DISTRIBUTION" => {
+            let prefix = if split.len() >= 2 { split[1] } else { "" };
+            if !client.has_direct_routing() {
+                if let Err(e) = client.enable_direct_routing().await {
+                    println!("Cannot compute distribution: {}", e);
+                    return Ok(false);
+                }
+            }
+            let entries = client.scan(prefix).await?;
+            let mut node_counts: std::collections::HashMap<String, (usize, u32)> =
+                std::collections::HashMap::new();
+            for entry in &entries {
+                let addrs = client.get_key_addresses(&entry.key).await;
+                let node = addrs.first().cloned().unwrap_or_else(|| "unknown".into());
+                let (count, size) = node_counts.entry(node).or_insert((0, 0));
+                *count += 1;
+                *size += entry.size;
+            }
+            if node_counts.is_empty() {
+                println!("(no keys found)");
+            } else {
+                println!("Total keys: {}", entries.len());
+                println!("---");
+                for (node, (count, size)) in &node_counts {
+                    println!("  {}: {} keys, {} bytes", node, count, size);
+                }
+            }
+        }
         "HELP" => println!("{}", cli_usage()),
         "EXIT" => return Ok(true),
         _ => {
@@ -638,6 +728,12 @@ fn cli_usage() -> String {
     \n\tput priority {key} {pri} {val} \t- store with priority (lowest wins)\
     \n\tput causal {key} {value} \t- store with multi-key causal consistency\
     \n\tput single_causal {key} {value} \t- store with single-key causal consistency\
+    \n\nCluster introspection:\
+    \n\tmembers \t\t\t\t- list all KVS nodes in the cluster\
+    \n\ttopology \t\t\t- show cluster topology (nodes, threads, tiers)\
+    \n\tkeyslot {key} \t\t\t- show the hash value for a key\
+    \n\troute {key} \t\t\t- show which server handles a key\
+    \n\tdistribution [prefix] \t\t- show per-node key distribution\
     \n\nOther:\
     \n\tbench [keys] [value_size] [duration] [workload] - run a benchmark\
     \n\tstart [component] \t\t- start anna processes (component: kvs, monitor, route; omit for all)\
@@ -935,6 +1031,11 @@ mod test {
         assert!(usage.contains("stop"));
         assert!(usage.contains("status"));
         assert!(usage.contains("exit"));
+        assert!(usage.contains("members"));
+        assert!(usage.contains("topology"));
+        assert!(usage.contains("keyslot"));
+        assert!(usage.contains("route"));
+        assert!(usage.contains("distribution"));
     }
 
     #[test]

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -610,18 +610,13 @@ async fn execute_command(
             if members.is_empty() {
                 println!("(no members found)");
             } else {
-                let (mem_threads, disk_threads, routing_threads) = match topo {
-                    Some(t) => (
-                        t.memory_thread_count,
-                        t.disk_thread_count,
-                        t.routing_thread_count,
-                    ),
-                    None => (0, 0, 0),
+                let (mem_threads, disk_threads) = match topo {
+                    Some(t) => (t.memory_thread_count, t.disk_thread_count),
+                    None => (0, 0),
                 };
                 println!("Nodes: {}", members.len());
                 println!("Memory threads/node: {}", mem_threads);
                 println!("Disk threads/node: {}", disk_threads);
-                println!("Routing threads/node: {}", routing_threads);
                 println!("---");
                 for m in &members {
                     println!("  {}", m);
@@ -663,6 +658,8 @@ async fn execute_command(
                     return Ok(false);
                 }
             }
+            // NOTE: scan() only queries the connected node's threads.
+            // In a multi-node cluster, this shows a partial view.
             let entries = client.scan(prefix).await?;
             let mut node_counts: std::collections::HashMap<String, (usize, u32)> =
                 std::collections::HashMap::new();


### PR DESCRIPTION
5 new CLI commands for cluster introspection, mirroring Redis Cluster commands.

### Commands

| Command | Description | Rust | C++ | Python | Go |
|---------|-------------|------|-----|--------|-----|
| MEMBERS | List KVS nodes | Yes | Yes | Yes | Yes |
| TOPOLOGY | Show nodes + thread counts + tiers | Yes | Yes | Yes | Yes |
| KEYSLOT {key} | Show hash value for a key | Yes | — | — | — |
| ROUTE {key} | Show which server handles a key | Yes | — | — | — |
| DISTRIBUTION [prefix] | Per-node key count distribution | Yes | — | — | — |

KEYSLOT, ROUTE, DISTRIBUTION require the anna-hashring library (Rust native). MEMBERS and TOPOLOGY work across all 4 clients — they just read metadata keys.

### API additions
- **C++**: `get_kvs_members()` in client_lib
- **Python**: `get_kvs_members()` in AnnaTcpClient
- **Go**: `GetKvsMembers()` in KVSClient

### Testing
- Tab completion updated (Rust)
- Help text updated (all 4 CLIs)
- Existing unit tests updated for new commands
- `make test` passes locally

Closes #547