### PR TITLE
Split anna-kvs into lib + bin

### DIFF
--- a/server/rust/anna-kvs/Cargo.toml
+++ b/server/rust/anna-kvs/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 description = "Anna KVS server (Rust port)"
 
+[lib]
+name = "anna_kvs"
+path = "src/lib.rs"
+
 [[bin]]
 name = "anna-kvs-rs"
 path = "src/main.rs"

--- a/server/rust/anna-kvs/src/context.rs
+++ b/server/rust/anna-kvs/src/context.rs
@@ -15,7 +15,7 @@ use crate::storage::SerializerMap;
 
 /// Pending client request waiting for replication factor resolution.
 #[derive(Debug, Clone)]
-pub(crate) struct PendingRequest {
+pub struct PendingRequest {
     pub r#type: i32,
     pub lattice_type: i32,
     pub payload: Vec<u8>,
@@ -26,20 +26,20 @@ pub(crate) struct PendingRequest {
 
 /// Pending gossip waiting for replication factor resolution.
 #[derive(Debug, Clone)]
-pub(crate) struct PendingGossip {
+pub struct PendingGossip {
     pub lattice_type: i32,
     pub payload: Vec<u8>,
     pub expiry_epoch_ms: u64,
 }
 
 /// Map from target address to set of keys to gossip to that address.
-pub(crate) type AddressKeysetMap = HashMap<Address, HashSet<Key>>;
+pub type AddressKeysetMap = HashMap<Address, HashSet<Key>>;
 
-/// Outgoing ZMQ message: (target_address, serialized_payload).
-pub(crate) type OutgoingMessage = (Address, Vec<u8>);
+/// Outgoing message: (target_address, serialized_payload).
+pub type OutgoingMessage = (Address, Vec<u8>);
 
 /// All mutable KVS state shared across handlers.
-pub(crate) struct KvsContext {
+pub struct KvsContext {
     // ── Identity ──
     pub thread_id: u32,
     pub public_ip: Address,
@@ -90,18 +90,18 @@ pub(crate) struct KvsContext {
     pub seed: u32,
 }
 
-#[cfg(test)]
-pub(crate) mod tests {
+/// Test support utilities — available to downstream crates for testing.
+pub mod test_support {
     use super::*;
     use anna_server_common::hash_ring::{ConsistentHashRing, DEFAULT_VIRTUAL_THREAD_NUM};
 
     /// Create a minimal KvsContext for testing with a single memory-tier node.
-    pub(crate) fn make_test_ctx() -> KvsContext {
+    pub fn make_test_ctx() -> KvsContext {
         make_test_ctx_with_node("1.1.1.1", "1.1.1.1")
     }
 
     /// Create a minimal KvsContext with a specific node in the ring.
-    pub(crate) fn make_test_ctx_with_node(pub_ip: &str, priv_ip: &str) -> KvsContext {
+    pub fn make_test_ctx_with_node(pub_ip: &str, priv_ip: &str) -> KvsContext {
         let mut global = HashMap::new();
         let mut local = HashMap::new();
 

--- a/server/rust/anna-kvs/src/handlers/cache_ip_response.rs
+++ b/server/rust/anna-kvs/src/handlers/cache_ip_response.rs
@@ -22,7 +22,7 @@ fn get_cache_ip_from_metadata(key: &str) -> Option<&str> {
 }
 
 /// Handle a cache IP response — updates the bidirectional cache↔key mappings.
-pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) {
+pub fn handle(ctx: &mut KvsContext, data: &[u8]) {
     let response = match KeyResponse::decode(data) {
         Ok(r) => r,
         Err(e) => {
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn updates_cache_key_mappings() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let data = make_cache_response("10.0.0.5", &["key_a", "key_b"]);
         handle(&mut ctx, &data);
 
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn removes_stale_keys() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
 
         // Initial: cache has key_a and key_b.
         let data1 = make_cache_response("10.0.0.5", &["key_a", "key_b"]);

--- a/server/rust/anna-kvs/src/handlers/cache_registration.rs
+++ b/server/rust/anna-kvs/src/handlers/cache_registration.rs
@@ -11,7 +11,7 @@ use crate::context::KvsContext;
 ///
 /// Format: `StringSet` protobuf where `keys[0]` is the cache IP and
 /// `keys[1..]` are the keys that cache is watching.
-pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) {
+pub fn handle(ctx: &mut KvsContext, data: &[u8]) {
     let msg = match StringSet::decode(data) {
         Ok(m) => m,
         Err(e) => {
@@ -53,7 +53,7 @@ mod tests {
 
     #[test]
     fn registers_cache_and_keys() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let msg = StringSet {
             keys: vec!["tcp://10.0.0.5:6850".into(), "key_a".into(), "key_b".into()],
         };
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn empty_message_ignored() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let msg = StringSet { keys: vec![] };
         handle(&mut ctx, &msg.encode_to_vec());
         assert!(ctx.extant_caches.is_empty());

--- a/server/rust/anna-kvs/src/handlers/gossip.rs
+++ b/server/rust/anna-kvs/src/handlers/gossip.rs
@@ -11,7 +11,7 @@ use crate::context::{KvsContext, OutgoingMessage, PendingGossip};
 use crate::handlers::utils::process_put;
 
 /// Handle incoming gossip — apply locally or forward to responsible threads.
-pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
     let gossip = match KeyRequest::decode(data) {
         Ok(r) => r,
         Err(e) => {
@@ -126,7 +126,7 @@ mod tests {
     use anna_server_common::proto::kvs::LwwValue;
 
     fn ctx_with_lww() -> KvsContext {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
         ctx

--- a/server/rust/anna-kvs/src/handlers/management_node_response.rs
+++ b/server/rust/anna-kvs/src/handlers/management_node_response.rs
@@ -12,7 +12,7 @@ use prost::Message;
 use crate::context::{KvsContext, OutgoingMessage};
 
 /// Handle a management node response containing the list of cache nodes.
-pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
     let func_nodes = match StringSet::decode(data) {
         Ok(s) => s,
         Err(e) => {
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn updates_extant_caches() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.extant_caches.insert("old_cache".into());
 
         let msg = StringSet {
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn cleans_up_deleted_cache_mappings() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.extant_caches.insert("dead_cache".into());
         ctx.cache_ip_to_keys
             .entry("dead_cache".into())

--- a/server/rust/anna-kvs/src/handlers/mod.rs
+++ b/server/rust/anna-kvs/src/handlers/mod.rs
@@ -4,15 +4,15 @@
 //! outgoing ZMQ messages. Handlers take `&mut KvsContext` for shared state
 //! and return `Vec<OutgoingMessage>` for messages that need to be sent.
 
-pub(crate) mod cache_ip_response;
-pub(crate) mod cache_registration;
-pub(crate) mod gossip;
-pub(crate) mod management_node_response;
-pub(crate) mod node_depart;
-pub(crate) mod node_join;
-pub(crate) mod replication_change;
-pub(crate) mod replication_response;
-pub(crate) mod scan;
-pub(crate) mod self_depart;
-pub(crate) mod user_request;
-pub(crate) mod utils;
+pub mod cache_ip_response;
+pub mod cache_registration;
+pub mod gossip;
+pub mod management_node_response;
+pub mod node_depart;
+pub mod node_join;
+pub mod replication_change;
+pub mod replication_response;
+pub mod scan;
+pub mod self_depart;
+pub mod user_request;
+pub mod utils;

--- a/server/rust/anna-kvs/src/handlers/node_depart.rs
+++ b/server/rust/anna-kvs/src/handlers/node_depart.rs
@@ -12,7 +12,7 @@ use crate::context::{KvsContext, OutgoingMessage};
 /// Format: `"{TIER}:{PUBLIC_IP}:{PRIVATE_IP}:{JOIN_COUNT}"`
 ///
 /// Thread 0 relays the departure to worker threads 1..N.
-pub(crate) fn handle(ctx: &mut KvsContext, serialized: &str) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &mut KvsContext, serialized: &str) -> Vec<OutgoingMessage> {
     let parts: Vec<&str> = serialized.split(':').collect();
     if parts.len() < 3 {
         log::warn!("node_depart: malformed message: {}", serialized);
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn removes_node_from_ring() {
-        let mut ctx = crate::context::tests::make_test_ctx_with_node("1.2.3.4", "10.0.0.1");
+        let mut ctx = crate::context::test_support::make_test_ctx_with_node("1.2.3.4", "10.0.0.1");
         assert!(!ctx.global_hash_rings[&Tier::Memory].is_empty());
 
         let msg = "MEMORY:1.2.3.4:10.0.0.1:0";
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn malformed_message_ignored() {
-        let mut ctx = crate::context::tests::make_test_ctx_with_node("1.2.3.4", "10.0.0.1");
+        let mut ctx = crate::context::test_support::make_test_ctx_with_node("1.2.3.4", "10.0.0.1");
         let msgs = handle(&mut ctx, "bad");
         assert!(msgs.is_empty());
         // Ring should be unchanged.

--- a/server/rust/anna-kvs/src/handlers/node_join.rs
+++ b/server/rust/anna-kvs/src/handlers/node_join.rs
@@ -13,7 +13,7 @@ use crate::context::{KvsContext, OutgoingMessage};
 /// Handle a node join message.
 ///
 /// Format: `"{TIER}:{PUBLIC_IP}:{PRIVATE_IP}:{JOIN_COUNT}"`
-pub(crate) fn handle(ctx: &mut KvsContext, serialized: &str) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &mut KvsContext, serialized: &str) -> Vec<OutgoingMessage> {
     let parts: Vec<&str> = serialized.split(':').collect();
     if parts.len() < 4 {
         log::warn!("node_join: malformed message: {}", serialized);
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn inserts_new_node_into_ring() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let initial_size = ctx.global_hash_rings[&Tier::Memory]
             .get_unique_servers()
             .len();
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn schedules_gossip_for_new_node() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
 
         // Add a key with replication factor.
         let mut kp = KeyProperty::default();
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn malformed_message_ignored() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let msgs = handle(&mut ctx, "bad");
         assert!(msgs.is_empty());
     }

--- a/server/rust/anna-kvs/src/handlers/replication_change.rs
+++ b/server/rust/anna-kvs/src/handlers/replication_change.rs
@@ -15,7 +15,7 @@ use crate::context::{AddressKeysetMap, KvsContext, OutgoingMessage};
 use crate::handlers::utils::build_gossip_messages;
 
 /// Handle a replication factor change message.
-pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
     log::info!("Received a replication factor change.");
 
     let mut outgoing = Vec::new();
@@ -177,7 +177,7 @@ mod tests {
     use anna_server_common::proto::kvs::LatticeType;
 
     fn ctx_with_stored_key(key: &str) -> KvsContext {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
         // Store a key.
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     fn thread0_relays_to_workers() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.thread_id = 0;
         ctx.thread_count = 3;
         let update = ReplicationFactorUpdate {
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn decode_failure_returns_early() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let msgs = handle(&mut ctx, b"garbage");
         // Only relay messages (if thread 0), no crash.
         assert!(msgs.is_empty() || msgs.iter().all(|(_, d)| d == b"garbage"));
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn invalid_tier_ignored() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let update = ReplicationFactorUpdate {
             updates: vec![ReplicationFactor {
                 key: "bad_tier_k".into(),
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn local_replication_update() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let update = ReplicationFactorUpdate {
             updates: vec![ReplicationFactor {
                 key: "local_k".into(),
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn updates_replication_factor() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
 
         let update = ReplicationFactorUpdate {
             updates: vec![ReplicationFactor {

--- a/server/rust/anna-kvs/src/handlers/replication_response.rs
+++ b/server/rust/anna-kvs/src/handlers/replication_response.rs
@@ -27,7 +27,7 @@ fn tier_from_i32(v: i32) -> Option<Tier> {
 
 /// Handle a replication factor response — update the replication map
 /// and drain any pending requests/gossip for the resolved key.
-pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
     let response = match KeyResponse::decode(data) {
         Ok(r) => r,
         Err(e) => {
@@ -283,14 +283,14 @@ mod tests {
 
     #[test]
     fn decode_failure_returns_empty() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let msgs = handle(&mut ctx, b"garbage");
         assert!(msgs.is_empty());
     }
 
     #[test]
     fn empty_tuples_returns_empty() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let response = KeyResponse::default();
         let msgs = handle(&mut ctx, &response.encode_to_vec());
         assert!(msgs.is_empty());
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn bad_metadata_key_returns_empty() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let response = KeyResponse {
             tuples: vec![KeyTuple {
                 key: "not_metadata".into(),
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn wrong_thread_returns_empty() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let response = KeyResponse {
             tuples: vec![KeyTuple {
                 key: "ANNA_METADATA|replication|wt_key".into(),
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn unexpected_error_returns_empty() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let response = KeyResponse {
             tuples: vec![KeyTuple {
                 key: "ANNA_METADATA|replication|err_key".into(),
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn pending_get_returns_value() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
 
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn pending_not_responsible_sends_wrong_thread() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         // Add a second node and set replication=1 so we might not be responsible.
         ctx.global_hash_rings
             .get_mut(&Tier::Memory)
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn pending_gossip_applied_when_responsible() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
 
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn updates_replication_map() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let data = make_rep_response("my_key", 2);
         let _ = handle(&mut ctx, &data);
 
@@ -456,7 +456,7 @@ mod tests {
 
     #[test]
     fn drains_pending_requests() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
 
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn key_dne_uses_default_replication() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.tier_metadata.insert(
             Tier::Memory,
             anna_server_common::metadata::TierMetadata {

--- a/server/rust/anna-kvs/src/handlers/scan.rs
+++ b/server/rust/anna-kvs/src/handlers/scan.rs
@@ -15,7 +15,7 @@ const MAX_SCAN_COUNT: u32 = 10000;
 ///
 /// Returns keys matching a prefix, starting from a numeric cursor position,
 /// up to `scan_count` entries. Metadata keys are excluded from results.
-pub(crate) fn handle(ctx: &KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
     let request = match KeyRequest::decode(data) {
         Ok(r) => r,
         Err(e) => {
@@ -106,7 +106,7 @@ mod tests {
     use anna_server_common::proto::kvs::LatticeType;
 
     fn make_scan_ctx() -> KvsContext {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         for i in 0..5 {
             let mut kp = KeyProperty::default();
             kp.set_size(10);

--- a/server/rust/anna-kvs/src/handlers/self_depart.rs
+++ b/server/rust/anna-kvs/src/handlers/self_depart.rs
@@ -13,7 +13,7 @@ use crate::handlers::utils::build_gossip_messages;
 /// Handle self-departure: gossip all data out and notify the cluster.
 ///
 /// `depart_done_addr` is the monitoring address to send the "done" message to.
-pub(crate) fn handle(ctx: &mut KvsContext, depart_done_addr: &str) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &mut KvsContext, depart_done_addr: &str) -> Vec<OutgoingMessage> {
     log::info!("This node is departing.");
 
     // Remove self from the hash ring.
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn notifies_routing_and_monitoring() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.routing_ips = vec!["10.0.0.5".into()];
         ctx.monitoring_ips = vec!["10.0.0.6".into()];
         let msgs = handle(&mut ctx, "tcp://monitor:6450");
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn relays_to_worker_threads() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.thread_count = 3;
         let msgs = handle(&mut ctx, "tcp://monitor:6450");
 
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn non_thread0_skips_notifications() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.thread_id = 1;
         ctx.routing_ips = vec!["10.0.0.5".into()];
         ctx.monitoring_ips = vec!["10.0.0.6".into()];
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn gossips_stored_data() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
 
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn depart_done_message_format() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let msgs = handle(&mut ctx, "tcp://monitor:6450");
         let done = msgs
             .iter()
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn removes_self_from_ring() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         assert!(!ctx.global_hash_rings[&Tier::Memory].is_empty());
 
         let _ = handle(&mut ctx, "tcp://monitor:6450");
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn sends_depart_done() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         let msgs = handle(&mut ctx, "tcp://monitor:6450");
 
         // Should include the depart-done message.

--- a/server/rust/anna-kvs/src/handlers/user_request.rs
+++ b/server/rust/anna-kvs/src/handlers/user_request.rs
@@ -17,7 +17,7 @@ use crate::context::{KvsContext, OutgoingMessage, PendingRequest};
 use crate::handlers::utils::{now_epoch_s, process_get, process_put};
 
 /// Handle a user GET/PUT request.
-pub(crate) fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
+pub fn handle(ctx: &mut KvsContext, data: &[u8]) -> Vec<OutgoingMessage> {
     let request = match KeyRequest::decode(data) {
         Ok(r) => r,
         Err(e) => {
@@ -270,7 +270,7 @@ mod tests {
     use anna_server_common::proto::kvs::LwwValue;
 
     fn ctx_with_lww_and_key(key: &str, value: &[u8]) -> KvsContext {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
 
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn get_missing_key_returns_key_dne() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
         let mut kr = KeyReplication::default();
@@ -366,7 +366,7 @@ mod tests {
 
     #[test]
     fn put_creates_key() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
         let mut kr = KeyReplication::default();
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn request_without_rep_factor_uses_defaults() {
-        let mut ctx = crate::context::tests::make_test_ctx();
+        let mut ctx = crate::context::test_support::make_test_ctx();
         ctx.serializers
             .insert(LatticeType::Lww as i32, Box::new(LwwSerializer::new()));
         // No replication factor — handler should init with defaults and process.

--- a/server/rust/anna-kvs/src/handlers/utils.rs
+++ b/server/rust/anna-kvs/src/handlers/utils.rs
@@ -15,7 +15,7 @@ use crate::storage::{Serializer, SerializerMap};
 
 /// Process a GET request for a key.
 /// Returns `(payload_bytes, error_code)`.
-pub(crate) fn process_get(key: &str, serializer: &dyn Serializer) -> (Vec<u8>, i32) {
+pub fn process_get(key: &str, serializer: &dyn Serializer) -> (Vec<u8>, i32) {
     let (data, err) = serializer.get(key);
     if err != 0 {
         (vec![], AnnaError::KeyDne as i32)
@@ -26,7 +26,7 @@ pub(crate) fn process_get(key: &str, serializer: &dyn Serializer) -> (Vec<u8>, i
 
 /// Process a PUT request for a key.
 /// Returns the serialized size on success.
-pub(crate) fn process_put(
+pub fn process_put(
     key: &str,
     lattice_type: LatticeType,
     payload: &[u8],
@@ -59,7 +59,7 @@ pub(crate) fn process_put(
 
 /// Build gossip KeyRequest messages from an address-keyset map.
 /// Returns a list of outgoing messages to send via ZMQ PUSH.
-pub(crate) fn build_gossip_messages(
+pub fn build_gossip_messages(
     addr_keyset_map: &AddressKeysetMap,
     serializers: &HashMap<i32, Box<dyn Serializer>>,
     stored_key_map: &HashMap<Key, KeyProperty>,
@@ -109,7 +109,7 @@ pub(crate) fn build_gossip_messages(
 
 /// Remove expired keys from the store.
 /// Returns the number of keys reaped.
-pub(crate) fn gc_reap_expired_keys(
+pub fn gc_reap_expired_keys(
     stored_key_map: &mut HashMap<Key, KeyProperty>,
     serializers: &mut SerializerMap,
 ) -> usize {
@@ -134,7 +134,7 @@ pub(crate) fn gc_reap_expired_keys(
 }
 
 /// Current epoch time in seconds.
-pub(crate) fn now_epoch_s() -> u32 {
+pub fn now_epoch_s() -> u32 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
@@ -144,7 +144,7 @@ pub(crate) fn now_epoch_s() -> u32 {
 /// Generate a monotonic timestamp combining wall-clock millis with a thread ID.
 /// Mirrors C++ `generate_timestamp` — dynamically scales the multiplier so
 /// that any thread ID fits without collision.
-pub(crate) fn generate_timestamp(tid: u32) -> u64 {
+pub fn generate_timestamp(tid: u32) -> u64 {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()

--- a/server/rust/anna-kvs/src/kvs_server.rs
+++ b/server/rust/anna-kvs/src/kvs_server.rs
@@ -16,9 +16,9 @@ use anna_server_common::types::Address;
 use omq_tokio::{Context, Message as ZmqMessage, Options, SocketType};
 use prost::Message;
 
-use crate::context::KvsContext;
-use crate::handlers;
-use crate::storage;
+use anna_kvs::context::KvsContext;
+use anna_kvs::handlers;
+use anna_kvs::storage;
 
 /// ZMQ PUSH socket cache — lazily connects on first send.
 struct SocketCache {

--- a/server/rust/anna-kvs/src/lib.rs
+++ b/server/rust/anna-kvs/src/lib.rs
@@ -1,0 +1,8 @@
+//! Anna KVS core library.
+//!
+//! Provides the storage layer, request handlers and server context used by
+//! both the `anna-kvs-rs` network binary and embeddable configurations.
+
+pub mod context;
+pub mod handlers;
+pub mod storage;

--- a/server/rust/anna-kvs/src/main.rs
+++ b/server/rust/anna-kvs/src/main.rs
@@ -2,10 +2,7 @@
 //!
 //! Usage: `anna-kvs-rs --config <config.yml>`
 
-mod context;
-mod handlers;
 mod kvs_server;
-mod storage;
 
 use anna_server_common::config::Config;
 use anna_server_common::metadata::Tier;


### PR DESCRIPTION
## Summary

Phase 1 of #273 (Allow anna-kvs directly embedding as a rust library).

Splits the `anna-kvs` crate into a library target (`anna_kvs`) and a binary target (`anna-kvs-rs`). This is a structural refactor with no behavior changes — it prepares the crate for downstream consumers like the upcoming `anna-embedded` crate (#574).

## Changes

- **Cargo.toml**: Added `[lib]` section (`anna_kvs`, `src/lib.rs`) alongside existing `[[bin]]`
- **lib.rs** (new): Re-exports `context`, `handlers`, `storage` modules
- **main.rs**: Removed `mod context/handlers/storage` declarations; binary now imports from the library. `mod kvs_server` (the ZMQ event loop) remains binary-only.
- **Visibility widened** from `pub(crate)` to `pub` on:
  - `KvsContext` struct and all fields
  - `PendingRequest`, `PendingGossip`, `AddressKeysetMap`, `OutgoingMessage` types
  - All 11 handler `handle()` functions and handler sub-modules
  - Utility functions: `process_get`, `process_put`, `build_gossip_messages`, `gc_reap_expired_keys`, `generate_timestamp`, `now_epoch_s`
- **Test support**: Moved `make_test_ctx()`/`make_test_ctx_with_node()` from `#[cfg(test)]` module to public `context::test_support` module, available to downstream crates

## Verification

- All 59 anna-kvs unit tests pass unchanged
- All black-box/integration tests pass (Rust, C++, Python, Go clients against both C++ and Rust servers)
- `make clippy && make fmt && make test` all pass

Closes #573