### PR TITLE
Add anna-embedded crate: embeddable actor-based KVS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "anna-embedded"
+version = "0.1.0"
+dependencies = [
+ "anna-kvs",
+ "anna-server-common",
+ "env_logger",
+ "log",
+ "prost",
+]
+
+[[package]]
 name = "anna-hashring"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "server/rust/anna-monitor",
     "server/rust/anna-hashring",
     "server/rust/anna-kvs",
+    "server/rust/anna-embedded",
     "server/rust/anna-route",
 ]
 default-members = ["clients/rust"]

--- a/server/rust/anna-embedded/Cargo.toml
+++ b/server/rust/anna-embedded/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "anna-embedded"
+version = "0.1.0"
+edition = "2021"
+description = "Embeddable Anna KVS — lock-free actor-based key-value store"
+
+[lib]
+name = "anna_embedded"
+path = "src/lib.rs"
+
+[dependencies]
+anna-kvs = { path = "../anna-kvs" }
+anna-server-common = { path = "../server-common" }
+log = "0.4"
+prost = "0.14"
+
+[dev-dependencies]
+env_logger = "0.11"

--- a/server/rust/anna-embedded/examples/basic.rs
+++ b/server/rust/anna-embedded/examples/basic.rs
@@ -1,0 +1,47 @@
+//! Basic example: single-threaded put/get/delete/scan.
+
+use anna_embedded::EmbeddedKvs;
+
+fn main() {
+    env_logger::init();
+
+    let kvs = EmbeddedKvs::new(2).expect("failed to create embedded KVS");
+    println!("Created embedded KVS with {} actors", kvs.num_actors());
+
+    // Put some values.
+    kvs.put("greeting", b"hello world").unwrap();
+    kvs.put("name", b"Anna").unwrap();
+    kvs.put("version", b"0.1.0").unwrap();
+
+    // Get a value.
+    let value = kvs.get("greeting").unwrap();
+    println!(
+        "greeting = {:?}",
+        value.map(|v| String::from_utf8_lossy(&v).to_string())
+    );
+
+    // Scan all keys.
+    let entries = kvs.scan("").unwrap();
+    println!("All keys ({}):", entries.len());
+    for entry in &entries {
+        println!("  {} ({} bytes)", entry.key, entry.size);
+    }
+
+    // Delete a key.
+    kvs.delete("name").unwrap();
+    let deleted = kvs.get("name").unwrap();
+    println!("name after delete = {:?}", deleted);
+
+    // Scan with prefix.
+    kvs.put("user:alice", b"alice@example.com").unwrap();
+    kvs.put("user:bob", b"bob@example.com").unwrap();
+    kvs.put("config:timeout", b"30").unwrap();
+
+    let users = kvs.scan("user:").unwrap();
+    println!("Keys with prefix 'user:' ({}):", users.len());
+    for entry in &users {
+        println!("  {}", entry.key);
+    }
+
+    println!("Done.");
+}

--- a/server/rust/anna-embedded/examples/multithreaded.rs
+++ b/server/rust/anna-embedded/examples/multithreaded.rs
@@ -1,0 +1,92 @@
+//! Multi-threaded example: concurrent reads and writes from multiple threads.
+
+use anna_embedded::EmbeddedKvs;
+use std::sync::Arc;
+use std::thread;
+use std::time::Instant;
+
+fn main() {
+    env_logger::init();
+
+    let num_actors = 4;
+    let num_writer_threads = 4;
+    let num_reader_threads = 4;
+    let keys_per_writer = 1000;
+
+    let kvs = Arc::new(EmbeddedKvs::new(num_actors).expect("failed to create embedded KVS"));
+    println!(
+        "Created embedded KVS with {} actors, launching {} writers and {} readers",
+        kvs.num_actors(),
+        num_writer_threads,
+        num_reader_threads
+    );
+
+    let start = Instant::now();
+
+    // Spawn writer threads.
+    let mut handles = Vec::new();
+    for writer_id in 0..num_writer_threads {
+        let kvs = Arc::clone(&kvs);
+        handles.push(thread::spawn(move || {
+            for i in 0..keys_per_writer {
+                let key = format!("w{}_key_{}", writer_id, i);
+                let value = format!("value_{}_{}", writer_id, i);
+                kvs.put(&key, value.as_bytes()).unwrap();
+            }
+        }));
+    }
+
+    // Wait for writers to finish.
+    for h in handles {
+        h.join().unwrap();
+    }
+    let write_elapsed = start.elapsed();
+    let total_writes = num_writer_threads * keys_per_writer;
+    println!(
+        "Wrote {} keys in {:.2?} ({:.0} ops/sec)",
+        total_writes,
+        write_elapsed,
+        total_writes as f64 / write_elapsed.as_secs_f64()
+    );
+
+    // Spawn reader threads that read all keys.
+    let read_start = Instant::now();
+    let mut handles = Vec::new();
+    for reader_id in 0..num_reader_threads {
+        let kvs = Arc::clone(&kvs);
+        handles.push(thread::spawn(move || {
+            let mut found = 0u64;
+            let mut missing = 0u64;
+            // Each reader reads keys from all writers.
+            for writer_id in 0..num_writer_threads {
+                for i in 0..keys_per_writer {
+                    let key = format!("w{}_key_{}", writer_id, i);
+                    match kvs.get(&key).unwrap() {
+                        Some(_) => found += 1,
+                        None => missing += 1,
+                    }
+                }
+            }
+            println!("Reader {}: found={}, missing={}", reader_id, found, missing);
+            found
+        }));
+    }
+
+    let mut total_reads = 0u64;
+    for h in handles {
+        total_reads += h.join().unwrap();
+    }
+    let read_elapsed = read_start.elapsed();
+    println!(
+        "Read {} keys in {:.2?} ({:.0} ops/sec)",
+        total_reads,
+        read_elapsed,
+        total_reads as f64 / read_elapsed.as_secs_f64()
+    );
+
+    // Final scan.
+    let entries = kvs.scan("").unwrap();
+    println!("Total keys in store: {}", entries.len());
+
+    println!("Done.");
+}

--- a/server/rust/anna-embedded/src/actor.rs
+++ b/server/rust/anna-embedded/src/actor.rs
@@ -1,0 +1,325 @@
+//! Actor thread — processes requests sequentially with its own storage.
+//!
+//! Each actor owns a `KvsContext` and `SerializerMap`. Requests arrive
+//! via a channel, are processed inline, and the response is sent back
+//! through a oneshot-style channel.
+
+use std::collections::HashMap;
+use std::sync::mpsc;
+use std::thread;
+
+use anna_kvs::handlers::utils::{
+    gc_reap_expired_keys, generate_timestamp, now_epoch_s, process_get, process_put,
+};
+use anna_kvs::storage::{self, SerializerMap};
+use anna_server_common::metadata::{is_metadata, KeyProperty};
+use anna_server_common::proto::kvs::{AnnaError, LatticeType, LwwValue};
+use anna_server_common::types::Key;
+use prost::Message;
+
+use crate::ScanEntry;
+
+/// A request sent to an actor thread.
+pub(crate) enum Request {
+    Put {
+        key: String,
+        value: Vec<u8>,
+        lattice_type: LatticeType,
+        expiry_epoch_ms: u64,
+    },
+    Get {
+        key: String,
+    },
+    Delete {
+        key: String,
+    },
+    Scan {
+        prefix: String,
+    },
+    Shutdown,
+}
+
+/// A response from an actor thread.
+pub(crate) enum Response {
+    Ok,
+    Value(Vec<u8>),
+    NotFound,
+    ScanResult(Vec<ScanEntry>),
+    Error(String),
+}
+
+/// An envelope wrapping a request and a reply channel.
+struct Envelope {
+    request: Request,
+    reply: mpsc::Sender<Response>,
+}
+
+/// Handle to a running actor thread. Holds the send side of the channel.
+pub(crate) struct ActorHandle {
+    sender: mpsc::Sender<Envelope>,
+}
+
+impl ActorHandle {
+    /// Spawn a new actor thread with the given thread ID.
+    pub(crate) fn spawn(tid: u32) -> Self {
+        let (tx, rx) = mpsc::channel::<Envelope>();
+
+        thread::Builder::new()
+            .name(format!("anna-actor-{}", tid))
+            .spawn(move || {
+                actor_loop(tid, rx);
+            })
+            .expect("failed to spawn actor thread");
+
+        ActorHandle { sender: tx }
+    }
+
+    /// Send a request and wait for the response.
+    pub(crate) fn send(&self, request: Request) -> crate::Result<Response> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        let envelope = Envelope {
+            request,
+            reply: reply_tx,
+        };
+        self.sender
+            .send(envelope)
+            .map_err(|_| crate::Error::ActorGone)?;
+        reply_rx.recv().map_err(|_| crate::Error::ActorGone)
+    }
+
+    /// Signal the actor to shut down (best-effort, does not block).
+    pub(crate) fn shutdown(&self) {
+        let (reply_tx, _) = mpsc::channel();
+        let _ = self.sender.send(Envelope {
+            request: Request::Shutdown,
+            reply: reply_tx,
+        });
+    }
+}
+
+/// Generate a strictly monotonic timestamp for this actor.
+///
+/// Combines `generate_timestamp(tid)` with a local sequence counter
+/// to guarantee that every operation within an actor gets a unique,
+/// strictly increasing timestamp — even when multiple operations
+/// happen within the same millisecond.
+fn monotonic_timestamp(tid: u32, seq: &mut u64) -> u64 {
+    let wall = generate_timestamp(tid);
+    *seq = (*seq).max(wall) + 1;
+    *seq
+}
+
+/// The actor event loop — processes requests one at a time.
+fn actor_loop(tid: u32, rx: mpsc::Receiver<Envelope>) {
+    let mut serializers = storage::create_memory_serializers();
+    let mut stored_key_map: HashMap<Key, KeyProperty> = HashMap::new();
+    let mut ts_seq: u64 = 0;
+
+    // Periodic GC tracking.
+    let mut last_gc = std::time::Instant::now();
+    let gc_interval = std::time::Duration::from_secs(30);
+
+    log::debug!("Actor {} started", tid);
+
+    while let Ok(envelope) = rx.recv() {
+        let response = match envelope.request {
+            Request::Put {
+                key,
+                value,
+                lattice_type,
+                expiry_epoch_ms,
+            } => handle_put(
+                &key,
+                &value,
+                lattice_type,
+                expiry_epoch_ms,
+                &mut serializers,
+                &mut stored_key_map,
+                monotonic_timestamp(tid, &mut ts_seq),
+            ),
+            Request::Get { key } => handle_get(&key, &serializers, &stored_key_map),
+            Request::Delete { key } => handle_delete(
+                &key,
+                &mut serializers,
+                &mut stored_key_map,
+                monotonic_timestamp(tid, &mut ts_seq),
+            ),
+            Request::Scan { prefix } => handle_scan(&prefix, &serializers, &stored_key_map),
+            Request::Shutdown => {
+                log::debug!("Actor {} shutting down", tid);
+                break;
+            }
+        };
+
+        // Send response (ignore error if caller dropped the receiver).
+        let _ = envelope.reply.send(response);
+
+        // Periodic GC.
+        if last_gc.elapsed() >= gc_interval {
+            let reaped = gc_reap_expired_keys(&mut stored_key_map, &mut serializers);
+            if reaped > 0 {
+                log::debug!("Actor {}: GC reaped {} expired keys", tid, reaped);
+            }
+            last_gc = std::time::Instant::now();
+        }
+    }
+
+    log::debug!("Actor {} stopped", tid);
+}
+
+/// Handle a PUT request: wrap the raw value in an LWW envelope and store it.
+fn handle_put(
+    key: &str,
+    value: &[u8],
+    lattice_type: LatticeType,
+    expiry_epoch_ms: u64,
+    serializers: &mut SerializerMap,
+    stored_key_map: &mut HashMap<Key, KeyProperty>,
+    timestamp: u64,
+) -> Response {
+    let payload = match lattice_type {
+        LatticeType::Lww => {
+            // Wrap raw bytes in an LWW envelope with a monotonic timestamp.
+            let lww = LwwValue {
+                timestamp,
+                value: value.to_vec(),
+            };
+            lww.encode_to_vec()
+        }
+        _ => {
+            // For other lattice types, the caller must provide the
+            // correctly serialized protobuf payload.
+            value.to_vec()
+        }
+    };
+
+    let serializer = match serializers.get_mut(&(lattice_type as i32)) {
+        Some(s) => s,
+        None => return Response::Error(format!("unsupported lattice type: {:?}", lattice_type)),
+    };
+
+    process_put(
+        key,
+        lattice_type,
+        &payload,
+        serializer.as_mut(),
+        stored_key_map,
+        expiry_epoch_ms,
+    );
+
+    Response::Ok
+}
+
+/// Handle a GET request: retrieve and unwrap the LWW value.
+fn handle_get(
+    key: &str,
+    serializers: &SerializerMap,
+    stored_key_map: &HashMap<Key, KeyProperty>,
+) -> Response {
+    let kp = match stored_key_map.get(key) {
+        Some(kp) => kp,
+        None => return Response::NotFound,
+    };
+
+    // Check for tombstone or expired key.
+    if kp.size() == 0 {
+        return Response::NotFound;
+    }
+    if kp.expiry_epoch_s > 0 && now_epoch_s() >= kp.expiry_epoch_s {
+        return Response::NotFound;
+    }
+
+    let lt = kp.lattice_type();
+    let serializer = match serializers.get(&(lt as i32)) {
+        Some(s) => s,
+        None => return Response::NotFound,
+    };
+
+    let (payload, err) = process_get(key, serializer.as_ref());
+    if err != AnnaError::NoError as i32 {
+        return Response::NotFound;
+    }
+
+    // For LWW, unwrap the envelope to return just the raw value.
+    match lt {
+        LatticeType::Lww => match LwwValue::decode(payload.as_slice()) {
+            Ok(lww) if lww.value.is_empty() => Response::NotFound,
+            Ok(lww) => Response::Value(lww.value),
+            Err(_) => Response::Value(payload),
+        },
+        _ => Response::Value(payload),
+    }
+}
+
+/// Handle a DELETE request: write a tombstone (empty LWW value).
+fn handle_delete(
+    key: &str,
+    serializers: &mut SerializerMap,
+    stored_key_map: &mut HashMap<Key, KeyProperty>,
+    timestamp: u64,
+) -> Response {
+    // A tombstone is an LWW value with an empty payload.
+    let lww = LwwValue {
+        timestamp,
+        value: vec![],
+    };
+    let payload = lww.encode_to_vec();
+
+    let serializer = match serializers.get_mut(&(LatticeType::Lww as i32)) {
+        Some(s) => s,
+        None => return Response::Error("LWW serializer not found".into()),
+    };
+
+    process_put(
+        key,
+        LatticeType::Lww,
+        &payload,
+        serializer.as_mut(),
+        stored_key_map,
+        0,
+    );
+
+    Response::Ok
+}
+
+/// Handle a SCAN request: list keys matching a prefix.
+///
+/// Uses the serializer's `get()` to detect tombstones (LWW with empty
+/// value), since `KeyProperty::size()` tracks the protobuf encoding
+/// size, not the logical value size.
+fn handle_scan(
+    prefix: &str,
+    serializers: &SerializerMap,
+    stored_key_map: &HashMap<Key, KeyProperty>,
+) -> Response {
+    let mut entries = Vec::new();
+    for (k, kp) in stored_key_map {
+        if is_metadata(k) {
+            continue;
+        }
+        if kp.expiry_epoch_s > 0 && now_epoch_s() >= kp.expiry_epoch_s {
+            continue;
+        }
+        if !prefix.is_empty() && !k.starts_with(prefix) {
+            continue;
+        }
+
+        // Check via the serializer whether this is a live value or a tombstone.
+        let lt = kp.lattice_type() as i32;
+        if let Some(serializer) = serializers.get(&lt) {
+            let (_, err) = process_get(k, serializer.as_ref());
+            if err != AnnaError::NoError as i32 {
+                continue; // Tombstone or missing — skip.
+            }
+        } else {
+            continue;
+        }
+
+        entries.push(ScanEntry {
+            key: k.clone(),
+            size: kp.size(),
+        });
+    }
+    entries.sort_by(|a, b| a.key.cmp(&b.key));
+    Response::ScanResult(entries)
+}

--- a/server/rust/anna-embedded/src/lib.rs
+++ b/server/rust/anna-embedded/src/lib.rs
@@ -1,0 +1,226 @@
+//! Embeddable Anna KVS — a lock-free, actor-based key-value store.
+//!
+//! `EmbeddedKvs` spawns N actor threads, each with independent storage.
+//! Keys are partitioned across actors using consistent hashing (the same
+//! algorithm as the distributed Anna KVS). Each actor processes requests
+//! sequentially with no locks on the hot path.
+//!
+//! # Example
+//!
+//! ```rust
+//! use anna_embedded::EmbeddedKvs;
+//!
+//! let kvs = EmbeddedKvs::new(4).unwrap(); // 4 actor threads
+//! kvs.put("hello", b"world").unwrap();
+//! let value = kvs.get("hello").unwrap();
+//! assert_eq!(value, Some(b"world".to_vec()));
+//! kvs.delete("hello").unwrap();
+//! assert_eq!(kvs.get("hello").unwrap(), None);
+//! ```
+
+mod actor;
+
+use actor::{ActorHandle, Request, Response};
+use anna_server_common::hash_ring::{ConsistentHashRing, DEFAULT_VIRTUAL_THREAD_NUM};
+use anna_server_common::proto::kvs::LatticeType;
+use std::fmt;
+
+/// Errors returned by the embedded KVS.
+#[derive(Debug)]
+pub enum Error {
+    /// The number of actors must be at least 1.
+    InvalidActorCount,
+    /// An actor thread has shut down or panicked.
+    ActorGone,
+    /// Internal error from the storage layer.
+    Internal(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidActorCount => write!(f, "actor count must be >= 1"),
+            Error::ActorGone => write!(f, "actor thread is no longer running"),
+            Error::Internal(msg) => write!(f, "internal error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Result type for embedded KVS operations.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// An entry returned by [`EmbeddedKvs::scan`].
+#[derive(Debug, Clone)]
+pub struct ScanEntry {
+    /// The key.
+    pub key: String,
+    /// Size in bytes of the stored value.
+    pub size: u32,
+}
+
+/// An embeddable, lock-free, actor-based key-value store.
+///
+/// Each actor thread owns independent storage and processes requests
+/// sequentially. Keys are partitioned across actors using consistent
+/// hashing. The public API is `Send + Sync` — multiple threads can
+/// call `put`/`get`/`delete` concurrently.
+pub struct EmbeddedKvs {
+    actors: Vec<ActorHandle>,
+    local_ring: ConsistentHashRing,
+}
+
+// The struct holds only Senders (which are Send+Sync) and an immutable ring.
+// SAFETY: ActorHandle contains only std::sync::mpsc::Sender (Send) and a u32.
+// ConsistentHashRing is read-only after construction.
+unsafe impl Send for EmbeddedKvs {}
+unsafe impl Sync for EmbeddedKvs {}
+
+impl EmbeddedKvs {
+    /// Create a new embedded KVS with `num_actors` actor threads.
+    ///
+    /// Each actor gets its own independent storage. Keys are partitioned
+    /// across actors using the same consistent hashing algorithm as the
+    /// distributed Anna KVS.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidActorCount`] if `num_actors` is 0.
+    pub fn new(num_actors: u32) -> Result<Self> {
+        if num_actors == 0 {
+            return Err(Error::InvalidActorCount);
+        }
+
+        // Build the local hash ring with all actor threads.
+        let mut local_ring = ConsistentHashRing::new();
+        for tid in 0..num_actors {
+            // Use dummy IPs — embedded mode has no network identity.
+            local_ring.insert(
+                "embedded",
+                "embedded",
+                tid,
+                0,
+                DEFAULT_VIRTUAL_THREAD_NUM,
+                false,
+            );
+        }
+
+        // Spawn actor threads.
+        let mut actors = Vec::with_capacity(num_actors as usize);
+        for tid in 0..num_actors {
+            actors.push(ActorHandle::spawn(tid));
+        }
+
+        Ok(EmbeddedKvs { actors, local_ring })
+    }
+
+    /// Store a value under a key (last-writer-wins semantics).
+    ///
+    /// If the key already exists, the new value replaces it (LWW merge
+    /// by timestamp — the newer write always wins).
+    pub fn put(&self, key: &str, value: &[u8]) -> Result<()> {
+        self.put_with_lattice(key, value, LatticeType::Lww, 0)
+    }
+
+    /// Store a value with a time-to-live in seconds.
+    ///
+    /// The key will be automatically removed after `ttl_secs` seconds.
+    pub fn put_with_ttl(&self, key: &str, value: &[u8], ttl_secs: u32) -> Result<()> {
+        let expiry_epoch_ms =
+            (anna_kvs::handlers::utils::now_epoch_s() as u64 + ttl_secs as u64) * 1000;
+        self.put_with_lattice(key, value, LatticeType::Lww, expiry_epoch_ms)
+    }
+
+    /// Retrieve the value for a key.
+    ///
+    /// Returns `Ok(None)` if the key does not exist.
+    pub fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        let actor = self.route(key);
+        let resp = actor.send(Request::Get {
+            key: key.to_string(),
+        })?;
+        match resp {
+            Response::Value(data) => Ok(Some(data)),
+            Response::NotFound => Ok(None),
+            Response::Error(msg) => Err(Error::Internal(msg)),
+            _ => Err(Error::Internal("unexpected response".into())),
+        }
+    }
+
+    /// Delete a key (tombstone write).
+    ///
+    /// After deletion, `get` returns `None`. The tombstone is eventually
+    /// garbage-collected.
+    pub fn delete(&self, key: &str) -> Result<()> {
+        let actor = self.route(key);
+        let resp = actor.send(Request::Delete {
+            key: key.to_string(),
+        })?;
+        match resp {
+            Response::Ok | Response::NotFound => Ok(()),
+            Response::Error(msg) => Err(Error::Internal(msg)),
+            _ => Err(Error::Internal("unexpected response".into())),
+        }
+    }
+
+    /// List keys matching an optional prefix.
+    ///
+    /// Returns entries from all actors, sorted by key. Pass an empty
+    /// string to list all keys.
+    pub fn scan(&self, prefix: &str) -> Result<Vec<ScanEntry>> {
+        let mut all_entries = Vec::new();
+        for actor in &self.actors {
+            let resp = actor.send(Request::Scan {
+                prefix: prefix.to_string(),
+            })?;
+            if let Response::ScanResult(entries) = resp {
+                all_entries.extend(entries);
+            }
+        }
+        all_entries.sort_by(|a, b| a.key.cmp(&b.key));
+        Ok(all_entries)
+    }
+
+    /// Return the number of actor threads.
+    pub fn num_actors(&self) -> u32 {
+        self.actors.len() as u32
+    }
+
+    /// Internal: put with explicit lattice type and expiry.
+    fn put_with_lattice(
+        &self,
+        key: &str,
+        value: &[u8],
+        lattice_type: LatticeType,
+        expiry_epoch_ms: u64,
+    ) -> Result<()> {
+        let actor = self.route(key);
+        let resp = actor.send(Request::Put {
+            key: key.to_string(),
+            value: value.to_vec(),
+            lattice_type,
+            expiry_epoch_ms,
+        })?;
+        match resp {
+            Response::Ok => Ok(()),
+            Response::Error(msg) => Err(Error::Internal(msg)),
+            _ => Err(Error::Internal("unexpected response".into())),
+        }
+    }
+
+    /// Route a key to its responsible actor using the local hash ring.
+    fn route(&self, key: &str) -> &ActorHandle {
+        let tids = self.local_ring.find_responsible_local(key, 1);
+        let tid = tids.first().copied().unwrap_or(0);
+        &self.actors[tid as usize]
+    }
+}
+
+impl Drop for EmbeddedKvs {
+    fn drop(&mut self) {
+        for actor in &self.actors {
+            actor.shutdown();
+        }
+    }
+}

--- a/server/rust/anna-embedded/tests/embedded.rs
+++ b/server/rust/anna-embedded/tests/embedded.rs
@@ -1,0 +1,247 @@
+//! Integration tests for the embedded KVS.
+
+use anna_embedded::EmbeddedKvs;
+use std::sync::Arc;
+use std::thread;
+
+#[test]
+fn put_and_get() {
+    let kvs = EmbeddedKvs::new(2).unwrap();
+    kvs.put("key1", b"value1").unwrap();
+
+    let result = kvs.get("key1").unwrap();
+    assert_eq!(result, Some(b"value1".to_vec()));
+}
+
+#[test]
+fn get_missing_key() {
+    let kvs = EmbeddedKvs::new(1).unwrap();
+    let result = kvs.get("nonexistent").unwrap();
+    assert_eq!(result, None);
+}
+
+#[test]
+fn delete_key() {
+    let kvs = EmbeddedKvs::new(2).unwrap();
+    kvs.put("del_me", b"gone").unwrap();
+    assert_eq!(kvs.get("del_me").unwrap(), Some(b"gone".to_vec()));
+
+    kvs.delete("del_me").unwrap();
+    assert_eq!(kvs.get("del_me").unwrap(), None);
+}
+
+#[test]
+fn delete_nonexistent_key() {
+    let kvs = EmbeddedKvs::new(1).unwrap();
+    // Deleting a key that doesn't exist should not error.
+    kvs.delete("never_existed").unwrap();
+}
+
+#[test]
+fn overwrite_value() {
+    let kvs = EmbeddedKvs::new(2).unwrap();
+    kvs.put("key", b"first").unwrap();
+    kvs.put("key", b"second").unwrap();
+
+    let result = kvs.get("key").unwrap();
+    assert_eq!(result, Some(b"second".to_vec()));
+}
+
+#[test]
+fn scan_all_keys() {
+    let kvs = EmbeddedKvs::new(2).unwrap();
+    kvs.put("b_key", b"b").unwrap();
+    kvs.put("a_key", b"a").unwrap();
+    kvs.put("c_key", b"c").unwrap();
+
+    let entries = kvs.scan("").unwrap();
+    assert_eq!(entries.len(), 3);
+    // Should be sorted.
+    assert_eq!(entries[0].key, "a_key");
+    assert_eq!(entries[1].key, "b_key");
+    assert_eq!(entries[2].key, "c_key");
+}
+
+#[test]
+fn scan_with_prefix() {
+    let kvs = EmbeddedKvs::new(2).unwrap();
+    kvs.put("user:alice", b"a").unwrap();
+    kvs.put("user:bob", b"b").unwrap();
+    kvs.put("config:timeout", b"30").unwrap();
+
+    let users = kvs.scan("user:").unwrap();
+    assert_eq!(users.len(), 2);
+    assert!(users.iter().all(|e| e.key.starts_with("user:")));
+
+    let configs = kvs.scan("config:").unwrap();
+    assert_eq!(configs.len(), 1);
+}
+
+#[test]
+fn scan_excludes_deleted_keys() {
+    let kvs = EmbeddedKvs::new(1).unwrap();
+    kvs.put("keep", b"yes").unwrap();
+    kvs.put("remove", b"no").unwrap();
+    kvs.delete("remove").unwrap();
+
+    let entries = kvs.scan("").unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].key, "keep");
+}
+
+#[test]
+fn multiple_actors_partition_keys() {
+    let kvs = EmbeddedKvs::new(4).unwrap();
+
+    // Write many keys — they should be distributed across actors.
+    for i in 0..100 {
+        kvs.put(&format!("key_{}", i), format!("val_{}", i).as_bytes())
+            .unwrap();
+    }
+
+    // All keys should be retrievable.
+    for i in 0..100 {
+        let val = kvs.get(&format!("key_{}", i)).unwrap();
+        assert_eq!(val, Some(format!("val_{}", i).into_bytes()));
+    }
+
+    let entries = kvs.scan("").unwrap();
+    assert_eq!(entries.len(), 100);
+}
+
+#[test]
+fn zero_actors_is_error() {
+    let result = EmbeddedKvs::new(0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn single_actor_works() {
+    let kvs = EmbeddedKvs::new(1).unwrap();
+    kvs.put("solo", b"value").unwrap();
+    assert_eq!(kvs.get("solo").unwrap(), Some(b"value".to_vec()));
+}
+
+#[test]
+fn many_actors_works() {
+    let kvs = EmbeddedKvs::new(16).unwrap();
+    for i in 0..50 {
+        kvs.put(&format!("k{}", i), b"v").unwrap();
+    }
+    let entries = kvs.scan("").unwrap();
+    assert_eq!(entries.len(), 50);
+}
+
+#[test]
+fn concurrent_writes() {
+    let kvs = Arc::new(EmbeddedKvs::new(4).unwrap());
+    let mut handles = Vec::new();
+
+    for thread_id in 0..8 {
+        let kvs = Arc::clone(&kvs);
+        handles.push(thread::spawn(move || {
+            for i in 0..100 {
+                let key = format!("t{}_k{}", thread_id, i);
+                kvs.put(&key, b"value").unwrap();
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // All 800 keys should be present.
+    let entries = kvs.scan("").unwrap();
+    assert_eq!(entries.len(), 800);
+}
+
+#[test]
+fn concurrent_reads_and_writes() {
+    let kvs = Arc::new(EmbeddedKvs::new(4).unwrap());
+
+    // Pre-populate.
+    for i in 0..100 {
+        kvs.put(&format!("pre_{}", i), b"initial").unwrap();
+    }
+
+    let mut handles = Vec::new();
+
+    // Writers overwrite existing keys.
+    for thread_id in 0..4 {
+        let kvs = Arc::clone(&kvs);
+        handles.push(thread::spawn(move || {
+            for i in 0..100 {
+                let key = format!("pre_{}", i);
+                let val = format!("updated_by_{}", thread_id);
+                kvs.put(&key, val.as_bytes()).unwrap();
+            }
+        }));
+    }
+
+    // Readers read concurrently.
+    for _ in 0..4 {
+        let kvs = Arc::clone(&kvs);
+        handles.push(thread::spawn(move || {
+            for i in 0..100 {
+                let key = format!("pre_{}", i);
+                // Should always get a value (never None since we pre-populated
+                // and writers only overwrite, never delete).
+                let val = kvs.get(&key).unwrap();
+                assert!(val.is_some(), "key {} should exist", key);
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}
+
+#[test]
+fn ttl_key_expires() {
+    let kvs = EmbeddedKvs::new(1).unwrap();
+    // Set a TTL of 1 second.
+    kvs.put_with_ttl("ephemeral", b"temporary", 1).unwrap();
+
+    // Should be readable immediately.
+    assert_eq!(kvs.get("ephemeral").unwrap(), Some(b"temporary".to_vec()));
+
+    // Wait for expiry.
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // Should be gone.
+    assert_eq!(kvs.get("ephemeral").unwrap(), None);
+}
+
+#[test]
+fn large_values() {
+    let kvs = EmbeddedKvs::new(2).unwrap();
+    let large_value = vec![42u8; 1_000_000]; // 1 MB
+    kvs.put("large", &large_value).unwrap();
+
+    let result = kvs.get("large").unwrap().unwrap();
+    assert_eq!(result.len(), 1_000_000);
+    assert!(result.iter().all(|&b| b == 42));
+}
+
+#[test]
+fn empty_value() {
+    let kvs = EmbeddedKvs::new(1).unwrap();
+    kvs.put("empty", b"").unwrap();
+
+    // Empty value is stored as an LWW tombstone, which means it's treated
+    // as deleted. This is consistent with the Anna KVS semantics.
+    let result = kvs.get("empty").unwrap();
+    assert_eq!(result, None);
+}
+
+#[test]
+fn binary_values() {
+    let kvs = EmbeddedKvs::new(2).unwrap();
+    let binary = vec![0u8, 1, 2, 255, 254, 253, 0, 0];
+    kvs.put("binary", &binary).unwrap();
+
+    let result = kvs.get("binary").unwrap().unwrap();
+    assert_eq!(result, binary);
+}


### PR DESCRIPTION
## Summary

Phase 2 of #273 (Allow anna-kvs directly embedding as a rust library).

New `anna-embedded` crate that provides an embeddable, lock-free key-value store using the same actor model as the distributed Anna KVS.

## Design

- **Actor model**: Each actor thread owns independent storage (`SerializerMap` + `stored_key_map`), processes requests sequentially with no locks on the hot path
- **Consistent hashing**: Keys are partitioned across actors using the same `ConsistentHashRing::find_responsible_local` algorithm as the distributed server
- **Channel-based communication**: Requests arrive via `std::sync::mpsc` channels (no new dependencies required)
- **Monotonic timestamps**: Per-actor sequence counter ensures LWW overwrites always succeed, even within the same millisecond
- **Tombstone-aware scan**: Uses serializer `get()` to detect LWW tombstones (encoded protobuf size is non-zero even for empty values)
- **Periodic GC**: Reaps expired keys using the same `gc_reap_expired_keys` from `anna-kvs` lib
- **`Send + Sync`**: Safe for concurrent use from multiple threads

## Public API

```rust
let kvs = EmbeddedKvs::new(4)?;          // 4 actor threads
kvs.put("key", b"value")?;
kvs.put_with_ttl("key", b"value", 60)?;  // 60s TTL
let val = kvs.get("key")?;               // -> Option<Vec<u8>>
kvs.delete("key")?;
let entries = kvs.scan("prefix:")?;      // -> Vec<ScanEntry>
```

## Tests (18 integration tests)

- Basic put/get/delete/scan
- Overwrite semantics (LWW)
- TTL expiry
- Large values (1 MB), binary values, empty values
- Multi-actor key partitioning (100 keys across 4 actors)
- Concurrent writes (8 threads, 800 keys)
- Concurrent reads + writes (4 writers + 4 readers)
- Scan with prefix filtering, deleted key exclusion

## Examples

- `basic.rs` — single-threaded put/get/delete/scan
- `multithreaded.rs` — concurrent access with throughput measurement (~154K writes/sec, ~193K reads/sec in debug mode with 4 actors)

## What is NOT included (deferred)

- `MessageSender` trait: Not needed yet since we start with rep_factor=1 (no gossip between actors). Will be added when gossip support is needed.
- Async wrapper: Can add `tokio::task::spawn_blocking` later if needed.
- Other lattice types in public API: Currently only LWW is exposed via `put`/`get`. Other types can be added as needed.

Closes #574