### PR TITLE
Add example apps for all client libraries

### DIFF
--- a/clients/cpp/examples/basic.cpp
+++ b/clients/cpp/examples/basic.cpp
@@ -1,0 +1,175 @@
+// Basic example of using the anna C++ client library.
+//
+// This example starts the anna server processes (monitor, route, kvs),
+// connects a client, performs basic key-value operations (put, get, delete),
+// and then shuts the server down.
+//
+// Prerequisites:
+//   The anna server binaries (anna-monitor, anna-route, anna-kvs) must
+//   be in your PATH. Build them first with `make server-cpp` or `make server-rust`.
+//
+// Building and running:
+//   This example is built automatically as part of `make client-cpp`.
+//   Run it from the repository root:
+//     ./clients/cpp/build/examples/basic
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+#include "client_lib.hpp"
+
+static const char* kConfigTemplate = R"(monitoring:
+  scaling_alert_ip: 127.0.0.1
+  ip: 127.0.0.1
+routing:
+  monitoring:
+    - 127.0.0.1
+  ip: 127.0.0.1
+user:
+  monitoring:
+    - 127.0.0.1
+  routing:
+    - 127.0.0.1
+  ip: 127.0.0.1
+server:
+  monitoring:
+    - 127.0.0.1
+  routing:
+    - 127.0.0.1
+  seed_ip: 127.0.0.1
+  public_ip: 127.0.0.1
+  private_ip: 127.0.0.1
+  scaling_alert_ip: "NULL"
+policy:
+  elasticity: false
+  selective-rep: false
+  tiering: false
+disk: /tmp/anna_example_cpp/disk
+capacities:
+  memory-cap: 1
+  disk-cap: 0
+threads:
+  memory: 1
+  disk: 1
+  routing: 1
+  benchmark: 1
+replication:
+  memory: 1
+  disk: 0
+  minimum: 1
+  local: 1
+ports:
+  base_offset: 0
+)";
+
+// Write a config file and return the path.
+static std::string generate_config() {
+  std::string dir = "/tmp/anna_example_cpp";
+  system(("mkdir -p " + dir + "/disk").c_str());
+  std::string path = dir + "/config.yml";
+  std::ofstream f(path);
+  f << kConfigTemplate;
+  f.close();
+  return path;
+}
+
+// Wait for the routing tier to accept TCP connections.
+static bool wait_for_routing(int timeout_secs = 30) {
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(timeout_secs);
+  while (std::chrono::steady_clock::now() < deadline) {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      continue;
+    }
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(6450);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    bool ok = (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) == 0);
+    close(sock);
+    if (ok) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+  return false;
+}
+
+int main() {
+  std::string config_path = generate_config();
+
+  // Start the anna server
+  std::cout << "Starting anna server..." << std::endl;
+  int count = annalib::start(config_path);
+  std::cout << "  Started " << count << " processes" << std::endl;
+
+  if (!wait_for_routing()) {
+    std::cerr << "Routing tier did not start" << std::endl;
+    annalib::stop();
+    return 1;
+  }
+
+  // Connect a client
+  annalib::ClientConfig config;
+  config.routing_ips = {"127.0.0.1"};
+  config.routing_thread_count = 1;
+  config.ip = "127.0.0.1";
+  auto client = annalib::make_client(config, 50);
+
+  // PUT a value
+  std::cout << "\nPUT greeting = hello" << std::endl;
+  auto result = annalib::put(client.get(), "greeting", "hello");
+  if (!result.succeeded()) {
+    std::cerr << "PUT failed" << std::endl;
+  }
+
+  // GET it back
+  std::string val = annalib::get(client.get(), "greeting");
+  std::cout << "GET greeting = " << val << std::endl;
+
+  // Overwrite the value
+  std::cout << "\nPUT greeting = hello world" << std::endl;
+  annalib::put(client.get(), "greeting", "hello world");
+
+  val = annalib::get(client.get(), "greeting");
+  std::cout << "GET greeting = " << val << std::endl;
+
+  // PUT a second key
+  std::cout << "\nPUT count = 42" << std::endl;
+  annalib::put(client.get(), "count", "42");
+
+  // DELETE the first key
+  std::cout << "\nDELETE greeting" << std::endl;
+  annalib::del(client.get(), "greeting");
+
+  // Verify deletion
+  val = annalib::get(client.get(), "greeting");
+  if (val.empty()) {
+    std::cout << "GET greeting = (deleted)" << std::endl;
+  } else {
+    std::cout << "GET greeting = " << val << " (unexpected)" << std::endl;
+  }
+
+  // GET the remaining key
+  val = annalib::get(client.get(), "count");
+  std::cout << "GET count = " << val << std::endl;
+
+  // Stop the server
+  std::cout << "\nStopping anna server..." << std::endl;
+  int stopped = annalib::stop();
+  std::cout << "  Stopped " << stopped << " processes" << std::endl;
+
+  std::cout << "\nDone!" << std::endl;
+  return 0;
+}

--- a/clients/cpp/examples/basic.cpp
+++ b/clients/cpp/examples/basic.cpp
@@ -11,7 +11,7 @@
 // Building and running:
 //   This example is built automatically as part of `make client-cpp`.
 //   Run it from the repository root:
-//     ./clients/cpp/build/examples/basic
+//     ./clients/cpp/build/examples/basic-example
 
 #include <arpa/inet.h>
 #include <sys/socket.h>
@@ -132,6 +132,8 @@ int main() {
   auto result = annalib::put(client.get(), "greeting", "hello");
   if (!result.succeeded()) {
     std::cerr << "PUT failed" << std::endl;
+    annalib::stop();
+    return 1;
   }
 
   // GET it back

--- a/clients/cpp/src/CMakeLists.txt
+++ b/clients/cpp/src/CMakeLists.txt
@@ -36,3 +36,8 @@ ADD_EXECUTABLE(anna-cli cli.cpp)
 TARGET_LINK_LIBRARIES(anna-cli anna-client-lib anna-client-zmq fmt::fmt ${ZeroMQ_LIBRARY} ${LIBRARY_DEPENDENCIES})
 
 SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/cli)
+
+# Example: basic put/get/delete with self-starting server.
+ADD_EXECUTABLE(basic-example ${CMAKE_CURRENT_SOURCE_DIR}/../examples/basic.cpp)
+TARGET_LINK_LIBRARIES(basic-example anna-client-lib anna-client-zmq fmt::fmt ${ZeroMQ_LIBRARY} ${LIBRARY_DEPENDENCIES})
+SET_TARGET_PROPERTIES(basic-example PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples)

--- a/clients/go/examples/basic/main.go
+++ b/clients/go/examples/basic/main.go
@@ -1,0 +1,196 @@
+// Basic example of using the anna Go client library.
+//
+// This example starts the anna server processes (monitor, route, kvs),
+// connects a client, performs basic key-value operations (put, get, delete),
+// and then shuts the server down.
+//
+// Prerequisites:
+//
+//	The anna server binaries (anna-monitor, anna-route, anna-kvs) must
+//	be in your PATH. Build them first with `make server-cpp` or `make server-rust`.
+//
+// Running:
+//
+//	go run clients/go/examples/basic/main.go
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	annalib "github.com/andrewdavidmackenzie/anna/clients/go/annalib"
+)
+
+const configTemplate = `monitoring:
+  scaling_alert_ip: 127.0.0.1
+  ip: 127.0.0.1
+routing:
+  monitoring:
+    - 127.0.0.1
+  ip: 127.0.0.1
+user:
+  monitoring:
+    - 127.0.0.1
+  routing:
+    - 127.0.0.1
+  ip: 127.0.0.1
+server:
+  monitoring:
+    - 127.0.0.1
+  routing:
+    - 127.0.0.1
+  seed_ip: 127.0.0.1
+  public_ip: 127.0.0.1
+  private_ip: 127.0.0.1
+  scaling_alert_ip: "NULL"
+policy:
+  elasticity: false
+  selective-rep: false
+  tiering: false
+disk: %s
+capacities:
+  memory-cap: 1
+  disk-cap: 0
+threads:
+  memory: 1
+  disk: 1
+  routing: 1
+  benchmark: 1
+replication:
+  memory: 1
+  disk: 0
+  minimum: 1
+  local: 1
+ports:
+  base_offset: 0
+`
+
+// waitForRouting waits for the routing tier to accept TCP connections.
+func waitForRouting(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:6450", time.Second)
+		if err == nil {
+			conn.Close()
+			time.Sleep(time.Second)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("routing tier did not start within %v", timeout)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func main() {
+	// Create a temporary config
+	workDir, err := os.MkdirTemp("", "anna_example_")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(workDir)
+
+	diskDir := filepath.Join(workDir, "disk")
+	os.MkdirAll(diskDir, 0o755)
+
+	configPath := filepath.Join(workDir, "config.yml")
+	config := fmt.Sprintf(configTemplate, diskDir)
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write config: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Start the anna server
+	fmt.Println("Starting anna server...")
+	count, err := annalib.Start(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to start: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("  Started %d processes\n", count)
+
+	defer func() {
+		fmt.Println("\nStopping anna server...")
+		killed, _ := annalib.Stop()
+		fmt.Printf("  Stopped %d processes\n", killed)
+	}()
+
+	if err := waitForRouting(30 * time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	// Connect a client
+	clientConfig := annalib.DefaultClientConfig()
+	client, err := annalib.NewKVSClient(clientConfig, 50)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create client: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close()
+
+	// PUT a value
+	fmt.Println("\nPUT greeting = hello")
+	if err := client.Put("greeting", "hello"); err != nil {
+		fmt.Fprintf(os.Stderr, "PUT failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// GET it back
+	val, err := client.Get("greeting")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "GET failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("GET greeting = %s\n", val)
+
+	// Overwrite the value
+	fmt.Println("\nPUT greeting = hello world")
+	if err := client.Put("greeting", "hello world"); err != nil {
+		fmt.Fprintf(os.Stderr, "PUT overwrite failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	val, err = client.Get("greeting")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "GET failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("GET greeting = %s\n", val)
+
+	// PUT a second key
+	fmt.Println("\nPUT count = 42")
+	if err := client.Put("count", "42"); err != nil {
+		fmt.Fprintf(os.Stderr, "PUT count failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// DELETE the first key
+	fmt.Println("\nDELETE greeting")
+	if err := client.Delete("greeting"); err != nil {
+		fmt.Fprintf(os.Stderr, "DELETE failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Verify deletion
+	_, err = client.Get("greeting")
+	if err != nil {
+		fmt.Println("GET greeting = (deleted)")
+	} else {
+		fmt.Printf("GET greeting = %s (unexpected)\n", val)
+	}
+
+	// GET the remaining key
+	val, err = client.Get("count")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "GET count failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("GET count = %s\n", val)
+
+	fmt.Println("\nDone!")
+}

--- a/clients/go/examples/basic/main.go
+++ b/clients/go/examples/basic/main.go
@@ -85,12 +85,13 @@ func waitForRouting(timeout time.Duration) error {
 	}
 }
 
-func main() {
+// run contains the example logic. Returning an error lets deferred cleanup
+// (server stop, temp dir removal) run before main reports the failure.
+func run() error {
 	// Create a temporary config
 	workDir, err := os.MkdirTemp("", "anna_example_")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create temp dir: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	defer os.RemoveAll(workDir)
 
@@ -100,16 +101,14 @@ func main() {
 	configPath := filepath.Join(workDir, "config.yml")
 	config := fmt.Sprintf(configTemplate, diskDir)
 	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to write config: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to write config: %w", err)
 	}
 
 	// Start the anna server
 	fmt.Println("Starting anna server...")
 	count, err := annalib.Start(configPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to start: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to start: %w", err)
 	}
 	fmt.Printf("  Started %d processes\n", count)
 
@@ -120,77 +119,79 @@ func main() {
 	}()
 
 	if err := waitForRouting(30 * time.Second); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	// Connect a client
 	clientConfig := annalib.DefaultClientConfig()
 	client, err := annalib.NewKVSClient(clientConfig, 50)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create client: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create client: %w", err)
 	}
 	defer client.Close()
 
 	// PUT a value
 	fmt.Println("\nPUT greeting = hello")
 	if err := client.Put("greeting", "hello"); err != nil {
-		fmt.Fprintf(os.Stderr, "PUT failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("PUT failed: %w", err)
 	}
 
 	// GET it back
 	val, err := client.Get("greeting")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "GET failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("GET failed: %w", err)
 	}
 	fmt.Printf("GET greeting = %s\n", val)
 
 	// Overwrite the value
 	fmt.Println("\nPUT greeting = hello world")
 	if err := client.Put("greeting", "hello world"); err != nil {
-		fmt.Fprintf(os.Stderr, "PUT overwrite failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("PUT overwrite failed: %w", err)
 	}
 
 	val, err = client.Get("greeting")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "GET failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("GET failed: %w", err)
 	}
 	fmt.Printf("GET greeting = %s\n", val)
 
 	// PUT a second key
 	fmt.Println("\nPUT count = 42")
 	if err := client.Put("count", "42"); err != nil {
-		fmt.Fprintf(os.Stderr, "PUT count failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("PUT count failed: %w", err)
 	}
 
 	// DELETE the first key
 	fmt.Println("\nDELETE greeting")
 	if err := client.Delete("greeting"); err != nil {
-		fmt.Fprintf(os.Stderr, "DELETE failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("DELETE failed: %w", err)
 	}
 
-	// Verify deletion
-	_, err = client.Get("greeting")
+	// Verify deletion: Delete writes an empty LWW value, so Get succeeds
+	// with an empty string rather than returning an error.
+	got, err := client.Get("greeting")
 	if err != nil {
+		fmt.Printf("GET greeting error: %v\n", err)
+	} else if got == "" {
 		fmt.Println("GET greeting = (deleted)")
 	} else {
-		fmt.Printf("GET greeting = %s (unexpected)\n", val)
+		fmt.Printf("GET greeting = %s (unexpected)\n", got)
 	}
 
 	// GET the remaining key
 	val, err = client.Get("count")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "GET count failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("GET count failed: %w", err)
 	}
 	fmt.Printf("GET count = %s\n", val)
 
 	fmt.Println("\nDone!")
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/clients/python/examples/basic.py
+++ b/clients/python/examples/basic.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Basic example of using the anna Python client library.
+
+This example starts the anna server processes (monitor, route, kvs),
+connects a client, performs basic key-value operations (put, get, delete),
+and then shuts the server down.
+
+Prerequisites:
+    The anna server binaries (anna-monitor, anna-route, anna-kvs) must
+    be in your PATH or pointed to by the ANNA_SERVER_PATH environment
+    variable. Build them first with `make server-cpp` or `make server-rust`.
+
+Running:
+    python clients/python/examples/basic.py
+"""
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+# Add the client library to the path
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CLIENT_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, ".."))
+if CLIENT_DIR not in sys.path:
+    sys.path.insert(0, CLIENT_DIR)
+
+from anna.client import AnnaTcpClient
+from anna.lattices import LWWPairLattice
+from anna import process_mgmt
+
+CONFIG_TEMPLATE = """\
+monitoring:
+  scaling_alert_ip: 127.0.0.1
+  ip: 127.0.0.1
+routing:
+  monitoring:
+    - 127.0.0.1
+  ip: 127.0.0.1
+user:
+  monitoring:
+    - 127.0.0.1
+  routing:
+    - 127.0.0.1
+  ip: 127.0.0.1
+server:
+  monitoring:
+    - 127.0.0.1
+  routing:
+    - 127.0.0.1
+  seed_ip: 127.0.0.1
+  public_ip: 127.0.0.1
+  private_ip: 127.0.0.1
+  scaling_alert_ip: "NULL"
+policy:
+  elasticity: false
+  selective-rep: false
+  tiering: false
+disk: {disk_dir}
+capacities:
+  memory-cap: 1
+  disk-cap: 0
+threads:
+  memory: 1
+  disk: 1
+  routing: 1
+  benchmark: 1
+replication:
+  memory: 1
+  disk: 0
+  minimum: 1
+  local: 1
+ports:
+  base_offset: 0
+"""
+
+
+def wait_for_routing(host="127.0.0.1", port=6450, timeout=30):
+    """Wait for the routing tier to accept TCP connections."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(1.0)
+                if s.connect_ex((host, port)) == 0:
+                    time.sleep(1)
+                    return
+        except Exception:
+            pass
+        time.sleep(0.5)
+    raise TimeoutError("Routing tier did not start within {} seconds".format(timeout))
+
+
+def main():
+    # Create a temporary config
+    work_dir = tempfile.mkdtemp(prefix="anna_example_")
+    disk_dir = os.path.join(work_dir, "disk")
+    os.makedirs(disk_dir, exist_ok=True)
+    config_path = os.path.join(work_dir, "config.yml")
+    with open(config_path, "w") as f:
+        f.write(CONFIG_TEMPLATE.format(disk_dir=disk_dir))
+
+    # Start the anna server
+    print("Starting anna server...")
+    count = process_mgmt.start(config_path)
+    print(f"  Started {count} processes")
+
+    try:
+        wait_for_routing()
+
+        # Connect a client
+        client = AnnaTcpClient("127.0.0.1", "127.0.0.1", local=True, offset=0)
+
+        # PUT a value
+        ts = time.time_ns()
+        print("\nPUT greeting = hello")
+        result = client.put("greeting", LWWPairLattice(ts, b"hello"))
+        assert result["greeting"] is True, "PUT failed"
+
+        # GET it back
+        got = client.get("greeting")
+        print(f"GET greeting = {got['greeting'].reveal().decode()}")
+
+        # Overwrite the value
+        ts = time.time_ns()
+        print("\nPUT greeting = hello world")
+        client.put("greeting", LWWPairLattice(ts, b"hello world"))
+
+        got = client.get("greeting")
+        print(f"GET greeting = {got['greeting'].reveal().decode()}")
+
+        # PUT a second key
+        ts = time.time_ns()
+        print("\nPUT count = 42")
+        client.put("count", LWWPairLattice(ts, b"42"))
+
+        # DELETE the first key
+        print("\nDELETE greeting")
+        client.delete("greeting")
+
+        # Verify deletion
+        got = client.get("greeting")
+        if got["greeting"] is None:
+            print("GET greeting = (deleted)")
+        else:
+            print(f"GET greeting = {got['greeting'].reveal().decode()} (unexpected)")
+
+        # GET the remaining key
+        got = client.get("count")
+        print(f"GET count = {got['count'].reveal().decode()}")
+
+    finally:
+        # Stop the server
+        print("\nStopping anna server...")
+        killed = process_mgmt.stop()
+        print(f"  Stopped {killed} processes")
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/examples/basic.py
+++ b/clients/python/examples/basic.py
@@ -15,9 +15,7 @@ Running:
 """
 
 import os
-import signal
 import socket
-import subprocess
 import sys
 import tempfile
 import time
@@ -118,7 +116,8 @@ def main():
         ts = time.time_ns()
         print("\nPUT greeting = hello")
         result = client.put("greeting", LWWPairLattice(ts, b"hello"))
-        assert result["greeting"] is True, "PUT failed"
+        if result.get("greeting") is not True:
+            raise RuntimeError("PUT failed")
 
         # GET it back
         got = client.get("greeting")

--- a/clients/rust/examples/basic.rs
+++ b/clients/rust/examples/basic.rs
@@ -1,0 +1,160 @@
+//! Basic example of using the anna Rust client library.
+//!
+//! This example starts the anna server processes (monitor, route, kvs),
+//! connects a client, performs basic key-value operations (put, get, delete),
+//! and then shuts the server down.
+//!
+//! # Prerequisites
+//!
+//! The anna server binaries (`anna-monitor`, `anna-route`, `anna-kvs`) must
+//! be in your PATH. Build them first with `make server-cpp` or `make server-rust`.
+//!
+//! # Running
+//!
+//! ```sh
+//! cargo run --example basic
+//! ```
+
+use std::fs;
+use std::net::TcpStream;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use annalib::client_config::ClientConfig;
+use annalib::kvs_client::KVSClient;
+
+/// Generate a minimal anna config file in a temporary directory.
+fn generate_config() -> String {
+    let config_dir = std::env::temp_dir().join(format!("anna_example_{}", std::process::id()));
+    fs::create_dir_all(&config_dir).expect("Failed to create config dir");
+    let config_path = config_dir.join("config.yml");
+    let ip = "127.0.0.1";
+
+    let content = format!(
+        r#"monitoring:
+  scaling_alert_ip: {ip}
+  ip: {ip}
+routing:
+  monitoring:
+    - {ip}
+  ip: {ip}
+user:
+  monitoring:
+    - {ip}
+  routing:
+    - {ip}
+  ip: {ip}
+server:
+  monitoring:
+    - {ip}
+  routing:
+    - {ip}
+  seed_ip: {ip}
+  public_ip: {ip}
+  private_ip: {ip}
+  scaling_alert_ip: "NULL"
+policy:
+  elasticity: false
+  selective-rep: false
+  tiering: false
+disk: {disk}
+capacities:
+  memory-cap: 1
+  disk-cap: 0
+threads:
+  memory: 1
+  disk: 1
+  routing: 1
+  benchmark: 1
+replication:
+  memory: 1
+  disk: 0
+  minimum: 1
+  local: 1
+ports:
+  base_offset: 0
+"#,
+        ip = ip,
+        disk = config_dir.join("disk").to_string_lossy(),
+    );
+    fs::write(&config_path, content).expect("Failed to write config");
+    config_path.to_string_lossy().to_string()
+}
+
+/// Wait for the routing tier to accept TCP connections (up to 30 seconds).
+fn wait_for_routing() {
+    let addr = "127.0.0.1:6450";
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(1)).is_ok() {
+            // Give the cluster a moment to stabilize
+            std::thread::sleep(Duration::from_secs(1));
+            return;
+        }
+        if Instant::now() > deadline {
+            panic!("Routing tier did not start within 30 seconds");
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let config_path = generate_config();
+
+    // Start the anna server processes
+    println!("Starting anna server...");
+    let count = annalib::start(Path::new(&config_path), &[])
+        .expect("Failed to start anna server (are the binaries in PATH?)");
+    println!("  Started {} processes", count);
+
+    wait_for_routing();
+
+    // Connect a client
+    let config = ClientConfig::default();
+    let mut client = KVSClient::new(&config, Some(50)).await;
+
+    // PUT a value
+    println!("\nPUT greeting = hello");
+    client.put("greeting", "hello").await.expect("PUT failed");
+
+    // GET it back
+    let val = client.get("greeting").await.expect("GET failed");
+    println!("GET greeting = {}", val);
+
+    // Overwrite the value
+    println!("\nPUT greeting = hello world");
+    client
+        .put("greeting", "hello world")
+        .await
+        .expect("PUT overwrite failed");
+
+    let val = client.get("greeting").await.expect("GET overwrite failed");
+    println!("GET greeting = {}", val);
+
+    // PUT a second key
+    println!("\nPUT count = 42");
+    client.put("count", "42").await.expect("PUT count failed");
+
+    // DELETE the first key
+    println!("\nDELETE greeting");
+    client.delete("greeting").await.expect("DELETE failed");
+
+    // Verify deletion: GET should return KeyDoesNotExist error
+    match client.get("greeting").await {
+        Err(annalib::Error::KeyDoesNotExist(_)) => println!("GET greeting = (deleted)"),
+        Ok(val) => println!("GET greeting = {} (unexpected)", val),
+        Err(e) => println!("GET greeting error: {}", e),
+    }
+
+    // GET the remaining key
+    let val = client.get("count").await.expect("GET count failed");
+    println!("GET count = {}", val);
+
+    // Stop the server
+    println!("\nStopping anna server...");
+    let stopped = annalib::stop(&[]).expect("Failed to stop anna server");
+    println!("  Stopped {} processes", stopped);
+
+    println!("\nDone!");
+}

--- a/clients/rust/examples/basic.rs
+++ b/clients/rust/examples/basic.rs
@@ -108,6 +108,19 @@ async fn main() {
         .expect("Failed to start anna server (are the binaries in PATH?)");
     println!("  Started {} processes", count);
 
+    // Ensure the server is stopped on exit (including panics)
+    struct StopGuard;
+    impl Drop for StopGuard {
+        fn drop(&mut self) {
+            println!("\nStopping anna server...");
+            match annalib::stop(&[]) {
+                Ok(n) => println!("  Stopped {} processes", n),
+                Err(e) => eprintln!("  Failed to stop: {}", e),
+            }
+        }
+    }
+    let _guard = StopGuard;
+
     wait_for_routing();
 
     // Connect a client
@@ -151,10 +164,6 @@ async fn main() {
     let val = client.get("count").await.expect("GET count failed");
     println!("GET count = {}", val);
 
-    // Stop the server
-    println!("\nStopping anna server...");
-    let stopped = annalib::stop(&[]).expect("Failed to stop anna server");
-    println!("  Stopped {} processes", stopped);
-
     println!("\nDone!");
+    // StopGuard::drop() will stop the server
 }

--- a/clients/rust/examples/basic.rs
+++ b/clients/rust/examples/basic.rs
@@ -140,9 +140,9 @@ async fn main() {
     println!("\nDELETE greeting");
     client.delete("greeting").await.expect("DELETE failed");
 
-    // Verify deletion: GET should return KeyDoesNotExist error
+    // Verify deletion: GET should return a KEY_DNE error
     match client.get("greeting").await {
-        Err(annalib::Error::KeyDoesNotExist(_)) => println!("GET greeting = (deleted)"),
+        Err(e) if e.to_string().contains("KEY_DNE") => println!("GET greeting = (deleted)"),
         Ok(val) => println!("GET greeting = {} (unexpected)", val),
         Err(e) => println!("GET greeting error: {}", e),
     }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,6 @@
 ignore:
   - "**/tests/**"
   - "**/build/**"
-  - "**/examples/**"
   - "target/**"
   - "**/test_*.py"
   - "**/test_*.cpp"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 ignore:
   - "**/tests/**"
   - "**/build/**"
+  - "**/examples/**"
   - "target/**"
   - "**/test_*.py"
   - "**/test_*.cpp"


### PR DESCRIPTION
## Summary

Adds a basic example app for each client language, demonstrating how to use the client library to interact with the anna KVS. Each example is self-contained: it starts the anna server, performs operations, and shuts down.

Closes #572

## Examples Added

| Language | Path | How to Run |
|----------|------|-----------|
| **Rust** | `clients/rust/examples/basic.rs` | `cargo run --example basic` |
| **Python** | `clients/python/examples/basic.py` | `python clients/python/examples/basic.py` |
| **Go** | `clients/go/examples/basic/main.go` | `go run clients/go/examples/basic/main.go` |
| **C++** | `clients/cpp/examples/basic.cpp` | `./clients/cpp/build/examples/basic-example` (built via `make client-cpp`) |

## What Each Example Demonstrates

1. **Server lifecycle**: Generates a temporary config, starts anna-monitor + anna-route + anna-kvs, waits for the routing tier to accept connections
2. **Basic operations**: PUT, GET, overwrite, DELETE
3. **Cleanup**: Stops the server processes on exit

## Prerequisites

Server binaries (`anna-monitor`, `anna-route`, `anna-kvs`) must be in PATH. Build them with `make server-cpp` or `make server-rust`.

## Note

The `anna-embedded` crate already has its own examples (`basic.rs` and `multithreaded.rs`) that were added in #576.